### PR TITLE
Automate SASL provider detection

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
+++ b/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
@@ -18,12 +18,26 @@
 
 package org.wildfly.security.sasl;
 
+import java.util.Map;
+
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslServerFactory;
+
 /**
  * The core WildFly SASL utilities.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class WildFlySasl {
+
+    /*
+     These two properties are to prevent checkstyle from raising a false positive for imports used only in JavaDoc.
+     The checkstyle problem is fixed upstream.
+     TODO: Remove these once checkstyle is updated to 6.1 or later.
+     */
+    private static final Class<?> ssf = SaslServerFactory.class;
+    private static final Class<?> scf = SaslClientFactory.class;
+    private static final Class<?> map = Map.class;
 
     /**
      * Property name to specify if the GSSAPI mechanism should support credential delegation. The property contains "true" then
@@ -65,4 +79,11 @@ public final class WildFlySasl {
      * required.
      */
     public static final String CHANNEL_BINDING_REQUIRED = "wildfly.sasl.channel-binding-required";
+
+    /**
+     * A flag indicating that all possible supported mechanism names should be returned, regardless of the presence
+     * or absence of any other query flags.  This flag is only effective on calls to {@link SaslServerFactory#getMechanismNames(Map)}
+     * or {@link SaslClientFactory#getMechanismNames(Map)} for Elytron-provided SASL factories.
+     */
+    public static final String MECHANISM_QUERY_ALL = "wildfly.sasl.mechanism-query-all";
 }

--- a/src/main/java/org/wildfly/security/sasl/WildFlySaslProvider.java
+++ b/src/main/java/org/wildfly/security/sasl/WildFlySaslProvider.java
@@ -18,41 +18,19 @@
 
 package org.wildfly.security.sasl;
 
-import static org.wildfly.security.sasl.anonymous.AbstractAnonymousFactory.ANONYMOUS;
-import static org.wildfly.security.sasl.gssapi.AbstractGssapiFactory.GSSAPI;
-import static org.wildfly.security.sasl.localuser.LocalUserSaslFactory.JBOSS_LOCAL_USER;
-import static org.wildfly.security.sasl.md5digest.MD5DigestServerFactory.JBOSS_DIGEST_MD5;
-import static org.wildfly.security.sasl.plain.PlainServerFactory.PLAIN;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_1;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_1_PLUS;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_256;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_256_PLUS;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_384;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_384_PLUS;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_512;
-import static org.wildfly.security.sasl.scram.Scram.SCRAM_SHA_512_PLUS;
-
 import java.security.Provider;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 
 import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslServerFactory;
 
 import org.kohsuke.MetaInfServices;
 import org.wildfly.security.Version;
-import org.wildfly.security.sasl.anonymous.AnonymousClientFactory;
-import org.wildfly.security.sasl.anonymous.AnonymousServerFactory;
-import org.wildfly.security.sasl.gssapi.GssapiClientFactory;
-import org.wildfly.security.sasl.gssapi.GssapiServerFactory;
-import org.wildfly.security.sasl.localuser.LocalUserClientFactory;
-import org.wildfly.security.sasl.localuser.LocalUserServerFactory;
-import org.wildfly.security.sasl.plain.PlainServerFactory;
-import org.wildfly.security.sasl.md5digest.MD5DigestClientFactory;
-import org.wildfly.security.sasl.md5digest.MD5DigestServerFactory;
-import org.wildfly.security.sasl.scram.ScramSaslClientFactory;
-import org.wildfly.security.sasl.scram.ScramSaslServerFactory;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -74,33 +52,45 @@ public class WildFlySaslProvider extends Provider {
      */
     public WildFlySaslProvider() {
         super("wildfly-sasl", 1.0, INFO);
-        // NOTE: make sure that all client and server factories listed here also end up in the META-INF/services files.
         final List<String> noAliases = Collections.emptyList();
         final Map<String, String> noProperties = Collections.emptyMap();
-        putService(new Service(this, SASL_CLIENT_FACTORY, ANONYMOUS, AnonymousClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, ANONYMOUS, AnonymousServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, PLAIN, PlainServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, JBOSS_LOCAL_USER, LocalUserServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, JBOSS_LOCAL_USER, LocalUserClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, GSSAPI, GssapiServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, GSSAPI, GssapiClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, JBOSS_DIGEST_MD5, MD5DigestClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, JBOSS_DIGEST_MD5, MD5DigestServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_1, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_1_PLUS, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_256, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_256_PLUS, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_384, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_384_PLUS, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_512, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_CLIENT_FACTORY, SCRAM_SHA_512_PLUS, ScramSaslClientFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_1, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_1_PLUS, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_256, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_256_PLUS, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_384, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_384_PLUS, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_512, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
-        putService(new Service(this, SASL_SERVER_FACTORY, SCRAM_SHA_512_PLUS, ScramSaslServerFactory.class.getName(), noAliases, noProperties));
+        final ClassLoader myClassLoader = WildFlySaslProvider.class.getClassLoader();
+        final String myClassName = WildFlySaslProvider.class.getName();
+        final String myPackageWithDot = myClassName.substring(0, myClassName.lastIndexOf('.') + 1);
+        final ServiceLoader<SaslClientFactory> clientLoader = ServiceLoader.load(SaslClientFactory.class, myClassLoader);
+        final Iterator<SaslClientFactory> clientIterator = clientLoader.iterator();
+        final Map<String, String> props = Collections.singletonMap(WildFlySasl.MECHANISM_QUERY_ALL, "true");
+        for (;;) try {
+            if (! clientIterator.hasNext()) break;
+            final SaslClientFactory factory = clientIterator.next();
+            if (factory.getClass().getClassLoader() != myClassLoader) {
+                continue;
+            }
+            final String className = factory.getClass().getName();
+            if (!className.startsWith(myPackageWithDot)) {
+                continue;
+            }
+            final String[] names = factory.getMechanismNames(props);
+            for (String name : names) {
+                putService(new Service(this, SASL_CLIENT_FACTORY, name, className, noAliases, noProperties));
+            }
+        } catch (ServiceConfigurationError | RuntimeException ignored) {}
+        final ServiceLoader<SaslServerFactory> serverLoader = ServiceLoader.load(SaslServerFactory.class, myClassLoader);
+        final Iterator<SaslServerFactory> serverIterator = serverLoader.iterator();
+        for (;;) try {
+            if (!(serverIterator.hasNext())) break;
+            final SaslServerFactory factory = serverIterator.next();
+            if (factory.getClass().getClassLoader() != myClassLoader) {
+                continue;
+            }
+            final String className = factory.getClass().getName();
+            if (!className.startsWith(myPackageWithDot)) {
+                continue;
+            }
+            final String[] names = factory.getMechanismNames(props);
+            for (String name : names) {
+                putService(new Service(this, SASL_SERVER_FACTORY, name, className, noAliases, noProperties));
+            }
+        } catch (ServiceConfigurationError | RuntimeException ignored) {}
     }
 }

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
@@ -143,7 +143,7 @@ public final class ScramSaslClientFactory implements SaslClientFactory {
     }
 
     public String[] getMechanismNames(final Map<String, ?> props) {
-        if ("true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
+        if (!"true".equals(props.get(WildFlySasl.MECHANISM_QUERY_ALL)) && "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
             return new String[] {
                 Scram.SCRAM_SHA_1_PLUS,
                 Scram.SCRAM_SHA_256_PLUS,

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServerFactory.java
@@ -132,7 +132,7 @@ public final class ScramSaslServerFactory implements SaslServerFactory {
     }
 
     public String[] getMechanismNames(final Map<String, ?> props) {
-        if ("true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
+        if (!"true".equals(props.get(WildFlySasl.MECHANISM_QUERY_ALL)) && "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
             return new String[] {
                 Scram.SCRAM_SHA_1_PLUS,
                 Scram.SCRAM_SHA_256_PLUS,

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractSaslFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractSaslFactory.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import javax.security.sasl.Sasl;
 
+import org.wildfly.security.sasl.WildFlySasl;
+
 /**
  * Abstract SASL factory base class.
  *
@@ -64,7 +66,8 @@ public abstract class AbstractSaslFactory {
      * @return {@code true} if there is a match, {@code false} otherwise
      */
     protected boolean matches(final Map<String, ?> props) {
-        return  ! (getPropertyValue(Sasl.POLICY_NOPLAINTEXT, props, false) && isPlainText()
+        return getPropertyValue(WildFlySasl.MECHANISM_QUERY_ALL, props, false) ||
+                ! (getPropertyValue(Sasl.POLICY_NOPLAINTEXT, props, false) && isPlainText()
                 || getPropertyValue(Sasl.POLICY_NOANONYMOUS, props, false) && isAnonymous()
                 || getPropertyValue(Sasl.POLICY_FORWARD_SECRECY, props, false) && ! isForwardSecrecy()
                 || getPropertyValue(Sasl.POLICY_NOACTIVE, props, false) && isActiveSusceptible()


### PR DESCRIPTION
Adds a WildFlySasl property indicating that all mechanisms should be returned, and uses this means to get a full list of all mechanisms from all bundled SASL clients and servers.
