### PR TITLE
[RFC] ELY-118 Reloadable File Based KeyStore

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -169,4 +169,5 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 39, value = "Expected token \"%s\" at offset %d of mechanism selection string \"%s\"")
     IllegalArgumentException mechSelectorTokenExpected(String token, int offset, String string);
+
 }

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -1,0 +1,227 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Central point for watching for modifications to KeyStores.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class KeyStoreWatcher {
+
+    /*
+     * Some key points: - - Could have multiple key stores in the same folder. - Could have multiple key store instances
+     * interested in the same underlying store.
+     *
+     * To begin with lest just assume singleton, but maybe this could be replaced with a container specific version.
+     */
+
+
+    private final ExecutorService executor;
+    private final FileSystem fileSystem;
+
+    private volatile Map<Path, Map<String, List<Store>>> watchedPaths = new HashMap<Path, Map<String, List<Store>>>();
+    private final Map<Path, WatchKey> registrations = new HashMap<Path, WatchKey>();
+
+    private volatile WatchService watchService;
+
+    private static KeyStoreWatcher theWatcher = new KeyStoreWatcher();
+
+    private KeyStoreWatcher() {
+        fileSystem = FileSystems.getDefault();
+        executor = Executors.newCachedThreadPool();
+    }
+
+    static KeyStoreWatcher getDefault() {
+        return theWatcher;
+    }
+
+    synchronized void register(File watchFile, Store keyStore) throws IOException {
+        File canonical = watchFile.getCanonicalFile();
+
+        File parentDir = canonical.getParentFile();
+        String fileName = canonical.getName();
+
+        Path dirPath = parentDir.toPath();
+
+        boolean watchRequired = false;
+        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+        List<Store> pathStores = null;
+        if (pathRegistration == null) {
+            watchRequired = true;
+            pathRegistration = new HashMap<String, List<Store>>();
+            pathStores = new LinkedList<Store>();
+        } else {
+            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
+            List<Store> tmpStore = pathRegistration.get(fileName);
+            if (tmpStore != null) {
+                // Copy the store so we can add to it without affecting any iterator.
+                pathStores = new LinkedList<Store>(tmpStore);
+            } else {
+                pathStores = new LinkedList<Store>();
+            }
+        }
+
+        pathStores.add(keyStore);
+        pathRegistration.put(fileName, pathStores);
+        Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
+        newWatchedPaths.put(dirPath, pathRegistration);
+        watchedPaths = newWatchedPaths;
+
+        if (watchRequired) {
+            if (watchService == null) {
+                watchService = fileSystem.newWatchService();
+                executor.execute(new EventTaker());
+            }
+            // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
+            WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+            registrations.put(dirPath, key);
+        }
+    }
+
+    synchronized void deRegister(File watchFile, Store keyStore) throws IOException {
+        File canonical = watchFile.getCanonicalFile();
+
+        File parentDir = canonical.getParentFile();
+        String fileName = canonical.getName();
+
+        Path dirPath = parentDir.toPath();
+
+        boolean watchRequired = false;
+        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+        List<Store> pathStores = null;
+        if (pathRegistration != null) {
+            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
+            List<Store> tmpStores = pathRegistration.get(fileName);
+            if (tmpStores != null) {
+                pathStores = new LinkedList<Store>(tmpStores);
+                Iterator<Store> storeIterator = pathStores.iterator();
+                while (storeIterator.hasNext()) {
+                    Store current = storeIterator.next();
+                    if (keyStore == current) {
+                        storeIterator.remove();
+                    }
+                }
+                if (pathStores.isEmpty()) {
+                    pathRegistration.remove(fileName);
+                } else {
+                    pathRegistration.put(fileName, pathStores);
+                }
+            }
+
+            Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
+            if (pathRegistration.isEmpty()) {
+                newWatchedPaths.remove(dirPath);
+                WatchKey key = registrations.remove(dirPath);
+                if (key != null) {
+                    key.cancel();
+                }
+                if (newWatchedPaths.isEmpty()) {
+                    watchService.close();
+                    watchService = null;
+                }
+            } else {
+                newWatchedPaths.put(dirPath, pathRegistration);
+            }
+            watchedPaths = newWatchedPaths;
+        }
+
+    }
+
+    interface Store {
+
+        void modified();
+
+    }
+
+    private class EventTaker implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                while (watchService != null) {
+                    WatchKey key = watchService.take();
+                    Path watchedPath = (Path) key.watchable();
+                    Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
+                    if (pathRegistration != null) {
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())
+                                    || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
+                                Path context = (Path) event.context();
+                                String name = context.getFileName().toString();
+                                List<Store> stores = pathRegistration.get(name);
+                                if (stores != null) {
+                                    for (Store current : stores) {
+                                        executor.execute(new Notifier(current));
+                                    }
+                                }
+
+                            } else if (StandardWatchEventKinds.OVERFLOW.equals(event.kind())) {
+                                // No idea what happened so reload them all.
+                                for (List<Store> stores : pathRegistration.values()) {
+                                    for (Store current : stores) {
+                                        executor.execute(new Notifier(current));
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                    key.reset();
+                }
+            } catch (ClosedWatchServiceException | InterruptedException e) {
+                //e.printStackTrace();
+            }
+        }
+    }
+
+    private class Notifier implements Runnable {
+
+        private final Store store;
+
+        private Notifier(Store store) {
+            this.store = store;
+        }
+
+        @Override
+        public void run() {
+            store.modified();
+        }
+
+    }
+}
+

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -166,13 +166,16 @@ class KeyStoreWatcher {
                 while (watchService != null) {
                     WatchKey key = watchService.take();
                     Path watchedPath = (Path) key.watchable();
+                    System.out.println("Path " + watchedPath.toString());
                     Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
                     if (pathRegistration != null) {
                         for (WatchEvent<?> event : key.pollEvents()) {
+                            System.out.println("Event Name " + event.kind().name());
                             if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())
                                     || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
                                 Path context = (Path) event.context();
                                 String name = context.getFileName().toString();
+                                System.out.println("File Name " + name);
                                 List<Store> stores = pathRegistration.get(name);
                                 if (stores != null) {
                                     for (Store current : stores) {

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -98,7 +98,7 @@ class KeyStoreWatcher {
                 pollThread.start();
             }
             // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
-            WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+            WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
             registrations.put(dirPath, key);
         }
     }

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -181,12 +181,15 @@ class KeyStoreWatcher {
                                 }
 
                             } else if (StandardWatchEventKinds.OVERFLOW.equals(event.kind())) {
+                                throw new IllegalStateException("OVERFLOW");
                                 // No idea what happened so reload them all.
+                                /*
                                 for (List<Store> stores : pathRegistration.values()) {
                                     for (Store current : stores) {
                                         current.modified();
                                     }
                                 }
+                                */
                             }
                         }
 

--- a/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.Provider;
+
+/**
+ * A file base {@link KeyStore} that supports dynamic reloading when changes to the underlying store are detected.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ReloadableFileKeyStore extends KeyStore implements Closeable {
+
+    private final ReloadableKeyStoreSpiImpl keyStoreSpi;
+
+    private ReloadableFileKeyStore(ReloadableKeyStoreSpiImpl keyStoreSpi, Provider provider, String type) {
+        super(keyStoreSpi, provider, type);
+        this.keyStoreSpi = keyStoreSpi;
+    }
+
+    public static ReloadableFileKeyStore getInstance(String type, Provider provider, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        ReloadableKeyStoreSpiImpl spi = new ReloadableKeyStoreSpiImpl(type, provider, storeLocation, storePassword);
+
+        return new ReloadableFileKeyStore(spi, provider, type);
+    }
+
+    public static ReloadableFileKeyStore getInstance(String type, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        return getInstance(type, null, storeLocation, storePassword);
+    }
+
+    public void close() throws IOException {
+        keyStoreSpi.close();
+    }
+
+}

--- a/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
@@ -55,4 +55,17 @@ public class ReloadableFileKeyStore extends KeyStore implements Closeable {
         keyStoreSpi.close();
     }
 
+    public void addObserver(final KeyStoreObserver oberserver) {
+        keyStoreSpi.addObserver(oberserver);
+    }
+
+    public void removeObserver(final KeyStoreObserver oberserver) {
+        keyStoreSpi.removeObserver(oberserver);
+    }
+
+    interface KeyStoreObserver {
+
+        void updated();
+
+    }
 }

--- a/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.wildfly.security.keystore.KeyStoreWatcher.Store;
+
+/**
+ * The {@link KeyStoreSpi} to add support for reloading based on modifications.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class ReloadableKeyStoreSpiImpl extends KeyStoreSpi implements Store {
+
+    private final String type;
+    private final Provider provider;
+    private final File storeLocation;
+    private final char[] storePassword;
+
+    private final AtomicReference<KeyStore> currentStore = new AtomicReference<KeyStore>();
+
+    ReloadableKeyStoreSpiImpl(String type, Provider provider, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        this.type = type;
+        this.provider = provider;
+        this.storeLocation = storeLocation;
+        this.storePassword = storePassword.clone();
+    }
+
+
+    Provider getProvider() {
+        return currentStore.get().getProvider();
+    }
+
+    @Override
+    public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        try {
+            return currentStore.get().getKey(alias, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String alias) {
+        try {
+            return currentStore.get().getCertificateChain(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String alias) {
+        try {
+            return currentStore.get().getCertificate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Date engineGetCreationDate(String alias) {
+        try {
+            return currentStore.get().getCreationDate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+        currentStore.get().setKeyEntry(alias, key, password, chain);
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        currentStore.get().setKeyEntry(alias, key, chain);
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+        currentStore.get().setCertificateEntry(alias, cert);
+    }
+
+    @Override
+    public void engineDeleteEntry(String alias) throws KeyStoreException {
+        currentStore.get().deleteEntry(alias);
+    }
+
+    @Override
+    public Enumeration<String> engineAliases() {
+        try {
+            return currentStore.get().aliases();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        try {
+            return currentStore.get().containsAlias(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public int engineSize() {
+        try {
+            return currentStore.get().size();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String alias) {
+        try {
+            return currentStore.get().isKeyEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String alias) {
+        try {
+            return currentStore.get().isCertificateEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate cert) {
+        try {
+            return currentStore.get().getCertificateAlias(cert);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineStore(OutputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        try {
+            currentStore.get().store(stream, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        if (stream != null || password != null) {
+            throw new IllegalStateException("Custom load not supported.");
+        }
+
+        boolean registrationRequired = currentStore.get() == null;
+        doLoad(false);
+        if (registrationRequired) {
+            KeyStoreWatcher.getDefault().register(storeLocation, this);
+        }
+    }
+
+
+    private void doLoad(boolean dontFail) {
+        KeyStore theStore;
+        try {
+            theStore = provider == null ? KeyStore.getInstance(type) : KeyStore.getInstance(type, provider);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+
+        try (FileInputStream fis = new FileInputStream(storeLocation)) {
+            theStore.load(fis, storePassword);
+
+            currentStore.set(theStore);
+        } catch (IOException | NoSuchAlgorithmException | CertificateException e) {
+            if (dontFail == false) {
+                throw new IllegalStateException("Unable to load KeyStore", e);
+            }
+        }
+    }
+
+    @Override
+    public void modified() {
+        doLoad(true);
+    }
+
+    void close() throws IOException {
+        KeyStoreWatcher.getDefault().deRegister(storeLocation, this);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
@@ -221,6 +221,7 @@ class ReloadableKeyStoreSpiImpl extends KeyStoreSpi implements Store {
 
     @Override
     public void modified() {
+        System.out.println("SPI Modified");
         doLoad(true);
     }
 

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -85,28 +85,39 @@ public class ReloadableKeyStoreTest {
     @Test
     public void verifyStoreUpdates() throws Exception {
         try (ReloadableFileKeyStore testedStore = reloadableKeyStore()) {
+            System.out.println("1");
             StoreCountDown countDown = new StoreCountDown();
+            System.out.println("2");
             KeyStoreWatcher.getDefault().register(keystoreFile, countDown);
-
+            System.out.println("3");
             assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            System.out.println("4");
             assertFalse(testedStore.containsAlias(TEST_ALAIS));
-
+            System.out.println("5");
             addKeyPairAndCert(TEST_ALAIS);
+            System.out.println("6");
             save();
-
+            System.out.println("7");
             countDown.await();
+            System.out.println("8");
             assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            System.out.println("9");
             assertTrue(testedStore.containsAlias(TEST_ALAIS));
-
+            System.out.println("10");
             remove(DEFAULT_ALIAS);
+            System.out.println("11");
             countDown.reset();
+            System.out.println("12");
             save();
-
+            System.out.println("13");
             countDown.await();
+            System.out.println("14");
             assertFalse(testedStore.containsAlias(DEFAULT_ALIAS));
+            System.out.println("15");
             assertTrue(testedStore.containsAlias(TEST_ALAIS));
-
+            System.out.println("16");
             KeyStoreWatcher.getDefault().deRegister(keystoreFile, countDown);
+            System.out.println("17");
         }
     }
 

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -18,9 +18,9 @@
 
 package org.wildfly.security.keystore;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.wildfly.security.keystore.KeyStoreWatcher.Store;
+import org.wildfly.security.keystore.ReloadableFileKeyStore.KeyStoreObserver;
 
 import sun.security.x509.CertAndKeyGen;
 import sun.security.x509.X500Name;
@@ -88,7 +88,7 @@ public class ReloadableKeyStoreTest {
             System.out.println("1");
             StoreCountDown countDown = new StoreCountDown();
             System.out.println("2");
-            KeyStoreWatcher.getDefault().register(keystoreFile, countDown);
+            testedStore.addObserver(countDown);
             System.out.println("3");
             assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
             System.out.println("4");
@@ -116,7 +116,7 @@ public class ReloadableKeyStoreTest {
             System.out.println("15");
             assertTrue(testedStore.containsAlias(TEST_ALAIS));
             System.out.println("16");
-            KeyStoreWatcher.getDefault().deRegister(keystoreFile, countDown);
+            testedStore.removeObserver(countDown);
             System.out.println("17");
         }
     }
@@ -178,12 +178,12 @@ public class ReloadableKeyStoreTest {
         return workingDir;
     }
 
-    private static class StoreCountDown implements Store {
+    private static class StoreCountDown implements KeyStoreObserver {
 
         private volatile CountDownLatch latch = new CountDownLatch(1);
 
         @Override
-        public void modified() {
+        public void updated() {
             System.out.println("Test Store modified");
             latch.countDown();
         }

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -158,8 +158,10 @@ public class ReloadableKeyStoreTest {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
         System.out.println("Delete real file");
-        if (keystoreFile.delete() == false) {
-            fail("Unable to delete KeyStore");
+        if (keystoreFile.exists()) {
+            if (keystoreFile.delete() == false) {
+                fail("Unable to delete KeyStore");
+            }
         }
         System.out.println("Rename temp to real");
         if (tempFile.renameTo(keystoreFile) == false) {

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -29,10 +29,13 @@ import java.security.KeyStore;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.KeyStore.ProtectionParameter;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.security.keystore.KeyStoreWatcher.Store;
 
 import sun.security.x509.CertAndKeyGen;
 import sun.security.x509.X500Name;
@@ -50,6 +53,7 @@ public class ReloadableKeyStoreTest {
     private static final String TEST_ALAIS = "test";
 
     private File workingDir = null;
+    private File tempFile = null;
     private File keystoreFile = null;
 
     /**
@@ -61,6 +65,7 @@ public class ReloadableKeyStoreTest {
     @Before
     public void beforeTest() throws GeneralSecurityException, IOException {
         workingDir = getWorkingDir();
+        tempFile = new File(workingDir, "temp.jks");
         keystoreFile = new File(workingDir, "keystore.jks");
 
         workingKeyStore = emptyKeyStore();
@@ -79,22 +84,28 @@ public class ReloadableKeyStoreTest {
     @Test
     public void verifyStoreUpdates() throws Exception {
         try (ReloadableFileKeyStore testedStore = reloadableKeyStore()) {
+            StoreCountDown countDown = new StoreCountDown();
+            KeyStoreWatcher.getDefault().register(keystoreFile, countDown);
+
             assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
             assertFalse(testedStore.containsAlias(TEST_ALAIS));
 
             addKeyPairAndCert(TEST_ALAIS);
             save();
-            Thread.sleep(1000);
 
+            countDown.await();
             assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
             assertTrue(testedStore.containsAlias(TEST_ALAIS));
 
             remove(DEFAULT_ALIAS);
+            countDown.reset();
             save();
-            Thread.sleep(1000);
 
+            countDown.await();
             assertFalse(testedStore.containsAlias(DEFAULT_ALIAS));
             assertTrue(testedStore.containsAlias(TEST_ALAIS));
+
+            KeyStoreWatcher.getDefault().deRegister(keystoreFile, countDown);
         }
     }
 
@@ -130,9 +141,10 @@ public class ReloadableKeyStoreTest {
     }
 
     private void save() throws IOException, GeneralSecurityException {
-        try (FileOutputStream fos = new FileOutputStream(keystoreFile)) {
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
+        tempFile.renameTo(keystoreFile);
     }
 
     private static File getWorkingDir() {
@@ -142,6 +154,31 @@ public class ReloadableKeyStoreTest {
         }
 
         return workingDir;
+    }
+
+    private static class StoreCountDown implements Store {
+
+        private volatile CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void modified() {
+            latch.countDown();
+        }
+
+        void reset() {
+            latch = new CountDownLatch(1);
+        }
+
+        void await() {
+            try {
+                if (latch.await(1, TimeUnit.SECONDS) == false) {
+                    throw new IllegalStateException("Latch never reached '0' but timed out.");
+                }
+            } catch (InterruptedException e) {
+                throw new IllegalStateException("Interrupted waiting for count down.", e);
+            }
+        }
+
     }
 
 }

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -158,7 +158,9 @@ public class ReloadableKeyStoreTest {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
         System.out.println("Delete real file");
-        keystoreFile.delete();
+        if (keystoreFile.delete() == false) {
+            fail("Unable to delete KeyStore");
+        }
         System.out.println("Rename temp to real");
         if (tempFile.renameTo(keystoreFile) == false) {
             fail("Unable to rename temporary keystore to test keystore.");

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.KeyStore.ProtectionParameter;
+import java.security.cert.X509Certificate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import sun.security.x509.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+/**
+ * Test case to test support for reloadable key stores.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ReloadableKeyStoreTest {
+
+    private static final String KEY_STORE_TYPE = "jks";
+    private static final char[] STORE_PASSWORD = "password".toCharArray();
+    private static final String DEFAULT_ALIAS = "default";
+    private static final String TEST_ALAIS = "test";
+
+    private File workingDir = null;
+    private File keystoreFile = null;
+
+    /**
+     * This is the working key store being used to modify the contents of the store, the store being tested is created in the
+     * individual tests.
+     */
+    private KeyStore workingKeyStore = null;
+
+    @Before
+    public void beforeTest() throws GeneralSecurityException, IOException {
+        workingDir = getWorkingDir();
+        keystoreFile = new File(workingDir, "keystore.jks");
+
+        workingKeyStore = emptyKeyStore();
+        addKeyPairAndCert(DEFAULT_ALIAS);
+        save();
+    }
+
+    @After
+    public void afterTest() {
+        keystoreFile.delete();
+        keystoreFile = null;
+        workingDir.delete();
+        workingDir = null;
+    }
+
+    @Test
+    public void verifyStoreUpdates() throws Exception {
+        try (ReloadableFileKeyStore testedStore = reloadableKeyStore()) {
+            assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertFalse(testedStore.containsAlias(TEST_ALAIS));
+
+            addKeyPairAndCert(TEST_ALAIS);
+            save();
+            Thread.sleep(1000);
+
+            assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertTrue(testedStore.containsAlias(TEST_ALAIS));
+
+            remove(DEFAULT_ALIAS);
+            save();
+            Thread.sleep(1000);
+
+            assertFalse(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertTrue(testedStore.containsAlias(TEST_ALAIS));
+        }
+    }
+
+    private ReloadableFileKeyStore reloadableKeyStore() throws GeneralSecurityException, IOException {
+        ReloadableFileKeyStore theStore  = ReloadableFileKeyStore.getInstance(KEY_STORE_TYPE, keystoreFile, STORE_PASSWORD);
+        theStore.load(null, null);
+
+        return theStore;
+    }
+
+    private KeyStore emptyKeyStore() throws GeneralSecurityException, IOException {
+        KeyStore theStore = KeyStore.getInstance(KEY_STORE_TYPE);
+        theStore.load(null, null);
+
+        return theStore;
+    }
+
+    @SuppressWarnings("restriction")
+    private void addKeyPairAndCert(final String alias) throws GeneralSecurityException, IOException {
+        CertAndKeyGen keyGen = new CertAndKeyGen("RSA", "SHA1WithRSA");
+        keyGen.generate(512); // For the purpose of this test, as small as we can go.
+        X509Certificate cert = keyGen.getSelfCertificate(new X500Name(String.format("cn=%s", alias)), 31536000); // Validity one
+                                                                                                                 // year.
+
+        ProtectionParameter pp = new KeyStore.PasswordProtection(STORE_PASSWORD);
+        PrivateKeyEntry pke = new PrivateKeyEntry(keyGen.getPrivateKey(), new X509Certificate[] { cert });
+
+        workingKeyStore.setEntry(alias, pke, pp);
+    }
+
+    private void remove(final String alias) throws GeneralSecurityException{
+        workingKeyStore.deleteEntry(alias);
+    }
+
+    private void save() throws IOException, GeneralSecurityException {
+        try (FileOutputStream fos = new FileOutputStream(keystoreFile)) {
+            workingKeyStore.store(fos, STORE_PASSWORD);
+        }
+    }
+
+    private static File getWorkingDir() {
+        File workingDir = new File("./target/keystore");
+        if (workingDir.exists() == false) {
+            workingDir.mkdirs();
+        }
+
+        return workingDir;
+    }
+
+}

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -142,10 +142,13 @@ public class ReloadableKeyStoreTest {
     }
 
     private void save() throws IOException, GeneralSecurityException {
+        System.out.println("Write to temp file");
         try (FileOutputStream fos = new FileOutputStream(tempFile)) {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
+        System.out.println("Delete real file");
         keystoreFile.delete();
+        System.out.println("Rename temp to real");
         if (tempFile.renameTo(keystoreFile) == false) {
             fail("Unable to rename temporary keystore to test keystore.");
         }
@@ -166,6 +169,7 @@ public class ReloadableKeyStoreTest {
 
         @Override
         public void modified() {
+            System.out.println("Test Store modified");
             latch.countDown();
         }
 
@@ -181,6 +185,7 @@ public class ReloadableKeyStoreTest {
             } catch (InterruptedException e) {
                 throw new IllegalStateException("Interrupted waiting for count down.", e);
             }
+            System.out.println("Away done");
         }
 
     }

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -157,12 +157,14 @@ public class ReloadableKeyStoreTest {
         try (FileOutputStream fos = new FileOutputStream(tempFile)) {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
+        /*
         System.out.println("Delete real file");
         if (keystoreFile.exists()) {
             if (keystoreFile.delete() == false) {
                 fail("Unable to delete KeyStore");
             }
         }
+        */
         System.out.println("Rename temp to real");
         if (tempFile.renameTo(keystoreFile) == false) {
             fail("Unable to rename temporary keystore to test keystore.");

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -20,11 +20,12 @@ package org.wildfly.security.keystore;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.KeyStore.PrivateKeyEntry;
@@ -166,9 +167,13 @@ public class ReloadableKeyStoreTest {
         }
         */
         System.out.println("Rename temp to real");
+        Files.move(tempFile.toPath(), keystoreFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+
+        /*
         if (tempFile.renameTo(keystoreFile) == false) {
             fail("Unable to rename temporary keystore to test keystore.");
         }
+        */
     }
 
     private static File getWorkingDir() {

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.keystore;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -144,7 +145,10 @@ public class ReloadableKeyStoreTest {
         try (FileOutputStream fos = new FileOutputStream(tempFile)) {
             workingKeyStore.store(fos, STORE_PASSWORD);
         }
-        tempFile.renameTo(keystoreFile);
+        keystoreFile.delete();
+        if (tempFile.renameTo(keystoreFile) == false) {
+            fail("Unable to rename temporary keystore to test keystore.");
+        }
     }
 
     private static File getWorkingDir() {


### PR DESCRIPTION
Here is an implementation for automatic reloading of a file based key store based on NIO notifications.

Initially the description sounded simple but it didn't seem to turn out that way - or I have missed something stupidly obvious hence the RFC ;-)

First of all the test case, in retrospect I don't think that can stay - we do need out own certificate and CSR implementation BUT even without that part the test ends up being a race condition as firstly we have the potential delay in the notification from the filesystem to report the modification, secondly we have the possible delay in the dispatched task to actually perform the load.

So the impl itself, the first issue was that the notifications were actually for a directory and not a specific file, I think the chances are there could be many stores located in the same directory, this then led to the problem of requiring a thread to wait for the notifications and finally we could have mutliple KeyStore instances referencing the same file and so KeyStoreWatcher was born.  

But overall I can't help feeling that this is something that we should expect to be available within the application server so that is how the method to obtain the KeyStoreWatcher ended up being called getDefault() so we could potentially set (with some refactoring) a different implementation.
