### PR TITLE
[ELY-4] Implement Unix MD5 Crypt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <version.org.jboss.logging>3.1.3.GA</version.org.jboss.logging>
         <version.org.jboss.logging.tools>1.2.0.Beta1</version.org.jboss.logging.tools>
         <version.org.jboss.remoting>4.0.0.Beta1</version.org.jboss.remoting>
+        <version.junit.junit>4.11</version.junit.junit>
 
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
@@ -108,6 +109,14 @@
             <artifactId>jboss-logging-processor</artifactId>
             <version>${version.org.jboss.logging.tools}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit.junit}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/wildfly/security/password/impl/CryptUtil.java
+++ b/src/main/java/org/wildfly/security/password/impl/CryptUtil.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compasswordLengthiance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by appasswordLengthicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impasswordLengthied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.password.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+/**
+ * Utility class that contains methods needed by various Crypt password types.
+ *
+ * @author <a href="mailto:jpkroehling.javadoc@redhat.com">Juraci Paixão Kröhling</a>
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+final class CryptUtil {
+
+    private static final String charMap = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    public static char[] produceCharsFromBytes(byte first, byte second, byte third, int numOfChars) {
+
+        // note that the original C implementation uses "unsigned char", and we use byte (because of MessageDigest),
+        // so, we need to get an 8-bit unsigned char by using a binary-and
+        int offset = ((first & 0xFF) << 16) | ((second & 0xFF) << 8) | (third & 0xFF);
+
+        char[] output = new char[numOfChars];
+        for (int i = 0 ; i < numOfChars ; i++) {
+            output[i] = charMap.charAt(offset & 0x3F);
+            offset >>= 6;
+        }
+
+        return output;
+    }
+}

--- a/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.password.impl;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+
+import org.wildfly.security.password.interfaces.UnixMD5CryptPassword;
+import org.wildfly.security.password.spec.UnixMD5CryptPasswordSpec;
+
+/**
+ * Implementation of the Unix MD5 Crypt password.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+final class UnixMD5CryptPasswordImpl extends AbstractPasswordImpl implements UnixMD5CryptPassword {
+
+    private static final long serialVersionUID = 8315521712238708363L;
+
+    private final byte[] hash;
+    private final byte[] salt;
+
+    UnixMD5CryptPasswordImpl(final byte[] hash, final byte[] salt) {
+        this.hash = hash;
+        this.salt = salt;
+    }
+
+    UnixMD5CryptPasswordImpl(UnixMD5CryptPassword unixMD5CryptPassword) {
+        this.hash = unixMD5CryptPassword.getHash().clone();
+        this.salt = unixMD5CryptPassword.getSalt().clone();
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return UnixMD5CryptUtil.ALGORITHM_MD5_CRYPT;
+    }
+
+    @Override
+    public String getFormat() {
+        return null;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return null;
+    }
+
+    @Override
+    public byte[] getHash() {
+        return hash.clone();
+    }
+
+    @Override
+    public byte[] getSalt() {
+        return salt.clone();
+    }
+
+    @Override
+    <S extends KeySpec> S getKeySpec(final Class<S> keySpecType) throws InvalidKeySpecException {
+        if (keySpecType == UnixMD5CryptPasswordSpec.class) {
+            return keySpecType.cast(new UnixMD5CryptPasswordSpec(getEncoded(), getSalt()));
+        }
+        throw new InvalidKeySpecException();
+    }
+
+    @Override
+    boolean verify(final char[] guess) throws InvalidKeyException {
+        ByteBuffer guessAsBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(guess));
+        byte[] guessAsBytes = new byte[guessAsBuffer.remaining()];
+        guessAsBuffer.get(guessAsBytes);
+
+        byte[] test;
+        try {
+            test = UnixMD5CryptUtil.encode(guessAsBytes, getSalt());
+        } catch (NoSuchAlgorithmException e) {
+            throw new InvalidKeyException("Cannot verify password", e);
+        }
+        return Arrays.equals(getHash(), test);
+    }
+
+    @Override
+    <T extends KeySpec> boolean convertibleTo(final Class<T> keySpecType) {
+        return keySpecType == UnixMD5CryptPasswordSpec.class;
+    }
+}

--- a/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptUtil.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptUtil.java
@@ -1,0 +1,165 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compasswordLengthiance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by appasswordLengthicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impasswordLengthied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.password.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+/**
+ * Utility class that contains methods for hashing a password using the Unix
+ * MD5 Crypt algorithm.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+final class UnixMD5CryptUtil {
+
+    public static final String ALGORITHM_MD5_CRYPT = "md5-crypt";
+    private static final String MD5 = "MD5";
+
+    // The MD5 prefix
+    private static final String MAGIC = "$1$";
+
+    /**
+     * Hashes the given password using the MD5 Crypt algorithm.
+     *
+     * @param password the password to be hashed
+     * @param salt the salt, will be truncated to an array of 8 bytes if an array larger than 8 bytes is given
+     * @return a {@code byte[]} containing the hashed password
+     * @throws NoSuchAlgorithmException if a {@code MessageDigest} object that implements MD5 cannot be retrieved
+     */
+    public static byte[] encode(final byte[] password, byte[] salt) throws NoSuchAlgorithmException {
+        // Note that many of the comments below have been taken from or are based on comments from:
+        // ftp://ftp.arlut.utexas.edu/pub/java_hashes/SHA-crypt.txt and
+        // http://svnweb.freebsd.org/base/head/lib/libcrypt/crypt.c?revision=4246&view=markup (this is
+        // the original C implementation of the algorithm)
+
+        if (salt.length > 8) {
+            salt = Arrays.copyOfRange(salt, 0, 8);
+        }
+
+        // Add the password to digest A first since that is what is most unknown, then our magic
+        // string, then the raw salt
+        MessageDigest digestA = getMD5MessageDigest();
+        digestA.update(password);
+        digestA.update(MAGIC.getBytes(StandardCharsets.UTF_8));
+        digestA.update(salt);
+
+        // Add the password to digest B, followed by the salt, followed by the password again
+        MessageDigest digestB = getMD5MessageDigest();
+        digestB.update(password);
+        digestB.update(salt);
+        digestB.update(password);
+
+        // Finish digest B
+        byte[] finalDigest = digestB.digest();
+
+        // For each block of 16 bytes in the password string, add digest B to digest A and for the
+        // remaining N bytes of the password string, add the first N bytes of digest B to digest A
+        for (int i = password.length; i > 0; i -= 16) {
+            digestA.update(finalDigest, 0, i > 16 ? 16 : i);
+        }
+
+        // Don't leave anything around in vm they could use
+        Arrays.fill(finalDigest, (byte) 0);
+
+        // For each bit in the binary representation of the length of the password string up to
+        // and including the highest 1-digit, starting from the lowest bit position (numeric value 1):
+        // a) for a 1-digit, add a null character to digest A
+        // b) for a 0-digit, add the first character of the password to digest A
+        for (int i = password.length; i > 0; i >>= 1) {
+            if ((i & 1) == 1) {
+                digestA.update(finalDigest, 0, 1);
+            } else {
+                digestA.update(password, 0, 1);
+            }
+        }
+
+        // Finish digest A
+        finalDigest = digestA.digest();
+
+        // The algorithm uses a fixed number of iterations
+        for (int i = 0; i < 1000; i++) {
+
+            // Start a new digest
+            digestB = getMD5MessageDigest();
+
+            // If the round is odd, add the password to this digest
+            // Otherwise, add the previous round's digest (or digest A if this is round 0)
+            if ((i & 1) == 1) {
+                digestB.update(password);
+            } else {
+                digestB.update(finalDigest, 0, 16);
+            }
+
+            // If the round is not divisible by 3, add the salt
+            if ((i % 3) != 0) {
+                digestB.update(salt);
+            }
+
+            // If the round is not divisible by 7, add the password
+            if ((i % 7) != 0) {
+                digestB.update(password);
+            }
+
+            // If the round is odd, add the previous round's digest (or digest A if this is round 0)
+            // Otherwise, add the password
+            if ((i & 1) == 1) {
+                digestB.update(finalDigest, 0, 16);
+            } else {
+                digestB.update(password);
+            }
+
+            finalDigest = digestB.digest();
+        }
+
+        // Now make the output string
+        StringBuilder output = new StringBuilder();
+        output.append(MAGIC);
+        output.append(new String(salt));
+        output.append("$");
+        produceOutput(finalDigest, output);
+
+        // Don't leave anything around in vm they could use
+        Arrays.fill(finalDigest, (byte) 0);
+
+        return output.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static MessageDigest getMD5MessageDigest() throws NoSuchAlgorithmException {
+        return MessageDigest.getInstance(MD5);
+    }
+
+    /**
+     * Produce the base64-encoded final digest.
+     */
+    private static StringBuilder produceOutput(byte[] finalDigest, StringBuilder output) {
+        output.append(CryptUtil.produceCharsFromBytes(finalDigest[0], finalDigest[6], finalDigest[12], 4));
+        output.append(CryptUtil.produceCharsFromBytes(finalDigest[1], finalDigest[7], finalDigest[13], 4));
+        output.append(CryptUtil.produceCharsFromBytes(finalDigest[2], finalDigest[8], finalDigest[14], 4));
+        output.append(CryptUtil.produceCharsFromBytes(finalDigest[3], finalDigest[9], finalDigest[15], 4));
+        output.append(CryptUtil.produceCharsFromBytes(finalDigest[4], finalDigest[10], finalDigest[5], 4));
+
+        // For the last group, there's only one byte left
+        output.append(CryptUtil.produceCharsFromBytes((byte) 0, (byte) 0, finalDigest[11], 2));
+        return output;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/password/interfaces/UnixMD5CryptPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/UnixMD5CryptPassword.java
@@ -26,5 +26,5 @@ import org.wildfly.security.password.OneWayPassword;
 public interface UnixMD5CryptPassword extends OneWayPassword {
     byte[] getSalt();
 
-    int getIterationCount();
+    byte[] getHash();
 }

--- a/src/test/java/org/wildfly/security/password/impl/UnixMD5CryptUtilTest.java
+++ b/src/test/java/org/wildfly/security/password/impl/UnixMD5CryptUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.password.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests for UnixMD5CryptUtil.
+ * The expected results for these test cases were generated using the 
+ * {@code unix_md5_crypt} function from the {@code Crypt::PasswdMD5}
+ * Perl module.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class UnixMD5CryptUtilTest {
+
+    @Test
+    public void testSaltTruncated() throws NoSuchAlgorithmException {
+        String result = getEncoded("password", "thissaltstringistoolong");
+        assertTrue("Didn't truncate the salt", result.startsWith("$1$thissalt$"));
+        assertEquals("$1$thissalt$B4AUaoQwRs3ex2F95O4ut/", result);
+    }
+
+    @Test
+    public void testEmptyPassword() throws NoSuchAlgorithmException {
+        String result = getEncoded("", "1234");
+        assertEquals("$1$1234$.hKN8.QH1vHyGVLB072C0.", result);
+    }
+
+    @Test
+    public void testShortPassword() throws NoSuchAlgorithmException {
+        String result = getEncoded("Hello world!", "saltstring");
+        assertEquals("$1$saltstri$YMyguxXMBpd2TEZ.vS/3q1", result);
+    }
+    @Test
+    public void testLongPassword() throws NoSuchAlgorithmException {
+        String password = "This is a very very very long password. This is another sentence in the password. This is a test.";
+        String salt = "saltstringsaltstring";
+        String result = getEncoded(password, salt);
+        assertEquals("$1$saltstri$IQDu.vaa8hwk2UnOjF2PP.", result);
+    }
+
+    @Test
+    public void testCaseFromOriginalCImplementation() throws NoSuchAlgorithmException {
+        String result = getEncoded("0.s0.l33t", "deadbeef");
+        assertEquals("$1$deadbeef$0Huu6KHrKLVWfqa4WljDE0", result);
+    }
+
+    private String getEncoded(String passwordStr, String saltStr) throws NoSuchAlgorithmException {
+        byte[] password = passwordStr.getBytes(StandardCharsets.UTF_8);
+        byte[] salt = saltStr.getBytes(StandardCharsets.UTF_8);
+        return new String(UnixMD5CryptUtil.encode(password, salt));
+    }
+}


### PR DESCRIPTION
Implemented Unix MD5 Crypt and added some tests. Note that this implementation currently only handles an ID value of "1". Should "md5", the ID value representing the Sun MD5 Crypt algorithm, also be supported? (Just noticed that "md5" was referenced in the [identifyAlgorithm](https://github.com/wildfly-security/wildfly-elytron/pull/8/files#diff-89ce0408061333fe4d760f7738f33ebeR65) method in #8.) If so, I'll work on adding that but wanted to get some feedback in the meantime.

https://issues.jboss.org/browse/ELY-4
