### PR TITLE
GSSAPI compatibility tests and fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,30 @@
             <version>${version.junit.junit}</version>
             <scope>test</scope>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <version>2.2.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+            <version>2.2.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>1.10</version>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
+++ b/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
@@ -237,6 +237,7 @@ public class GssapiClient extends AbstractGssapiMechanism implements SaslClient 
                 if (gssContext.isEstablished()) {
                     log.trace("GSSContext established, transitioning to negotiate security layer.");
                     context.setNegotiationState(new SecurityLayerNegotiationState());
+                    if (response == null) response = NO_BYTES;
                 } else {
                     log.trace("GSSContext not established, expecting subsequent exchanges.");
                 }
@@ -271,6 +272,7 @@ public class GssapiClient extends AbstractGssapiMechanism implements SaslClient 
                             "Invalid message size received when no security layer supported by server '%d'",
                             maxBuffer));
                 }
+                maxBuffer = gssContext.getWrapSizeLimit(0, selectedQop == QOP.AUTH_CONF, maxBuffer);
 
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
                 baos.write(selectedQop.getValue());
@@ -278,8 +280,7 @@ public class GssapiClient extends AbstractGssapiMechanism implements SaslClient 
                     // No security layer selected to must set response to 000.
                     baos.write(new byte[] { 0x00, 0x00, 0x00 });
                 } else {
-                    actualMaxReceiveBuffer = gssContext.getWrapSizeLimit(0, selectedQop == QOP.AUTH_CONF,
-                            configuredMaxReceiveBuffer);
+                    actualMaxReceiveBuffer = configuredMaxReceiveBuffer!=0 ? configuredMaxReceiveBuffer : maxBuffer;
                     log.tracef("Out max buffer %d", actualMaxReceiveBuffer);
                     baos.write(intToNetworkOrderBytes(actualMaxReceiveBuffer));
                 }

--- a/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
@@ -154,25 +154,33 @@ public abstract class BaseGssapiTests extends BaseTestCase {
     private void testDataExchange(final SaslClient client, final SaslServer server) throws SaslException {
         byte[] original = "Some Test Data".getBytes(Charsets.UTF_8);
         byte[] backup = "Some Test Data".getBytes(Charsets.UTF_8);
-        byte[] fromClient = client.wrap(original, 0, original.length);
+
+        byte[] wrappedFromClient = client.wrap(original, 0, original.length);
 
         assertTrue("Original data unmodified", Arrays.equals(backup, original));
 
-        byte[] unwrapped = server.unwrap(fromClient, 0, fromClient.length);
+        byte[] unwrappedFromClient = server.unwrap(wrappedFromClient, 0, wrappedFromClient.length);
 
-        assertTrue("Unwrapped (By Server) matched original", Arrays.equals(unwrapped, original));
+        assertTrue("Unwrapped (By Server) matched original", Arrays.equals(unwrappedFromClient, original));
 
-        byte[] fromServer = server.wrap(original, 0, original.length);
+        byte[] wrappedFromServer = server.wrap(original, 0, original.length);
 
         assertTrue("Original data unmodified", Arrays.equals(backup, original));
 
-        unwrapped = client.unwrap(fromServer, 0, fromServer.length);
+        byte[] unwrappedFromServer = client.unwrap(wrappedFromServer, 0, wrappedFromServer.length);
 
-        assertTrue("Unwrapped (By Client) matched original", Arrays.equals(unwrapped, original));
+        assertTrue("Unwrapped (By Client) matched original", Arrays.equals(unwrappedFromServer, original));
     }
 
+    /**
+     * @param authServer whether the server must authenticate to the client
+     * @param mode quality-of-protection to use
+     */
     protected abstract SaslClient getSaslClient(final boolean authServer, final VerificationMode mode) throws Exception;
 
+    /**
+     * @param mode quality-of-protection to use
+     */
     protected abstract SaslServer getSaslServer(final VerificationMode mode) throws Exception;
 
     /*
@@ -317,7 +325,7 @@ public abstract class BaseGssapiTests extends BaseTestCase {
             for (Callback current : callbacks) {
                 if (current instanceof AuthorizeCallback) {
                     AuthorizeCallback ac = (AuthorizeCallback) current;
-                    ac.setAuthorized(ac.getAuthorizationID().equals(ac.getAuthorizationID()));
+                    ac.setAuthorized(ac.getAuthorizationID().equals(ac.getAuthenticationID()));
                 } else {
                     throw new UnsupportedCallbackException(current);
                 }

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiTestSuite.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiTestSuite.java
@@ -26,7 +26,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 /**
- * Test suite to run all GSSAPI tests to allow various permutations of mechanism interaction to be verified..
+ * Test suite to run all GSSAPI tests to allow various permutations of mechanism interaction to be verified.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilsUnitTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilsUnitTest.java
@@ -1,0 +1,59 @@
+package org.wildfly.security.sasl.gssapi;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.SaslException;
+
+import org.jboss.logging.Logger;
+import org.junit.Test;
+
+
+public class GssapiUtilsUnitTest extends AbstractGssapiMechanism {
+
+    public GssapiUtilsUnitTest() throws SaslException {
+        super("sasl", "imap", "test_server_1", new HashMap<String, String>(), new CallbackHandler(){
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                throw new UnsupportedCallbackException(callbacks[0]);
+            }
+        }, Logger.getLogger(GssapiUtilsUnitTest.class));
+    }
+
+    @Test
+    public void testIntToNetworkOrderBytes() throws Exception {
+        assertArrayEquals("JDK maxbuf", new byte[]{(byte)0x01,(byte)0x00,(byte)0x00}, intToNetworkOrderBytes(65536));
+        assertArrayEquals("WildFly maxbuf", new byte[]{(byte)0x00,(byte)0x0F,(byte)0xBA}, intToNetworkOrderBytes(4026));
+        assertArrayEquals("minimum", new byte[]{(byte)0x00,(byte)0x00,(byte)0x00}, intToNetworkOrderBytes(0));
+        assertArrayEquals("maximum", new byte[]{(byte)0xFF,(byte)0xFF,(byte)0xFF}, intToNetworkOrderBytes(16777215));
+        assertArrayEquals("bytes", new byte[]{(byte)0x83,(byte)0x82,(byte)0x81}, intToNetworkOrderBytes(8618625));
+    }
+
+    @Test
+    public void testNetworkOrderBytesToInt(){
+        assertEquals("JDK maxbuf", 65536, networkOrderBytesToInt(new byte[]{(byte)0x01,(byte)0x00,(byte)0x00}, 0, 3));
+        assertEquals("WildFly maxbuf", 4026, networkOrderBytesToInt(new byte[]{(byte)0x00,(byte)0x0F,(byte)0xBA}, 0, 3));
+        assertEquals("minimum", 0, networkOrderBytesToInt(new byte[]{(byte)0x00,(byte)0x00,(byte)0x00}, 0, 3));
+        assertEquals("one", 1, networkOrderBytesToInt(new byte[]{(byte)0x00,(byte)0x00,(byte)0x01}, 0, 3));
+        assertEquals("255", 255, networkOrderBytesToInt(new byte[]{(byte)0x00,(byte)0x00,(byte)0xFF}, 0, 3));
+        assertEquals("maximum", 16777215, networkOrderBytesToInt(new byte[]{(byte)0xFF,(byte)0xFF,(byte)0xFF}, 0, 3));
+        assertEquals("bytes", 8618625, networkOrderBytesToInt(new byte[]{(byte)0x83,(byte)0x82,(byte)0x81}, 0, 3));
+    }
+
+    @Test
+    public void testParsePreferredQop() throws Exception {
+        assertArrayEquals(new QOP[]{QOP.AUTH}, parsePreferredQop("auth"));
+        assertArrayEquals(new QOP[]{QOP.AUTH_INT}, parsePreferredQop("auth-int"));
+        assertArrayEquals(new QOP[]{QOP.AUTH_CONF}, parsePreferredQop("auth-conf"));
+        assertArrayEquals(new QOP[]{QOP.AUTH,QOP.AUTH_INT,QOP.AUTH_CONF}, parsePreferredQop("auth,auth-int,auth-conf"));
+        assertArrayEquals(new QOP[]{QOP.AUTH,QOP.AUTH_INT,QOP.AUTH_CONF}, parsePreferredQop("auth, auth-int, auth-conf"));
+        assertArrayEquals(new QOP[]{QOP.AUTH,QOP.AUTH_INT}, parsePreferredQop("\n auth \n,\n auth-int \n"));
+        assertArrayEquals(new QOP[]{QOP.AUTH}, parsePreferredQop(null));
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JAASUtil.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JAASUtil.java
@@ -42,18 +42,18 @@ import org.jboss.logging.Logger;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class JAASUtil {
+public class JAASUtil {
 
     private static Logger log = Logger.getLogger(JAASUtil.class);
 
     private static final boolean IS_IBM = System.getProperty("java.vendor").contains("IBM");
 
-    static Subject loginClient() throws LoginException {
+    public static Subject loginClient() throws LoginException {
         log.debug("loginClient");
         return login("jduke", "theduke".toCharArray(), false);
     }
 
-    static Subject loginServer() throws LoginException {
+    public static Subject loginServer() throws LoginException {
         log.debug("loginServer");
         return login("sasl/test_server_1", "servicepwd".toCharArray(), true);
     }

--- a/src/test/java/org/wildfly/security/sasl/gssapi/TestKDC.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/TestKDC.java
@@ -45,7 +45,7 @@ import org.apache.directory.server.protocol.shared.transport.UdpTransport;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class TestKDC {
+public class TestKDC {
 
     private File workingDir;
     private DirectoryService directoryService;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractGssapiTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractGssapiTest.java
@@ -1,0 +1,186 @@
+package org.wildfly.security.sasl.gssapi.compatibility;
+
+import java.io.IOException;
+import java.security.AccessController;
+import java.security.NoSuchProviderException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.util.Random;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.wildfly.security.sasl.WildFlySaslProvider;
+import org.wildfly.security.sasl.gssapi.BaseGssapiTests;
+import org.wildfly.security.sasl.gssapi.JAASUtil;
+import org.wildfly.security.sasl.gssapi.TestKDC;
+
+/*
+ * Every GSSAPI compatibility test must be in standalone test class because Random instances
+ * must be created for every test run new to ensure stable assertable output.
+ */
+@RunWith(JMockit.class)
+public abstract class AbstractGssapiTest {
+
+    protected boolean wildfly = true; // if test should be applied to WildFly or JDK SASL implementation
+
+    protected static TestKDC testKdc;
+    protected SaslServer server;
+    protected SaslClient client;
+    protected Subject clientSubject;
+    protected Subject serverSubject;
+    protected byte[] exchange;
+    protected byte[] message;
+    protected byte[] wrappedMessage;
+
+    private static final Provider wildFlySaslProvider = new WildFlySaslProvider();
+
+    @BeforeClass
+    public static void registerProvider() {
+        AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            public Integer run() {
+                return Security.insertProviderAt(wildFlySaslProvider, 1);
+            }
+        });
+    }
+
+    @AfterClass
+    public static void removeProvider() {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            public Void run() {
+                Security.removeProvider(wildFlySaslProvider.getName());
+                return null;
+            }
+        });
+    }
+
+    @BeforeClass
+    public static void installMockClasses() throws Exception {
+        new SystemMock();
+        new SecureRandomMock();
+    }
+
+    @Before
+    public void init() throws Exception {
+
+        testKdc = new TestKDC();
+        testKdc.startDirectoryService();
+        testKdc.startKDC();
+
+        /*
+        java.lang.reflect.Field seedUniquifier = Random.class.getDeclaredField("seedUniquifier");
+        seedUniquifier.setAccessible(true);
+        AtomicLong al = (AtomicLong)seedUniquifier.get(null);
+        al.set(-3282039941672302964L);
+        */
+
+        clientSubject = JAASUtil.loginClient();
+        serverSubject = JAASUtil.loginServer();
+
+    }
+
+    @After
+    public void dispose() throws Exception {
+        if(client != null) client.dispose();
+        if(server != null) server.dispose();
+        if(testKdc != null) testKdc.stopAll();
+    }
+
+    public static class SystemMock extends MockUp<System> {
+        @Mock
+        public long currentTimeMillis(){
+            return 123;
+        }
+        @Mock
+        public long nanoTime(){
+            return 1234;
+        }
+    }
+
+    public static class SecureRandomMock extends MockUp<SecureRandom> {
+        @Mock
+        public void nextBytes(byte[] bytes){
+            new Random().nextBytes(bytes);
+        }
+    }
+
+    protected byte[] evaluateByServer(final byte[] exchange) throws PrivilegedActionException {
+        return Subject.doAs(serverSubject, new PrivilegedExceptionAction<byte[]>() {
+            public byte[] run() throws Exception {
+                return server.evaluateResponse(exchange);
+            }
+        });
+    }
+
+    protected byte[] evaluateByClient(final byte[] exchange) throws PrivilegedActionException {
+        return Subject.doAs(clientSubject, new PrivilegedExceptionAction<byte[]>(){
+            public byte[] run() throws Exception {
+                return client.evaluateChallenge(exchange);
+            }
+        });
+    }
+
+    protected SaslClientFactory findSaslClientFactory(final boolean wildFlyProvider) throws Exception {
+        Provider p = findProvider("SaslClientFactory.GSSAPI", wildFlyProvider);
+        String factoryName = (String) p.get("SaslClientFactory.GSSAPI");
+        return (SaslClientFactory) BaseGssapiTests.class.getClassLoader().loadClass(factoryName).newInstance();
+    }
+
+    protected SaslServerFactory findSaslServerFactory(final boolean wildFlyProvider) throws Exception {
+        Provider p = findProvider("SaslServerFactory.GSSAPI", wildFlyProvider);
+        String factoryName = (String) p.get("SaslServerFactory.GSSAPI");
+        return (SaslServerFactory) BaseGssapiTests.class.getClassLoader().loadClass(factoryName).newInstance();
+    }
+
+    protected Provider findProvider(final String filter, final boolean wildFlyProvider) throws Exception {
+        Provider[] providers = Security.getProviders(filter);
+        for (Provider current : providers) {
+            if (wildFlyProvider && current instanceof WildFlySaslProvider) {
+                return current;
+            }
+            if (!wildFlyProvider && !(current instanceof WildFlySaslProvider)) {
+                return current;
+            }
+        }
+        throw new NoSuchProviderException("Provider not found (filter="+filter+",wildFly="+Boolean.toString(wildFlyProvider)+")");
+    }
+
+    protected class AuthorizeOnlyCallbackHandler implements CallbackHandler {
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            for (Callback current : callbacks) {
+                if (current instanceof AuthorizeCallback) {
+                    AuthorizeCallback ac = (AuthorizeCallback) current;
+                    ac.setAuthorized(ac.getAuthorizationID().equals(ac.getAuthenticationID()));
+                } else {
+                    throw new UnsupportedCallbackException(current);
+                }
+            }
+        }
+    }
+
+    protected class NoCallbackHandler implements CallbackHandler {
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            throw new UnsupportedCallbackException(callbacks[0]);
+        }
+    }
+}

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicConfidencyGssapiTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicConfidencyGssapiTest.java
@@ -1,0 +1,107 @@
+package org.wildfly.security.sasl.gssapi.compatibility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.security.sasl.util.HexConverter;
+
+public class BasicConfidencyGssapiTest extends AbstractGssapiTest {
+
+    @Test
+    public void testAuthConf() throws Exception {
+
+        client = Subject.doAs(clientSubject, new PrivilegedExceptionAction<SaslClient>() {
+            public SaslClient run() throws Exception {
+                SaslClientFactory factory = findSaslClientFactory(wildfly);
+                Map<String, String> props = new HashMap<String, String>();
+                props.put(Sasl.QOP, "auth-conf");
+                props.put(Sasl.SERVER_AUTH, Boolean.toString(true));
+                props.put(Sasl.MAX_BUFFER, Integer.toString(61234));
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+            }
+        });
+
+        server = Subject.doAs(serverSubject, new PrivilegedExceptionAction<SaslServer>() {
+            public SaslServer run() throws Exception {
+                SaslServerFactory factory = findSaslServerFactory(wildfly);
+                Map<String, String> props = new HashMap<String, String>();
+                props.put(Sasl.QOP, "auth-conf");
+                props.put(Sasl.MAX_BUFFER, Integer.toString(64321));
+                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+            }
+        });
+
+        assertTrue(client.hasInitialResponse());
+
+        exchange = new byte[0];
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("6082020406092a864886f71201020201006e8201f3308201efa003020105a10302010ea20703050020000000a382010b6182010730820103a003020105a10d1b0b57494c44464c592e4f5247a220301ea003020100a11730151b047361736c1b0d746573745f7365727665725f31a381ca3081c7a003020110a281bf0481bc093d7ffd9e956da2c6f5dabb2b41e5ea0b0fc158da3b4f4258baabbf6eabc23e7fe31a65e09a73bfec3c754ee262af1777b9979d2e22eb9e9d8482b8bd40847667cdaa0d67486d5c88e8c65b26df3c6eda36cb36158ad108a0ed6153ea29e8865a9099b53e2d11e90b8c0dd82e18ea982c0e741bbc0e358fbc677b02dd6c4fa7f196f23d7d48f3f82fcd003164852af47f473e44f394d26cbeed416dab4a5225d23de3d7f8109b1c607c535bf5b128210ab54aa115a306786461ddc8a481ca3081c7a003020110a281bf0481bc417f7d7dbafefd13eb5d70b31fd7fe22c4f11c3805da0bb7232fcabc0fa63071aa7b5f7201aa4221f6314c1d71876d3854ae6c46dc39392977b434817b4ca7efdb28a7e96df0f495a18e926879ecd54e6e681e4a56313b0d70068cf78988e590461540f3535e4cb0baa7c3a8df84d5f8cdf956ac4cbdd51cb6b8d8ab598b5f0bfb53321f2a023dac159e493b396d3205bde177d30bf619c5278859c2832367307b3e29c2ab2b6d1884d3696c9cb7dc12de0c4174d933c361d618f658", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals("606c06092a864886f71201020202006f5d305ba003020105a10302010fa24f304da003020110a2460444cad60460dc79a055e9ed878bd80cb136baec236919258d370a9442465555054f5a09ccce3aeaf1ac6d5ddc3e4b207d06da2c85735410bff2cefa402a7c83501c24148aba", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals("603f06092a864886f71201020202010400ffffffff53696fad43cf3605bb6bf692ba0297db2f1760e16a8864dc13e32acd54a3cdbfe27f3ff20400fb4104040404", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("603f06092a864886f71201020202010400ffffffff209a962fae641a9fef596b5c0c9aa315149e9f1fa35b6124dc1f1b7d944635cbec6548270400ef3204040404", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertTrue(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals(null, exchange);
+        assertTrue(server.isComplete());
+        assertTrue(client.isComplete());
+        assertEquals("jduke@WILDFLY.ORG", server.getAuthorizationID());
+        assertEquals("auth-conf", server.getNegotiatedProperty(Sasl.QOP));
+        assertEquals("auth-conf", client.getNegotiatedProperty(Sasl.QOP));
+        assertEquals("64321", server.getNegotiatedProperty(Sasl.MAX_BUFFER)); // max length of received message before unwrapping
+        assertEquals("61234", client.getNegotiatedProperty(Sasl.MAX_BUFFER));
+        assertEquals("61165", server.getNegotiatedProperty(Sasl.RAW_SEND_SIZE)); // max length of sent message before wrapping
+        assertEquals("64252", client.getNegotiatedProperty(Sasl.RAW_SEND_SIZE));
+
+        message = new byte[]{(byte)0x00,(byte)0x12,(byte)0x34,(byte)0x56,(byte)0x78,(byte)0x9A,(byte)0xBC,(byte)0xDE,(byte)0xFF};
+        wrappedMessage = server.wrap(message, 0, message.length);
+        assertEquals("604706092a864886f712010202020104000200ffffe95b9a1821e8ed3d21b4abf3c62ca45e92638a381552f56e5ef247fac3b40bc614e465f25d2e30dd445266bbc5c648fcd2a124fc", HexConverter.convertToHexString(wrappedMessage));
+
+        message = client.unwrap(wrappedMessage, 0, wrappedMessage.length);
+        Assert.assertArrayEquals(message, new byte[]{(byte)0x00,(byte)0x12,(byte)0x34,(byte)0x56,(byte)0x78,(byte)0x9A,(byte)0xBC,(byte)0xDE,(byte)0xFF});
+
+        message = new byte[]{(byte)0xFF,(byte)0xED,(byte)0xCB,(byte)0xA9,(byte)0x87,(byte)0x65,(byte)0x43,(byte)0x21,(byte)0x00};
+        wrappedMessage = client.wrap(message, 0, message.length);
+        assertEquals("604706092a864886f712010202020104000200ffffea352a02de5169baaac0987aea3014538c86ff1023da61a2023677386011794e02afb3dd0bf2722d361e1eec5037ab9ba101f3ee", HexConverter.convertToHexString(wrappedMessage));
+
+        message = server.unwrap(wrappedMessage, 0, wrappedMessage.length);
+        Assert.assertArrayEquals(message, new byte[]{(byte)0xFF,(byte)0xED,(byte)0xCB,(byte)0xA9,(byte)0x87,(byte)0x65,(byte)0x43,(byte)0x21,(byte)0x00});
+
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicIntegrityGssapiTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicIntegrityGssapiTest.java
@@ -1,0 +1,106 @@
+package org.wildfly.security.sasl.gssapi.compatibility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.security.sasl.util.HexConverter;
+
+public class BasicIntegrityGssapiTest extends AbstractGssapiTest {
+
+    @Test
+    public void testAuthInt() throws Exception {
+
+        client = Subject.doAs(clientSubject, new PrivilegedExceptionAction<SaslClient>() {
+            public SaslClient run() throws Exception {
+                SaslClientFactory factory = findSaslClientFactory(wildfly);
+                Map<String, String> props = new HashMap<String, String>();
+                props.put(Sasl.QOP, "auth-int");
+                props.put(Sasl.SERVER_AUTH, Boolean.toString(true));
+                props.put(Sasl.MAX_BUFFER, Integer.toString(61234));
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+            }
+        });
+
+        server = Subject.doAs(serverSubject, new PrivilegedExceptionAction<SaslServer>() {
+            public SaslServer run() throws Exception {
+                SaslServerFactory factory = findSaslServerFactory(wildfly);
+                Map<String, String> props = new HashMap<String, String>();
+                props.put(Sasl.QOP, "auth-int");
+                props.put(Sasl.MAX_BUFFER, Integer.toString(64321));
+                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+            }
+        });
+
+        assertTrue(client.hasInitialResponse());
+
+        exchange = new byte[0];
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("6082020406092a864886f71201020201006e8201f3308201efa003020105a10302010ea20703050020000000a382010b6182010730820103a003020105a10d1b0b57494c44464c592e4f5247a220301ea003020100a11730151b047361736c1b0d746573745f7365727665725f31a381ca3081c7a003020110a281bf0481bc093d7ffd9e956da2c6f5dabb2b41e5ea0b0fc158da3b4f4258baabbf6eabc23e7fe31a65e09a73bfec3c754ee262af1777b9979d2e22eb9e9d8482b8bd40847667cdaa0d67486d5c88e8c65b26df3c6eda36cb36158ad108a0ed6153ea29e8865a9099b53e2d11e90b8c0dd82e18ea982c0e741bbc0e358fbc677b02dd6c4fa7f196f23d7d48f3f82fcd003164852af47f473e44f394d26cbeed416dab4a5225d23de3d7f8109b1c607c535bf5b128210ab54aa115a306786461ddc8a481ca3081c7a003020110a281bf0481bc417f7d7dbafefd13eb5d70b31fd7fe22c4f11c3805da0bb7232fcabc0fa63071aa7b5f7201aa4221f6314c1d71876d3854ae6c46dc39392977b434817b4ca7efdb28a7e96df0f495a18e926879ecd54e6e681e4a56313b0d70068cf78988e590461540f3535e4cb0baa7c3a8df84d5f8cdf956ac4cbdd51cb6b8d8ab598b5f0bfb53321f2a023dac159e493b396d3205bde177d30bf619c5278859c2832367307b3e29c2ab2b6d1884d3696c9cb7dc12de0c4174d933c361d618f658", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals("606c06092a864886f71201020202006f5d305ba003020105a10302010fa24f304da003020110a2460444cad60460dc79a055e9ed878bd80cb136baec236919258d370a9442465555054f5a09ccce3aeaf1ac6d5ddc3e4b207d06da2c85735410bff2cefa402a7c83501c24148aba", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals("603f06092a864886f71201020202010400ffffffff30713f88836239ce9b178f16de4d5f82ae6f0bfead460000c1923a8054a3cdbfe27f3ff20200fb4104040404", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertFalse(client.isComplete());
+
+        exchange = evaluateByClient(exchange);
+        assertEquals("603f06092a864886f71201020202010400ffffffffede57f84d47cd547ce7096f2b498e4a1574a2a153089812463a7ca7c944635cbec6548270200ef3204040404", HexConverter.convertToHexString(exchange));
+        assertFalse(server.isComplete());
+        assertTrue(client.isComplete());
+
+        exchange = evaluateByServer(exchange);
+        assertEquals(null, exchange);
+        assertTrue(server.isComplete());
+        assertTrue(client.isComplete());
+        assertEquals("jduke@WILDFLY.ORG", server.getAuthorizationID());
+        assertEquals("auth-int", server.getNegotiatedProperty(Sasl.QOP));
+        assertEquals("auth-int", client.getNegotiatedProperty(Sasl.QOP));
+        assertEquals("64321", server.getNegotiatedProperty(Sasl.MAX_BUFFER)); // max length of received message before unwrapping
+        assertEquals("61234", client.getNegotiatedProperty(Sasl.MAX_BUFFER));
+        assertEquals("61165", server.getNegotiatedProperty(Sasl.RAW_SEND_SIZE)); // max length of sent message before wrapping
+        assertEquals("64252", client.getNegotiatedProperty(Sasl.RAW_SEND_SIZE));
+
+        message = new byte[]{(byte)0x00,(byte)0x12,(byte)0x34,(byte)0x56,(byte)0x78,(byte)0x9A,(byte)0xBC,(byte)0xDE,(byte)0xFF};
+        wrappedMessage = server.wrap(message, 0, message.length);
+        assertEquals("604706092a864886f71201020202010400ffffffff2bc1f810d1f8bb2bd678800850e5f7cee7aa5660fc3f71aa72414d105f614c93350494cd00123456789abcdeff07070707070707", HexConverter.convertToHexString(wrappedMessage));
+
+        message = client.unwrap(wrappedMessage, 0, wrappedMessage.length);
+        Assert.assertArrayEquals(message, new byte[]{(byte)0x00,(byte)0x12,(byte)0x34,(byte)0x56,(byte)0x78,(byte)0x9A,(byte)0xBC,(byte)0xDE,(byte)0xFF});
+
+        message = new byte[]{(byte)0xFF,(byte)0xED,(byte)0xCB,(byte)0xA9,(byte)0x87,(byte)0x65,(byte)0x43,(byte)0x21,(byte)0x00};
+        wrappedMessage = client.wrap(message, 0, message.length);
+        assertEquals("604706092a864886f71201020202010400ffffffff80e2e86bdb65006a6daaf732c1ffc61f5ee022a9c84e826ee4f09dfacd2f8705b87d4490ffedcba9876543210007070707070707", HexConverter.convertToHexString(wrappedMessage));
+
+        message = server.unwrap(wrappedMessage, 0, wrappedMessage.length);
+        Assert.assertArrayEquals(message, new byte[]{(byte)0xFF,(byte)0xED,(byte)0xCB,(byte)0xA9,(byte)0x87,(byte)0x65,(byte)0x43,(byte)0x21,(byte)0x00});
+    }
+
+}


### PR DESCRIPTION
Tests of binary compatibility Elytron GSSAPI implementation + fixes of founded deviations.

I am not sure about getWrapSizeLimit() moving - Darran, can you check if this not harm something? (meaning of `actualMaxReceiveBuffer` was changed from max nonwrapped size to max wrapped size and `maxBuffer` oppositely)

I hope change `JAASUtil` and `TestKDC` to public (because using it in subpackage) in test scope will not be a problem.
- Fixed AbstractGssapiMechanism.DEFAULT_MAX_BUFFER_SIZE (3 octets =
  0xFFFFFF)
- Fixed bugs in networkOrderBytesToInt() and intToNetworkOrderBytes()
  ~~(and changed to static and package private to allow direct testing)~~
- ChallengeResponseState should return byte[0] instead of null
- SecurityLayerAdvertiser: gssContext.getWrapSizeLimit() moved on the
  opposite side of communication
- getNegotiatedProperty now returns Strings
