### PR TITLE
Fixes of tests for Java 8

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/util/ByteStringBuilder.java
+++ b/src/main/java/org/wildfly/security/sasl/util/ByteStringBuilder.java
@@ -40,8 +40,12 @@ public final class ByteStringBuilder {
     }
 
     public ByteStringBuilder(final byte[] content) {
-        this.content = content.clone();
-        this.length = this.content.length;
+        if (content != null && content.length != 0) {
+            this.content = content.clone();
+            this.length = this.content.length;
+        } else {
+            this.content = new byte[16];
+        }
     }
 
     public ByteStringBuilder append(boolean b) {
@@ -351,7 +355,7 @@ public final class ByteStringBuilder {
         final int cl = content.length;
         final int length = this.length;
         if (length == cl) {
-            content = this.content = Arrays.copyOf(content, cl + (cl + 1 >> 1));
+            content = this.content = Arrays.copyOf(content, cl + (cl + 1 >> 1)); // content must not be blank
         }
         content[length] = b;
         this.length = length + 1;

--- a/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
+++ b/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
@@ -21,11 +21,13 @@ package org.wildfly.security.sasl.util;
 import java.text.Normalizer;
 
 /**
+ * Preparation of Internationalized Strings ("stringprep") by RFC 3454
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 public final class StringPrep {
-    // these flags must keep their numeric values permanently,, and must not conflict
+    // these flags must keep their numeric values permanently, and must not conflict
 
     // mappings
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
@@ -249,7 +249,7 @@ public abstract class BaseGssapiTests extends BaseTestCase {
         Map<String, String> props = new HashMap<String, String>(baseProps);
         props.put(Sasl.QOP, mode.getQop());
 
-        return factory.createSaslServer(GSSAPI, "sasl", "test_server", props, new AuthorizeOnlyCallbackHandler());
+        return factory.createSaslServer(GSSAPI, "sasl", TEST_SERVER_1, props, new AuthorizeOnlyCallbackHandler());
     }
 
     /*

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilsUnitTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilsUnitTest.java
@@ -33,7 +33,7 @@ import org.jboss.logging.Logger;
 import org.junit.Test;
 
 /**
- *
+ * Tests of Gssapi helpers (don't require started kerberos server)
  */
 public class GssapiUtilsUnitTest extends AbstractGssapiMechanism {
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
@@ -63,7 +63,9 @@ import org.wildfly.security.sasl.gssapi.TestKDC;
 @RunWith(JMockit.class)
 public abstract class AbstractTest {
 
-    protected boolean wildfly = true; // if test should be applied to WildFly or JDK SASL implementation
+    protected boolean wildfly = true; // whether use WildFly or JDK SASL provider
+
+    protected static final String TEST_SERVER_1 = "test_server_1";
 
     protected static TestKDC testKdc;
     protected SaslServer server;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicAuthTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicAuthTest.java
@@ -51,7 +51,7 @@ public class BasicAuthTest extends AbstractTest {
                 props.put(Sasl.QOP, "auth");
                 props.put(Sasl.SERVER_AUTH, Boolean.toString(true));
                 //props.put(Sasl.MAX_BUFFER, Integer.toString(0)); // required for JDK implementation
-                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", TEST_SERVER_1, props, new NoCallbackHandler());
             }
         });
 
@@ -61,7 +61,7 @@ public class BasicAuthTest extends AbstractTest {
                 Map<String, String> props = new HashMap<String, String>();
                 props.put(Sasl.QOP, "auth");
                 //props.put(Sasl.MAX_BUFFER, Integer.toString(0)); // required for JDK implementation
-                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+                return factory.createSaslServer("GSSAPI", "sasl", TEST_SERVER_1, props, new AuthorizeOnlyCallbackHandler());
             }
         });
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicConfidenceTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicConfidenceTest.java
@@ -54,7 +54,7 @@ public class BasicConfidenceTest extends AbstractTest {
                 props.put(Sasl.QOP, "auth-conf");
                 props.put(Sasl.SERVER_AUTH, Boolean.toString(true));
                 props.put(Sasl.MAX_BUFFER, Integer.toString(61234));
-                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", TEST_SERVER_1, props, new NoCallbackHandler());
             }
         });
 
@@ -64,7 +64,7 @@ public class BasicConfidenceTest extends AbstractTest {
                 Map<String, String> props = new HashMap<String, String>();
                 props.put(Sasl.QOP, "auth-conf");
                 props.put(Sasl.MAX_BUFFER, Integer.toString(64321));
-                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+                return factory.createSaslServer("GSSAPI", "sasl", TEST_SERVER_1, props, new AuthorizeOnlyCallbackHandler());
             }
         });
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicIntegrityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/BasicIntegrityTest.java
@@ -54,7 +54,7 @@ public class BasicIntegrityTest extends AbstractTest {
                 props.put(Sasl.QOP, "auth-int");
                 props.put(Sasl.SERVER_AUTH, Boolean.toString(true));
                 props.put(Sasl.MAX_BUFFER, Integer.toString(61234));
-                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", TEST_SERVER_1, props, new NoCallbackHandler());
             }
         });
 
@@ -64,7 +64,7 @@ public class BasicIntegrityTest extends AbstractTest {
                 Map<String, String> props = new HashMap<String, String>();
                 props.put(Sasl.QOP, "auth-int");
                 props.put(Sasl.MAX_BUFFER, Integer.toString(64321));
-                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+                return factory.createSaslServer("GSSAPI", "sasl", TEST_SERVER_1, props, new AuthorizeOnlyCallbackHandler());
             }
         });
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/NoServerAuthTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/NoServerAuthTest.java
@@ -53,7 +53,7 @@ public class NoServerAuthTest extends AbstractTest {
                 props.put(Sasl.QOP, "auth");
                 props.put(Sasl.SERVER_AUTH, Boolean.toString(false));
                 props.put(Sasl.MAX_BUFFER, Integer.toString(0)); // required for JDK implementation
-                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", "test_server_1", props, new NoCallbackHandler());
+                return factory.createSaslClient(new String[]{"GSSAPI"}, null, "sasl", TEST_SERVER_1, props, new NoCallbackHandler());
             }
         });
 
@@ -63,7 +63,7 @@ public class NoServerAuthTest extends AbstractTest {
                 Map<String, String> props = new HashMap<String, String>();
                 props.put(Sasl.QOP, "auth");
                 props.put(Sasl.MAX_BUFFER, Integer.toString(0)); // required for JDK implementation
-                return factory.createSaslServer("GSSAPI", "sasl", "test_server_1", props, new AuthorizeOnlyCallbackHandler());
+                return factory.createSaslServer("GSSAPI", "sasl", TEST_SERVER_1, props, new AuthorizeOnlyCallbackHandler());
             }
         });
 

--- a/src/test/java/org/wildfly/security/sasl/test/ByteStringBuilderTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ByteStringBuilderTest.java
@@ -57,6 +57,13 @@ public class ByteStringBuilderTest {
     }
 
     @Test
+    public void testAppendIntoBlank() throws Exception {
+        ByteStringBuilder b = new ByteStringBuilder(new byte[]{});
+        b.append((byte)0x61);
+        Assert.assertArrayEquals(new byte[]{0x61}, b.toArray());
+    }
+
+    @Test
     public void testAppendBoolean() throws Exception {
         ByteStringBuilder b = new ByteStringBuilder(new byte[]{0x00});
         b.append(true);
@@ -79,7 +86,7 @@ public class ByteStringBuilderTest {
     }
 
     @Test
-    public void testAppendUtfRawChar() throws Exception {
+    public void testAppendUtf8Raw() throws Exception {
         ByteStringBuilder b = new ByteStringBuilder(new byte[]{0x00});
         b.appendUtf8Raw(0x61);
         assertEquals(2, b.length());
@@ -99,7 +106,16 @@ public class ByteStringBuilderTest {
     }
 
     @Test
-    public void testAppendUtfChar() throws Exception {
+    public void testAppendUtf8RawLonelySurrogate() throws Exception {
+        ByteStringBuilder b = new ByteStringBuilder(new byte[]{});
+        b.appendUtf8Raw(0xD800);
+        Assert.assertArrayEquals(new byte[]{(byte) 0xED, (byte)0xA0, (byte) 0x80}, b.toArray());
+        b.appendUtf8Raw(0xD8FF);
+        Assert.assertArrayEquals(new byte[]{(byte) 0xED, (byte)0xA0, (byte) 0x80, (byte) 0xED, (byte) 0xA3, (byte) 0xBF}, b.toArray());
+    }
+
+    @Test
+    public void testAppendUtf8Char() throws Exception {
         ByteStringBuilder b = new ByteStringBuilder(new byte[]{0x00});
         b.append('a');
         assertEquals(2, b.length());
@@ -110,6 +126,9 @@ public class ByteStringBuilderTest {
         b.append('你');
         assertEquals(7, b.length());
         Assert.assertArrayEquals(new byte[]{(byte) 0x00, (byte) 0x61, (byte) 0xD0, (byte) 0xB8, (byte) 0xE4, (byte) 0xBD, (byte) 0xA0}, b.toArray());
+        b.append('\uD800');
+        assertEquals(10, b.length());
+        Assert.assertArrayEquals(new byte[]{(byte) 0x00, (byte) 0x61, (byte) 0xD0, (byte) 0xB8, (byte) 0xE4, (byte) 0xBD, (byte) 0xA0, (byte) 0xED, (byte) 0xA0, (byte) 0x80}, b.toArray());
     }
 
     @Test

--- a/src/test/java/org/wildfly/security/sasl/test/ByteStringBuilderTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ByteStringBuilderTest.java
@@ -167,7 +167,7 @@ public class ByteStringBuilderTest {
         Assert.assertArrayEquals(new byte[]{(byte) 0x00, (byte) 0x61, (byte) 0x62, (byte) 0x63, (byte) 0xE4, (byte) 0xBD, (byte) 0xA0}, b.toArray());
     }
 
-    @Test // failing
+    @Test
     public void testAppendPartOfString() throws Exception {
         ByteStringBuilder b = new ByteStringBuilder(new byte[]{0x68}); // "h"
         b.append("abcd", 1, 2); // append "bc"

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -837,16 +837,16 @@ public class StringPrepTest {
     // ---------------------- helpers ----------------------
 
     private String codePointToString(int codePoint) {
-        ByteStringBuilder b = new ByteStringBuilder();
-        b.appendUtf8Raw(codePoint);
-        return new String(b.toArray(), StandardCharsets.UTF_8);
+        StringBuffer sb = new StringBuffer();
+        sb.appendCodePoint(codePoint);
+        return sb.toString();
     }
 
     private void testForbidChars(long profile, int codePoint) throws Exception {
         try {
             ByteStringBuilder b = new ByteStringBuilder();
             StringPrep.encode(codePointToString(codePoint), b, profile);
-            throw new Exception("Not throwed IllegalArgumentException for " + Integer.toHexString(codePoint) + "!");
+            Assert.fail("Not throwed IllegalArgumentException for " + Integer.toHexString(codePoint) + "!");
         } catch (IllegalArgumentException e) {}
     }
 

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -17,7 +17,7 @@
  */
 package org.wildfly.security.sasl.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
@@ -846,7 +846,7 @@ public class StringPrepTest {
         try {
             ByteStringBuilder b = new ByteStringBuilder();
             StringPrep.encode(codePointToString(codePoint), b, profile);
-            Assert.fail("Not throwed IllegalArgumentException for " + Integer.toHexString(codePoint) + "!");
+            fail("Not throwed IllegalArgumentException for " + Integer.toHexString(codePoint) + "!");
         } catch (IllegalArgumentException e) {}
     }
 
@@ -868,7 +868,7 @@ public class StringPrepTest {
     }
 
     @Test
-    public void testOwnCodePointToStringConversion() throws Exception {
+    public void testHelpersCodePointToStringConversion() throws Exception {
         assertEquals("\uD800", codePointToString(0xD800));
         assertEquals("\uDBB6\uDC00", codePointToString(0xFD800));
         assertEquals("\uDBFF\uDFFF", codePointToString(0x10FFFF));

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -837,9 +837,13 @@ public class StringPrepTest {
     // ---------------------- helpers ----------------------
 
     private String codePointToString(int codePoint) {
-        StringBuffer sb = new StringBuffer();
-        sb.appendCodePoint(codePoint);
-        return sb.toString();
+        if (codePoint <= 0xFFFF) {
+            return new String(new char[]{(char) codePoint}); // allow separated surrogates, but only 2-bytes codepoints
+        } else {
+            ByteStringBuilder b = new ByteStringBuilder();
+            b.appendUtf8Raw(codePoint);
+            return new String(b.toArray(), StandardCharsets.UTF_8); // String(byte[]) not permit separated surrogates
+        }
     }
 
     private void testForbidChars(long profile, int codePoint) throws Exception {
@@ -869,6 +873,7 @@ public class StringPrepTest {
 
     @Test
     public void testHelpersCodePointToStringConversion() throws Exception {
+        assertArrayEquals(new char[]{(char)0xD800}, codePointToString(0xD800).toCharArray());
         assertEquals("\uD800", codePointToString(0xD800));
         assertEquals("\uDBB6\uDC00", codePointToString(0xFD800));
         assertEquals("\uDBFF\uDFFF", codePointToString(0x10FFFF));


### PR DESCRIPTION
Trivial fixes of bugs in tests which was invisible in Java 7 and prevent compilation in Java 8.
* Bad name of SASL server caused usuccessful initialization (`GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos credentails)`) - was ignored by Java 7
* `ByteStringBuilder` cannot append codepoints 0xD8xx (lonely surrogates) - cannot be used to complete test of StringPrep validation - was replaced.