### PR TITLE
Credential decoders API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <build>

--- a/src/main/java/org/wildfly/security/auth/provider/CredentialDecoder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/CredentialDecoder.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.provider;
+
+/**
+ * A decoder which acquires an authentication name from a credential.  Implementations may indicate that the credential
+ * is not understood.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public interface CredentialDecoder {
+
+    /**
+     * Get the authentication name from an opaque credential.  If this decoder cannot understand the given credential
+     * type, {@code null} is returned.
+     *
+     * @param credential the credential to decode
+     * @return the authentication name, or {@code null} if this decoder does not understand the credential
+     */
+    String getNameFromCredential(Object credential);
+
+    static CredentialDecoder aggregate(final CredentialDecoder... decoders) {
+        if (decoders == null) {
+            throw new IllegalArgumentException("decoders is null");
+        }
+        return new CredentialDecoder() {
+            public String getNameFromCredential(final Object credential) {
+                String result;
+                for (CredentialDecoder decoder : decoders) {
+                    result = decoder.getNameFromCredential(credential);
+                    if (result != null) {
+                        return result;
+                    }
+                }
+                return null;
+            }
+        };
+    }
+}

--- a/src/main/java/org/wildfly/security/auth/provider/X509CertificateCredentialDecoder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/X509CertificateCredentialDecoder.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.provider;
+
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+/**
+ * A credential decoder which can decode an {@link X509Certificate}.  The decoded name is the subject DN as a
+ * string in {@link X500Principal#CANONICAL} format.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class X509CertificateCredentialDecoder implements CredentialDecoder {
+
+    public String getNameFromCredential(final Object credential) {
+        if (credential instanceof X509Certificate) {
+            return ((X509Certificate) credential).getSubjectX500Principal().getName(X500Principal.CANONICAL);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/wildfly/security/permission/PermissionActions.java
+++ b/src/main/java/org/wildfly/security/permission/PermissionActions.java
@@ -106,10 +106,10 @@ public final class PermissionActions {
 
     private static final ClassValue<Info<?>> storedInfo = new ClassValue<Info<?>>() {
         protected Info<?> computeValue(final Class<?> type) {
-            return computeReal(type.asSubclass(Enum.class));
+            return computeReal(type);
         }
 
-        private <E extends Enum<E>> Info<E> computeReal(final Class<E> type) {
+        private <E> Info<E> computeReal(final Class<E> type) {
             final TrieNode<E> root = new TrieNode<>();
             final E[] enumConstants = type.getEnumConstants();
             for (E e : enumConstants) {


### PR DESCRIPTION
Add a credential-decoding API.  Requires Java 8, includes build update to effect that change.