### PR TITLE
[ELY-118] Reloadable KeyStore

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -172,4 +172,5 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 40, value = "Proxied SASL authentication failed")
     SaslException saslProxyAuthenticationFailed();
+
 }

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -1,0 +1,227 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Central point for watching for modifications to KeyStores.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class KeyStoreWatcher {
+
+    /*
+     * Some key points: - - Could have multiple key stores in the same folder. - Could have multiple key store instances
+     * interested in the same underlying store.
+     *
+     * To begin with lest just assume singleton, but maybe this could be replaced with a container specific version.
+     */
+
+
+    private final ExecutorService executor;
+    private final FileSystem fileSystem;
+
+    private volatile Map<Path, Map<String, List<Store>>> watchedPaths = new HashMap<Path, Map<String, List<Store>>>();
+    private final Map<Path, WatchKey> registrations = new HashMap<Path, WatchKey>();
+
+    private volatile WatchService watchService;
+
+    private static KeyStoreWatcher theWatcher = new KeyStoreWatcher();
+
+    private KeyStoreWatcher() {
+        fileSystem = FileSystems.getDefault();
+        executor = Executors.newCachedThreadPool();
+    }
+
+    static KeyStoreWatcher getDefault() {
+        return theWatcher;
+    }
+
+    synchronized void register(File watchFile, Store keyStore) throws IOException {
+        File canonical = watchFile.getCanonicalFile();
+
+        File parentDir = canonical.getParentFile();
+        String fileName = canonical.getName();
+
+        Path dirPath = parentDir.toPath();
+
+        boolean watchRequired = false;
+        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+        List<Store> pathStores = null;
+        if (pathRegistration == null) {
+            watchRequired = true;
+            pathRegistration = new HashMap<String, List<Store>>();
+            pathStores = new LinkedList<Store>();
+        } else {
+            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
+            List<Store> tmpStore = pathRegistration.get(fileName);
+            if (tmpStore != null) {
+                // Copy the store so we can add to it without affecting any iterator.
+                pathStores = new LinkedList<Store>(tmpStore);
+            } else {
+                pathStores = new LinkedList<Store>();
+            }
+        }
+
+        pathStores.add(keyStore);
+        pathRegistration.put(fileName, pathStores);
+        Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
+        newWatchedPaths.put(dirPath, pathRegistration);
+        watchedPaths = newWatchedPaths;
+
+        if (watchRequired) {
+            if (watchService == null) {
+                watchService = fileSystem.newWatchService();
+                executor.execute(new EventTaker());
+            }
+            // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
+            WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+            registrations.put(dirPath, key);
+        }
+    }
+
+    synchronized void deRegister(File watchFile, Store keyStore) throws IOException {
+        File canonical = watchFile.getCanonicalFile();
+
+        File parentDir = canonical.getParentFile();
+        String fileName = canonical.getName();
+
+        Path dirPath = parentDir.toPath();
+
+        boolean watchRequired = false;
+        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+        List<Store> pathStores = null;
+        if (pathRegistration != null) {
+            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
+            List<Store> tmpStores = pathRegistration.get(fileName);
+            if (tmpStores != null) {
+                pathStores = new LinkedList<Store>(tmpStores);
+                Iterator<Store> storeIterator = pathStores.iterator();
+                while (storeIterator.hasNext()) {
+                    Store current = storeIterator.next();
+                    if (keyStore == current) {
+                        storeIterator.remove();
+                    }
+                }
+                if (pathStores.isEmpty()) {
+                    pathRegistration.remove(fileName);
+                } else {
+                    pathRegistration.put(fileName, pathStores);
+                }
+            }
+
+            Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
+            if (pathRegistration.isEmpty()) {
+                newWatchedPaths.remove(dirPath);
+                WatchKey key = registrations.remove(dirPath);
+                if (key != null) {
+                    key.cancel();
+                }
+                if (newWatchedPaths.isEmpty()) {
+                    watchService.close();
+                    watchService = null;
+                }
+            } else {
+                newWatchedPaths.put(dirPath, pathRegistration);
+            }
+            watchedPaths = newWatchedPaths;
+        }
+
+    }
+
+    interface Store {
+
+        void modified();
+
+    }
+
+    private class EventTaker implements Runnable {
+
+        @Override
+        public void run() {
+            try {
+                while (watchService != null) {
+                    WatchKey key = watchService.take();
+                    Path watchedPath = (Path) key.watchable();
+                    Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
+                    if (pathRegistration != null) {
+                        for (WatchEvent<?> event : key.pollEvents()) {
+                            if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())
+                                    || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
+                                Path context = (Path) event.context();
+                                String name = context.getFileName().toString();
+                                List<Store> stores = pathRegistration.get(name);
+                                if (stores != null) {
+                                    for (Store current : stores) {
+                                        executor.execute(new Notifier(current));
+                                    }
+                                }
+
+                            } else if (StandardWatchEventKinds.OVERFLOW.equals(event.kind())) {
+                                // No idea what happened so reload them all.
+                                for (List<Store> stores : pathRegistration.values()) {
+                                    for (Store current : stores) {
+                                        executor.execute(new Notifier(current));
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                    key.reset();
+                }
+            } catch (ClosedWatchServiceException | InterruptedException e) {
+                //e.printStackTrace();
+            }
+        }
+    }
+
+    private class Notifier implements Runnable {
+
+        private final Store store;
+
+        private Notifier(Store store) {
+            this.store = store;
+        }
+
+        @Override
+        public void run() {
+            store.modified();
+        }
+
+    }
+}
+

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -46,6 +46,22 @@ class KeyStoreWatcher {
 
     private final FileSystem fileSystem;
 
+    /**
+     * This {@link Map} is the central point where actively watched keystores are recorded.
+     *
+     * The purpose of the {@link KeyStoreWatcher} is to provide updates to individual KeyStores when updates are applied,
+     * however we need to work within the following constraints.
+     *  - The {@link WatchService} watches directories and not individual files.
+     *  - An administrator may have multiple keystores in the same directory.
+     *  - Keystores could be located in different directories.
+     *  - We could have multiple in-memory keystore instances backed by the same file.
+     *
+     *  So we have a {@link Map} where the key is a {@link Path} to the directory being monitored, the value is a further {@link Map}.
+     *  On the second {@link Map} the key is the name of the keystore file within the the directory being monitored and the value is a {@link List}
+     *  The {@link List} referenced by the {@link Map} is a list of all keystores that should be reloaded if a modification to the file is detected.
+     *
+     *  Note: This is defined as 'volatile' as on writes the whole {@link Map} will be replaced.
+     */
     private volatile Map<Path, Map<String, List<Store>>> watchedPaths = Collections.emptyMap();
     private final Map<Path, WatchKey> registrations = new HashMap<Path, WatchKey>();
 
@@ -73,10 +89,12 @@ class KeyStoreWatcher {
         Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
         List<Store> pathStores = null;
         if (pathRegistration == null) {
+            // There is no existing watch of this directory so we will need to start it but only do that after the Map has been updated.
             watchRequired = true;
             pathRegistration = new HashMap<String, List<Store>>();
             pathStores = new ArrayList<Store>();
         } else {
+            // We are adding to an existing Map so create a copy.
             pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
             List<Store> tmpStore = pathRegistration.get(fileName);
             if (tmpStore != null) {
@@ -87,14 +105,22 @@ class KeyStoreWatcher {
             }
         }
 
+        /*
+         * Modifications should not happen to any of these collections but to detect errors
+         * in the future make all unmodifiable.
+         */
         pathStores.add(keyStore);
+        // The pathStores is the one we created one way or another above.
         pathRegistration.put(fileName, Collections.unmodifiableList(pathStores));
+        // We are making modifications so copy watchedPaths
         Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
+        // pathRegistration was also created one way or another above.
         newWatchedPaths.put(dirPath, Collections.unmodifiableMap(pathRegistration));
         watchedPaths = Collections.unmodifiableMap(newWatchedPaths);
 
         if (watchRequired) {
             if (watchService == null) {
+                // Is this the very first Path to be watched, if so we are going to need a WatchService.
                 watchService = fileSystem.newWatchService();
                 Thread pollThread = new Thread(new EventTaker(), "KeyStoreWatcher Daemon");
                 pollThread.setDaemon(true);
@@ -102,6 +128,7 @@ class KeyStoreWatcher {
             }
             // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
             WatchKey key = dirPath.register(watchService,  StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+            // We also need to maintain a mapping with the WatchKey so we have something we can use to Cancel the registration latser.
             registrations.put(dirPath, key);
         }
     }
@@ -117,9 +144,12 @@ class KeyStoreWatcher {
         Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
         List<Store> pathStores = null;
         if (pathRegistration != null) {
+            // The act of removal means we know we will be replacing the list of keystores requiring notification, it
+            // may also result in this file being no-longer monitored - either way we need a copy to work on.
             pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
             List<Store> tmpStores = pathRegistration.get(fileName);
             if (tmpStores != null) {
+                // Remove all references to this store from a copy of the list of stores to be notified about this file.
                 pathStores = new ArrayList<Store>(tmpStores);
                 Iterator<Store> storeIterator = pathStores.iterator();
                 while (storeIterator.hasNext()) {
@@ -131,24 +161,31 @@ class KeyStoreWatcher {
                 if (pathStores.isEmpty()) {
                     pathRegistration.remove(fileName);
                 } else {
+                    // Other stores are still expecting notifications.
                     pathRegistration.put(fileName, Collections.unmodifiableList(pathStores));
                 }
             }
 
+            // Copy of the watched paths so the updated collections can be added / entries removed as needed.
             Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
             if (pathRegistration.isEmpty()) {
+                // This was the last registration watching anything in the directory specified.
                 newWatchedPaths.remove(dirPath);
+                // Remove and cancel the WatchKey registration.
                 WatchKey key = registrations.remove(dirPath);
                 if (key != null) {
                     key.cancel();
                 }
+                // This could also have been the last directory overall being monitored, if so the WatchService can be closed and discarded.
                 if (newWatchedPaths.isEmpty()) {
                     watchService.close();
                     watchService = null;
                 }
             } else {
+                // Still some files to monitor so just set the updated Map for the current path.
                 newWatchedPaths.put(dirPath, Collections.unmodifiableMap(pathRegistration));
             }
+            // Finally set back the replacement Map.
             watchedPaths = Collections.unmodifiableMap(newWatchedPaths);
         }
 
@@ -166,10 +203,15 @@ class KeyStoreWatcher {
         public void run() {
             try {
                 WatchService watchService = null;
+                // We only want to run whilst there is an active watch service.
                 while ((watchService = KeyStoreWatcher.this.watchService) != null) {
                     WatchKey key = watchService.take();
                     Path watchedPath = (Path) key.watchable();
                     Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
+                    // watchedPaths is volatile, any further writes above will not affect the pathRegistration reference we just obtained.
+
+                    // We create a list of Store implementations to notify as a single file could trigger multiple events, e.g. on Windows
+                    // a rename can be seen as a CREATE followed by a MODIFY.
                     Set<Store> toNotify = new HashSet<Store>();
                     if (pathRegistration != null) {
                         for (WatchEvent<?> event : key.pollEvents()) {
@@ -177,7 +219,6 @@ class KeyStoreWatcher {
                                     || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
                                 Path context = (Path) event.context();
                                 String name = context.getFileName().toString();
-                                System.out.println("File Name " + name);
                                 List<Store> stores = pathRegistration.get(name);
                                 if (stores != null) {
                                     for (Store current : stores) {
@@ -195,13 +236,12 @@ class KeyStoreWatcher {
                             }
                         }
                     }
-                    key.reset();
+                    key.reset(); // Reset the Key so subsequent modifications can be picked up.
                     for (Store current : toNotify) {
                         current.modified();
                     }
                 }
             } catch (ClosedWatchServiceException | InterruptedException e) {
-                //e.printStackTrace();
             }
         }
     }

--- a/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
+++ b/src/main/java/org/wildfly/security/keystore/KeyStoreWatcher.java
@@ -29,7 +29,6 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -59,10 +58,8 @@ class KeyStoreWatcher {
      *  So we have a {@link Map} where the key is a {@link Path} to the directory being monitored, the value is a further {@link Map}.
      *  On the second {@link Map} the key is the name of the keystore file within the the directory being monitored and the value is a {@link List}
      *  The {@link List} referenced by the {@link Map} is a list of all keystores that should be reloaded if a modification to the file is detected.
-     *
-     *  Note: This is defined as 'volatile' as on writes the whole {@link Map} will be replaced.
      */
-    private volatile Map<Path, Map<String, List<Store>>> watchedPaths = Collections.emptyMap();
+    private final Map<Path, Map<String, List<Store>>> watchedPaths = new HashMap<Path, Map<String,List<Store>>>();
     private final Map<Path, WatchKey> registrations = new HashMap<Path, WatchKey>();
 
     private volatile WatchService watchService;
@@ -77,7 +74,7 @@ class KeyStoreWatcher {
         return theWatcher;
     }
 
-    synchronized void register(File watchFile, Store keyStore) throws IOException {
+    void register(File watchFile, Store keyStore) throws IOException {
         File canonical = watchFile.getCanonicalFile();
 
         File parentDir = canonical.getParentFile();
@@ -85,55 +82,40 @@ class KeyStoreWatcher {
 
         Path dirPath = parentDir.toPath();
 
-        boolean watchRequired = false;
-        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
-        List<Store> pathStores = null;
-        if (pathRegistration == null) {
-            // There is no existing watch of this directory so we will need to start it but only do that after the Map has been updated.
-            watchRequired = true;
-            pathRegistration = new HashMap<String, List<Store>>();
-            pathStores = new ArrayList<Store>();
-        } else {
-            // We are adding to an existing Map so create a copy.
-            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
-            List<Store> tmpStore = pathRegistration.get(fileName);
-            if (tmpStore != null) {
-                // Copy the store so we can add to it without affecting any iterator.
-                pathStores = new ArrayList<Store>(tmpStore);
-            } else {
+        synchronized (watchedPaths) {
+            Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+            List<Store> pathStores = null;
+            if (pathRegistration == null) {
+                if (watchService == null) {
+                    // Is this the very first Path to be watched, if so we are going to need a WatchService.
+                    watchService = fileSystem.newWatchService();
+                    Thread pollThread = new Thread(new EventTaker(), "KeyStoreWatcher Daemon");
+                    pollThread.setDaemon(true);
+                    pollThread.start();
+                }
+                // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
+                WatchKey key = dirPath.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+                // We also need to maintain a mapping with the WatchKey so we have something we can use to Cancel the
+                // registration latser.
+                registrations.put(dirPath, key);
+
+                pathRegistration = new HashMap<String, List<Store>>();
+                watchedPaths.put(dirPath, pathRegistration);
                 pathStores = new ArrayList<Store>();
+                pathRegistration.put(fileName, pathStores);
+            } else {
+                pathStores = pathRegistration.get(fileName);
+                if (pathStores == null) {
+                    pathStores = new ArrayList<Store>();
+                    pathRegistration.put(fileName, pathStores);
+                }
             }
-        }
 
-        /*
-         * Modifications should not happen to any of these collections but to detect errors
-         * in the future make all unmodifiable.
-         */
-        pathStores.add(keyStore);
-        // The pathStores is the one we created one way or another above.
-        pathRegistration.put(fileName, Collections.unmodifiableList(pathStores));
-        // We are making modifications so copy watchedPaths
-        Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
-        // pathRegistration was also created one way or another above.
-        newWatchedPaths.put(dirPath, Collections.unmodifiableMap(pathRegistration));
-        watchedPaths = Collections.unmodifiableMap(newWatchedPaths);
-
-        if (watchRequired) {
-            if (watchService == null) {
-                // Is this the very first Path to be watched, if so we are going to need a WatchService.
-                watchService = fileSystem.newWatchService();
-                Thread pollThread = new Thread(new EventTaker(), "KeyStoreWatcher Daemon");
-                pollThread.setDaemon(true);
-                pollThread.start();
-            }
-            // We use 'create' in addition to 'modify' as updates could be in the form of replacing a file.
-            WatchKey key = dirPath.register(watchService,  StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
-            // We also need to maintain a mapping with the WatchKey so we have something we can use to Cancel the registration latser.
-            registrations.put(dirPath, key);
+            pathStores.add(keyStore);
         }
     }
 
-    synchronized void deRegister(File watchFile, Store keyStore) throws IOException {
+    void deRegister(File watchFile, Store keyStore) throws IOException {
         File canonical = watchFile.getCanonicalFile();
 
         File parentDir = canonical.getParentFile();
@@ -141,54 +123,41 @@ class KeyStoreWatcher {
 
         Path dirPath = parentDir.toPath();
 
-        Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
-        List<Store> pathStores = null;
-        if (pathRegistration != null) {
-            // The act of removal means we know we will be replacing the list of keystores requiring notification, it
-            // may also result in this file being no-longer monitored - either way we need a copy to work on.
-            pathRegistration = new HashMap<String, List<Store>>(pathRegistration);
-            List<Store> tmpStores = pathRegistration.get(fileName);
-            if (tmpStores != null) {
-                // Remove all references to this store from a copy of the list of stores to be notified about this file.
-                pathStores = new ArrayList<Store>(tmpStores);
-                Iterator<Store> storeIterator = pathStores.iterator();
-                while (storeIterator.hasNext()) {
-                    Store current = storeIterator.next();
-                    if (keyStore == current) {
-                        storeIterator.remove();
+        synchronized (watchedPaths) {
+            final Map<String, List<Store>> pathRegistration = watchedPaths.get(dirPath);
+            if (pathRegistration != null) {
+                final List<Store> pathStores = pathRegistration.get(fileName);
+                if (pathStores != null) {
+                    // Remove all references to this store.
+                    Iterator<Store> storeIterator = pathStores.iterator();
+                    while (storeIterator.hasNext()) {
+                        Store current = storeIterator.next();
+                        if (keyStore == current) {
+                            storeIterator.remove();
+                        }
+                    }
+                    if (pathStores.isEmpty()) {
+                        pathRegistration.remove(fileName);
                     }
                 }
-                if (pathStores.isEmpty()) {
-                    pathRegistration.remove(fileName);
-                } else {
-                    // Other stores are still expecting notifications.
-                    pathRegistration.put(fileName, Collections.unmodifiableList(pathStores));
-                }
-            }
 
-            // Copy of the watched paths so the updated collections can be added / entries removed as needed.
-            Map<Path, Map<String, List<Store>>> newWatchedPaths = new HashMap<Path, Map<String, List<Store>>>(watchedPaths);
-            if (pathRegistration.isEmpty()) {
-                // This was the last registration watching anything in the directory specified.
-                newWatchedPaths.remove(dirPath);
-                // Remove and cancel the WatchKey registration.
-                WatchKey key = registrations.remove(dirPath);
-                if (key != null) {
-                    key.cancel();
+                if (pathRegistration.isEmpty()) {
+                    // This was the last registration watching anything in the directory specified.
+                    watchedPaths.remove(dirPath);
+                    // Remove and cancel the WatchKey registration.
+                    WatchKey key = registrations.remove(dirPath);
+                    if (key != null) {
+                        key.cancel();
+                    }
+                    // This could also have been the last directory overall being monitored, if so the WatchService can be
+                    // closed and discarded.
+                    if (watchedPaths.isEmpty()) {
+                        watchService.close();
+                        watchService = null;
+                    }
                 }
-                // This could also have been the last directory overall being monitored, if so the WatchService can be closed and discarded.
-                if (newWatchedPaths.isEmpty()) {
-                    watchService.close();
-                    watchService = null;
-                }
-            } else {
-                // Still some files to monitor so just set the updated Map for the current path.
-                newWatchedPaths.put(dirPath, Collections.unmodifiableMap(pathRegistration));
             }
-            // Finally set back the replacement Map.
-            watchedPaths = Collections.unmodifiableMap(newWatchedPaths);
         }
-
     }
 
     interface Store {
@@ -207,36 +176,43 @@ class KeyStoreWatcher {
                 while ((watchService = KeyStoreWatcher.this.watchService) != null) {
                     WatchKey key = watchService.take();
                     Path watchedPath = (Path) key.watchable();
-                    Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
-                    // watchedPaths is volatile, any further writes above will not affect the pathRegistration reference we just obtained.
 
-                    // We create a list of Store implementations to notify as a single file could trigger multiple events, e.g. on Windows
+                    // We create a list of Store implementations to notify as a single file could trigger multiple events, e.g.
+                    // on Windows
                     // a rename can be seen as a CREATE followed by a MODIFY.
                     Set<Store> toNotify = new HashSet<Store>();
-                    if (pathRegistration != null) {
-                        for (WatchEvent<?> event : key.pollEvents()) {
-                            if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())
-                                    || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
-                                Path context = (Path) event.context();
-                                String name = context.getFileName().toString();
-                                List<Store> stores = pathRegistration.get(name);
-                                if (stores != null) {
-                                    for (Store current : stores) {
-                                        toNotify.add(current);
-                                    }
-                                }
 
-                            } else if (StandardWatchEventKinds.OVERFLOW.equals(event.kind())) {
-                                // No idea what happened so reload them all.
-                                for (List<Store> stores : pathRegistration.values()) {
-                                    for (Store current : stores) {
-                                        toNotify.add(current);
+                    synchronized (watchedPaths) {
+                        Map<String, List<Store>> pathRegistration = watchedPaths.get(watchedPath);
+                        // watchedPaths is volatile, any further writes above will not affect the pathRegistration reference we
+                        // just obtained.
+
+                        if (pathRegistration != null) {
+                            for (WatchEvent<?> event : key.pollEvents()) {
+                                if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())
+                                        || StandardWatchEventKinds.ENTRY_MODIFY.equals(event.kind())) {
+                                    Path context = (Path) event.context();
+                                    String name = context.getFileName().toString();
+                                    List<Store> stores = pathRegistration.get(name);
+                                    if (stores != null) {
+                                        for (Store current : stores) {
+                                            toNotify.add(current);
+                                        }
+                                    }
+
+                                } else if (StandardWatchEventKinds.OVERFLOW.equals(event.kind())) {
+                                    // No idea what happened so reload them all.
+                                    for (List<Store> stores : pathRegistration.values()) {
+                                        for (Store current : stores) {
+                                            toNotify.add(current);
+                                        }
                                     }
                                 }
                             }
                         }
+                        key.reset(); // Reset the Key so subsequent modifications can be picked up.
                     }
-                    key.reset(); // Reset the Key so subsequent modifications can be picked up.
+
                     for (Store current : toNotify) {
                         current.modified();
                     }

--- a/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.Provider;
+
+/**
+ * A file base {@link KeyStore} that supports dynamic reloading when changes to the underlying store are detected.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ReloadableFileKeyStore extends KeyStore implements Closeable {
+
+    private final ReloadableKeyStoreSpiImpl keyStoreSpi;
+
+    private ReloadableFileKeyStore(ReloadableKeyStoreSpiImpl keyStoreSpi, Provider provider, String type) {
+        super(keyStoreSpi, provider, type);
+        this.keyStoreSpi = keyStoreSpi;
+    }
+
+    public static ReloadableFileKeyStore getInstance(String type, Provider provider, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        ReloadableKeyStoreSpiImpl spi = new ReloadableKeyStoreSpiImpl(type, provider, storeLocation, storePassword);
+
+        return new ReloadableFileKeyStore(spi, provider, type);
+    }
+
+    public static ReloadableFileKeyStore getInstance(String type, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        return getInstance(type, null, storeLocation, storePassword);
+    }
+
+    public void close() throws IOException {
+        keyStoreSpi.close();
+    }
+
+}

--- a/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableFileKeyStore.java
@@ -55,4 +55,17 @@ public class ReloadableFileKeyStore extends KeyStore implements Closeable {
         keyStoreSpi.close();
     }
 
+    public void addObserver(final KeyStoreObserver oberserver) {
+        keyStoreSpi.addObserver(oberserver);
+    }
+
+    public void removeObserver(final KeyStoreObserver oberserver) {
+        keyStoreSpi.removeObserver(oberserver);
+    }
+
+    interface KeyStoreObserver {
+
+        void updated();
+
+    }
 }

--- a/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
+++ b/src/main/java/org/wildfly/security/keystore/ReloadableKeyStoreSpiImpl.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.wildfly.security.keystore.KeyStoreWatcher.Store;
+
+/**
+ * The {@link KeyStoreSpi} to add support for reloading based on modifications.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class ReloadableKeyStoreSpiImpl extends KeyStoreSpi implements Store {
+
+    private final String type;
+    private final Provider provider;
+    private final File storeLocation;
+    private final char[] storePassword;
+
+    private final AtomicReference<KeyStore> currentStore = new AtomicReference<KeyStore>();
+
+    ReloadableKeyStoreSpiImpl(String type, Provider provider, File storeLocation, char[] storePassword)
+            throws KeyStoreException {
+        this.type = type;
+        this.provider = provider;
+        this.storeLocation = storeLocation;
+        this.storePassword = storePassword.clone();
+    }
+
+
+    Provider getProvider() {
+        return currentStore.get().getProvider();
+    }
+
+    @Override
+    public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        try {
+            return currentStore.get().getKey(alias, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String alias) {
+        try {
+            return currentStore.get().getCertificateChain(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String alias) {
+        try {
+            return currentStore.get().getCertificate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Date engineGetCreationDate(String alias) {
+        try {
+            return currentStore.get().getCreationDate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+        currentStore.get().setKeyEntry(alias, key, password, chain);
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        currentStore.get().setKeyEntry(alias, key, chain);
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+        currentStore.get().setCertificateEntry(alias, cert);
+    }
+
+    @Override
+    public void engineDeleteEntry(String alias) throws KeyStoreException {
+        currentStore.get().deleteEntry(alias);
+    }
+
+    @Override
+    public Enumeration<String> engineAliases() {
+        try {
+            return currentStore.get().aliases();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        try {
+            return currentStore.get().containsAlias(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public int engineSize() {
+        try {
+            return currentStore.get().size();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String alias) {
+        try {
+            return currentStore.get().isKeyEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String alias) {
+        try {
+            return currentStore.get().isCertificateEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate cert) {
+        try {
+            return currentStore.get().getCertificateAlias(cert);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineStore(OutputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        try {
+            currentStore.get().store(stream, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        if (stream != null || password != null) {
+            throw new IllegalStateException("Custom load not supported.");
+        }
+
+        boolean registrationRequired = currentStore.get() == null;
+        doLoad(false);
+        if (registrationRequired) {
+            KeyStoreWatcher.getDefault().register(storeLocation, this);
+        }
+    }
+
+
+    private void doLoad(boolean dontFail) {
+        KeyStore theStore;
+        try {
+            theStore = provider == null ? KeyStore.getInstance(type) : KeyStore.getInstance(type, provider);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+
+        try (FileInputStream fis = new FileInputStream(storeLocation)) {
+            theStore.load(fis, storePassword);
+
+            currentStore.set(theStore);
+        } catch (IOException | NoSuchAlgorithmException | CertificateException e) {
+            if (dontFail == false) {
+                throw new IllegalStateException("Unable to load KeyStore", e);
+            }
+        }
+    }
+
+    @Override
+    public void modified() {
+        doLoad(true);
+    }
+
+    void close() throws IOException {
+        KeyStoreWatcher.getDefault().deRegister(storeLocation, this);
+    }
+
+}

--- a/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/ReloadableKeyStoreTest.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.KeyStore.ProtectionParameter;
+import java.security.cert.X509Certificate;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import sun.security.x509.CertAndKeyGen;
+import sun.security.x509.X500Name;
+
+/**
+ * Test case to test support for reloadable key stores.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ReloadableKeyStoreTest {
+
+    private static final String KEY_STORE_TYPE = "jks";
+    private static final char[] STORE_PASSWORD = "password".toCharArray();
+    private static final String DEFAULT_ALIAS = "default";
+    private static final String TEST_ALAIS = "test";
+
+    private File workingDir = null;
+    private File keystoreFile = null;
+
+    /**
+     * This is the working key store being used to modify the contents of the store, the store being tested is created in the
+     * individual tests.
+     */
+    private KeyStore workingKeyStore = null;
+
+    @Before
+    public void beforeTest() throws GeneralSecurityException, IOException {
+        workingDir = getWorkingDir();
+        keystoreFile = new File(workingDir, "keystore.jks");
+
+        workingKeyStore = emptyKeyStore();
+        addKeyPairAndCert(DEFAULT_ALIAS);
+        save();
+    }
+
+    @After
+    public void afterTest() {
+        keystoreFile.delete();
+        keystoreFile = null;
+        workingDir.delete();
+        workingDir = null;
+    }
+
+    @Test
+    public void verifyStoreUpdates() throws Exception {
+        try (ReloadableFileKeyStore testedStore = reloadableKeyStore()) {
+            assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertFalse(testedStore.containsAlias(TEST_ALAIS));
+
+            addKeyPairAndCert(TEST_ALAIS);
+            save();
+            Thread.sleep(1000);
+
+            assertTrue(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertTrue(testedStore.containsAlias(TEST_ALAIS));
+
+            remove(DEFAULT_ALIAS);
+            save();
+            Thread.sleep(1000);
+
+            assertFalse(testedStore.containsAlias(DEFAULT_ALIAS));
+            assertTrue(testedStore.containsAlias(TEST_ALAIS));
+        }
+    }
+
+    private ReloadableFileKeyStore reloadableKeyStore() throws GeneralSecurityException, IOException {
+        ReloadableFileKeyStore theStore  = ReloadableFileKeyStore.getInstance(KEY_STORE_TYPE, keystoreFile, STORE_PASSWORD);
+        theStore.load(null, null);
+
+        return theStore;
+    }
+
+    private KeyStore emptyKeyStore() throws GeneralSecurityException, IOException {
+        KeyStore theStore = KeyStore.getInstance(KEY_STORE_TYPE);
+        theStore.load(null, null);
+
+        return theStore;
+    }
+
+    @SuppressWarnings("restriction")
+    private void addKeyPairAndCert(final String alias) throws GeneralSecurityException, IOException {
+        CertAndKeyGen keyGen = new CertAndKeyGen("RSA", "SHA1WithRSA");
+        keyGen.generate(512); // For the purpose of this test, as small as we can go.
+        X509Certificate cert = keyGen.getSelfCertificate(new X500Name(String.format("cn=%s", alias)), 31536000); // Validity one
+                                                                                                                 // year.
+
+        ProtectionParameter pp = new KeyStore.PasswordProtection(STORE_PASSWORD);
+        PrivateKeyEntry pke = new PrivateKeyEntry(keyGen.getPrivateKey(), new X509Certificate[] { cert });
+
+        workingKeyStore.setEntry(alias, pke, pp);
+    }
+
+    private void remove(final String alias) throws GeneralSecurityException{
+        workingKeyStore.deleteEntry(alias);
+    }
+
+    private void save() throws IOException, GeneralSecurityException {
+        try (FileOutputStream fos = new FileOutputStream(keystoreFile)) {
+            workingKeyStore.store(fos, STORE_PASSWORD);
+        }
+    }
+
+    private static File getWorkingDir() {
+        File workingDir = new File("./target/keystore");
+        if (workingDir.exists() == false) {
+            workingDir.mkdirs();
+        }
+
+        return workingDir;
+    }
+
+}


### PR DESCRIPTION
This is a continuation of https://github.com/wildfly-security/wildfly-elytron/pull/98 I have closed the original PR as with all the build attempts the comments list had grown considerably.

This PR has taken onboard comments from the original PR, the KeyStore now has an option to register an observer to be notified when it reloads and the testsuite has been updated to use this without any need for a sleep.

The testsuite is still using an internal API, we do want to replace that with our own implementation but I would suggest allowing that in for the moment whilst we are in the Alpha/Beta stage of releases and raise a blocker Jira to update this test to our own impl or remove the test if for some reason we do not provide that.