### PR TITLE
[ELY-145][ELY-90] Digest-MD5 - step three + integrity + encryption

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtils.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtils.java
@@ -52,7 +52,9 @@ class UserPasswordPasswordUtils {
         if (userPassword[0] != '{') {
             return createClearPasswordSpec(userPassword);
         } else {
-            if (userPassword[1] == 's' && userPassword[2] == 'h' && userPassword[3] == 'a') {
+            if (userPassword[1] == 'm' && userPassword[2] == 'd' && userPassword[3] == '5') {
+                return createSimpleDigestPasswordSpec(ALGORITHM_DIGEST_MD5, 5, userPassword);
+            } else if (userPassword[1] == 's' && userPassword[2] == 'h' && userPassword[3] == 'a') {
                 if (userPassword[4] == '}') {
                     // {sha}
                     return createSimpleDigestPasswordSpec(ALGORITHM_DIGEST_SHA_1, 5, userPassword);

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtils.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtils.java
@@ -52,7 +52,8 @@ class UserPasswordPasswordUtils {
         if (userPassword[0] != '{') {
             return createClearPasswordSpec(userPassword);
         } else {
-            if (userPassword[1] == 'm' && userPassword[2] == 'd' && userPassword[3] == '5') {
+            if (userPassword[1] == 'm' && userPassword[2] == 'd' && userPassword[3] == '5' && userPassword[4] == '}') {
+                // {md5}
                 return createSimpleDigestPasswordSpec(ALGORITHM_DIGEST_MD5, 5, userPassword);
             } else if (userPassword[1] == 's' && userPassword[2] == 'h' && userPassword[3] == 'a') {
                 if (userPassword[4] == '}') {
@@ -68,6 +69,9 @@ class UserPasswordPasswordUtils {
                     // {sha512}
                     return createSimpleDigestPasswordSpec(ALGORITHM_DIGEST_SHA_512, 8, userPassword);
                 }
+            } else if (userPassword[1] == 's' && userPassword[2] == 'm' && userPassword[3] == 'd' && userPassword[4] == '5' && userPassword[5] == '}') {
+                // {smd5}
+                return createSaltedSimpleDigestPasswordSpec(ALGORITHM_PASSWORD_SALT_DIGEST_MD5, 6, userPassword);
             } else if (userPassword[1] == 's' && userPassword[2] == 's' && userPassword[3] == 'h' && userPassword[4] == 'a') {
                 if (userPassword[5] == '}') {
                     // {ssha}
@@ -145,6 +149,8 @@ class UserPasswordPasswordUtils {
 
     private static int expectedDigestLengthBytes(final String algorithm) {
         switch (algorithm) {
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
+                return 16;
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
                 return 20;
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256:

--- a/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStore.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.cert.CertificateException;
+
+/**
+ * A wrapper around {@link KeyStore} to make it unmodifiable.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class UnmodifiableKeyStore extends KeyStore {
+
+    private UnmodifiableKeyStore(KeyStoreSpi keyStoreSpi, Provider provider, String type) {
+        super(keyStoreSpi, provider, type);
+    }
+
+    /**
+     * Wrap an existing initialised {@link KeyStore} with an unmodifiable wrapper.
+     *
+     * Note: References are held to the underlying {@link KeyStore} can still be modified and changes will still be visible in
+     * the representation returned here.
+     *
+     * @param toWrap the {@link KeyStore} to wrap.
+     * @return the unmodifiable wrapper around the {@link KeyStore}
+     * @throws NoSuchAlgorithmException
+     * @throws CertificateException
+     * @throws IOException
+     * @throws IllegalArgumentException if the {@link KeyStore} being wrapped is {@code null}
+     */
+    public static KeyStore unmodifiableKeyStore(final KeyStore toWrap) throws NoSuchAlgorithmException, CertificateException,
+            IOException {
+        if (toWrap == null) {
+            throw log.nullParameter("toWrap");
+        }
+
+        KeyStore keyStore = new UnmodifiableKeyStore(new UnmodifiableKeyStoreSpi(toWrap), toWrap.getProvider(),
+                toWrap.getType());
+        keyStore.load(null, null);
+
+        return keyStore;
+    }
+}

--- a/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStoreSpi.java
+++ b/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStoreSpi.java
@@ -37,7 +37,7 @@ import java.util.Enumeration;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class UnmodifiableKeyStoreSpi extends KeyStoreSpi {
+class UnmodifiableKeyStoreSpi extends KeyStoreSpi {
 
     private final KeyStore keyStore;
     private boolean loaded = false;

--- a/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStoreSpi.java
+++ b/src/main/java/org/wildfly/security/keystore/UnmodifiableKeyStoreSpi.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Date;
+import java.util.Enumeration;
+
+/**
+ * A wrapper {@link KeyStoreSpi} implementation around a {@link KeyStore} to make it unmodifiable.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class UnmodifiableKeyStoreSpi extends KeyStoreSpi {
+
+    private final KeyStore keyStore;
+    private boolean loaded = false;
+
+    UnmodifiableKeyStoreSpi(KeyStore keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    @Override
+    public Key engineGetKey(String alias, char[] password) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        try {
+            return keyStore.getKey(alias, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String alias) {
+        try {
+            return keyStore.getCertificateChain(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String alias) {
+        try {
+            return keyStore.getCertificate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public Date engineGetCreationDate(String alias) {
+        try {
+            return keyStore.getCreationDate(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineDeleteEntry(String alias) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Enumeration<String> engineAliases() {
+        try {
+            return keyStore.aliases();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        try {
+            return keyStore.containsAlias(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public int engineSize() {
+        try {
+            return keyStore.size();
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String alias) {
+        try {
+            return keyStore.isKeyEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String alias) {
+        try {
+            return keyStore.isCertificateEntry(alias);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate cert) {
+        try {
+            return keyStore.getCertificateAlias(cert);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineStore(OutputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        try {
+            keyStore.store(stream, password);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void engineLoad(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException,
+            CertificateException {
+        if (loaded) {
+            throw new UnsupportedOperationException();
+        }
+        loaded = true;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
@@ -59,7 +59,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         this.qop = qop;
         this.digestURI = digestURI;
         this.utf8Encoded = utf8Encoded;
-        this.digestResponse = DigestUtils.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        this.digestResponse = DigestUtils.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
     }
 
     DigestPasswordImpl(byte[] clonedHA1, byte[] clonedNonce, int nonceCount, byte[] clonedCnonce, String authzid, String qop, String digestURI, final String algorithm) throws NoSuchAlgorithmException {
@@ -91,7 +91,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         } catch (NoSuchAlgorithmException e) {
             throw new InvalidKeyException("No matching algorithm", e);
         }
-        byte[] guessBasedResponse = DigestUtils.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        byte[] guessBasedResponse = DigestUtils.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
         try {
             return Arrays.equals(digestResponse, guessBasedResponse);
         } catch (NullPointerException e) {

--- a/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
@@ -19,7 +19,7 @@ package org.wildfly.security.password.impl;
 
 import org.wildfly.security.password.interfaces.DigestPassword;
 import org.wildfly.security.password.spec.DigestPasswordSpec;
-import org.wildfly.security.sasl.digest._private.DigestUtils;
+import org.wildfly.security.sasl.digest._private.DigestUtil;
 
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -59,7 +59,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         this.qop = qop;
         this.digestURI = digestURI;
         this.utf8Encoded = utf8Encoded;
-        this.digestResponse = DigestUtils.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
+        this.digestResponse = DigestUtil.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
     }
 
     DigestPasswordImpl(byte[] clonedHA1, byte[] clonedNonce, int nonceCount, byte[] clonedCnonce, String authzid, String qop, String digestURI, final String algorithm) throws NoSuchAlgorithmException {
@@ -71,7 +71,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
     }
 
     private static MessageDigest getMessageDigest(String algorithm) throws NoSuchAlgorithmException {
-        return MessageDigest.getInstance(DigestUtils.passwordAlgorithm(algorithm));
+        return MessageDigest.getInstance(DigestUtil.passwordAlgorithm(algorithm));
     }
 
     @Override
@@ -91,7 +91,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         } catch (NoSuchAlgorithmException e) {
             throw new InvalidKeyException("No matching algorithm", e);
         }
-        byte[] guessBasedResponse = DigestUtils.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
+        byte[] guessBasedResponse = DigestUtil.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
         try {
             return Arrays.equals(digestResponse, guessBasedResponse);
         } catch (NullPointerException e) {

--- a/src/main/java/org/wildfly/security/password/impl/PasswordFactorySpiImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/PasswordFactorySpiImpl.java
@@ -204,10 +204,12 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     break;
                 }
             }
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512:
+            case ALGORITHM_SALT_PASSWORD_DIGEST_MD5:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384:
@@ -358,10 +360,12 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
             case ALGORITHM_DIGEST_SHA_512: {
                 return (password instanceof SimpleDigestPassword);
             }
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512:
+            case ALGORITHM_SALT_PASSWORD_DIGEST_MD5:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384:
@@ -460,10 +464,12 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     break;
                 }
             }
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512:
+            case ALGORITHM_SALT_PASSWORD_DIGEST_MD5:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384:

--- a/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
@@ -153,6 +153,9 @@ class SaltedSimpleDigestPasswordImpl extends AbstractPasswordImpl implements Sal
 
     private static MessageDigest getMessageDigest(final String algorithm) throws NoSuchAlgorithmException {
         switch (algorithm) {
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
+            case ALGORITHM_SALT_PASSWORD_DIGEST_MD5:
+                return MessageDigest.getInstance("MD5");
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1:
                 return MessageDigest.getInstance("SHA-1");
@@ -172,11 +175,13 @@ class SaltedSimpleDigestPasswordImpl extends AbstractPasswordImpl implements Sal
 
     private static boolean isSaltFirst(final String algorithm) throws NoSuchAlgorithmException {
         switch (algorithm) {
+            case ALGORITHM_PASSWORD_SALT_DIGEST_MD5:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384:
             case ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512:
                 return false;
+            case ALGORITHM_SALT_PASSWORD_DIGEST_MD5:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256:
             case ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384:

--- a/src/main/java/org/wildfly/security/password/impl/WildFlyElytronPasswordProvider.java
+++ b/src/main/java/org/wildfly/security/password/impl/WildFlyElytronPasswordProvider.java
@@ -63,10 +63,12 @@ public final class WildFlyElytronPasswordProvider extends Provider {
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
         putService(new Service(this, FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));

--- a/src/main/java/org/wildfly/security/password/interfaces/SaltedSimpleDigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/SaltedSimpleDigestPassword.java
@@ -28,6 +28,11 @@ import org.wildfly.security.password.OneWayPassword;
 public interface SaltedSimpleDigestPassword extends OneWayPassword {
 
     /**
+     * Algorithm name for digest created using MD5 with the password digested first followed by the salt.
+     */
+    String ALGORITHM_PASSWORD_SALT_DIGEST_MD5 = "password-salt-digest-md5";
+
+    /**
      * Algorithm name for digest created using SHA-1 with the password digested first followed by the salt.
      */
     String ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1 = "password-salt-digest-sha-1";
@@ -46,6 +51,11 @@ public interface SaltedSimpleDigestPassword extends OneWayPassword {
      * Algorithm name for digest created using SHA-512 with the password digested first followed by the salt.
      */
     String ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512 = "password-salt-digest-sha-512";
+
+    /**
+     * Algorithm name for digest created using MD5 with the salt digested first followed by the password.
+     */
+    String ALGORITHM_SALT_PASSWORD_DIGEST_MD5 = "salt-password-digest-md5";
 
     /**
      * Algorithm name for digest created using SHA-1 with the salt digested first followed by the password.

--- a/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
@@ -20,22 +20,15 @@ package org.wildfly.security.sasl.digest;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.InvalidParameterException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
 import java.util.Arrays;
 import java.util.HashMap;
 
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.DESKeySpec;
-import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.callback.CallbackHandler;
@@ -113,6 +106,7 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         super(mechanismName, protocol, serverName, callbackHandler);
 
         secureRandomGenerator = new SecureRandom();
+        hmacMD5 = getHmac();
 
         try {
             this.md5 = MessageDigest.getInstance(DigestUtils.HASH_algorithm);
@@ -373,21 +367,21 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         md5.reset();
         byte[] ki = md5.digest(key.toArray());
 
-        byte[] messageMac = computeHMAC(ki, wrapSeqNum, message, offset, len);
+        byte[] messageMac = DigestUtils.computeHMAC(ki, wrapSeqNum, hmacMD5, message, offset, len);
 
         byte[] result = new byte[len + 16];
         System.arraycopy(message, offset, result, 0, len);
         System.arraycopy(messageMac, 0, result, len, 10);
-        integerByteOrdered(1, result, len + 10, 2);  // 2-byte message type number in network byte order with value 1
-        integerByteOrdered(wrapSeqNum, result, len + 12, 4); // 4-byte sequence number in network byte order
+        DigestUtils.integerByteOrdered(1, result, len + 10, 2);  // 2-byte message type number in network byte order with value 1
+        DigestUtils.integerByteOrdered(wrapSeqNum, result, len + 12, 4); // 4-byte sequence number in network byte order
         wrapSeqNum++;
         return result;
     }
 
     private byte[] unwrapIntegrityProtectedMessage(byte[] message, int offset, int len) throws SaslException {
 
-        int messageType = decodeByteOrderedInteger(message, offset + len - 6, 2);
-        int extractedSeqNum = decodeByteOrderedInteger(message, offset + len - 4, 4);
+        int messageType = DigestUtils.decodeByteOrderedInteger(message, offset + len - 6, 2);
+        int extractedSeqNum = DigestUtils.decodeByteOrderedInteger(message, offset + len - 4, 4);
 
         if (messageType != 1) {
             throw new SaslException("MessageType must equal to 1, but is different");
@@ -411,7 +405,7 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         System.arraycopy(message, offset, extractedMessage, 0, len - 16);
         System.arraycopy(message, offset + len - 16, extractedMessageMac, 0, 10);
 
-        byte[] expectedHmac = computeHMAC(ki, extractedSeqNum, extractedMessage, 0, extractedMessage.length);
+        byte[] expectedHmac = DigestUtils.computeHMAC(ki, extractedSeqNum, hmacMD5, extractedMessage, 0, extractedMessage.length);
 
         // validate MAC block
         if (Arrays2.equals(expectedHmac, 0, extractedMessageMac, 0, 10) == false) {
@@ -427,7 +421,7 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
 
     private byte[] wrapConfidentialityProtectedMessage(byte[] message, int offset, int len) throws SaslException {
 
-        byte[] messageMac = computeHMAC(wrapHmacKeyConfidentiality, wrapSeqNum, message, offset, len);
+        byte[] messageMac = DigestUtils.computeHMAC(wrapHmacKeyConfidentiality, wrapSeqNum, hmacMD5, message, offset, len);
 
         int paddingLength = 0;
         byte[] pad = null;
@@ -454,31 +448,17 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
 
         byte[] result = new byte[cipheredPart.length + 6];
         System.arraycopy(cipheredPart, 0, result, 0, cipheredPart.length);
-        integerByteOrdered(1, result, cipheredPart.length, 2);  // 2-byte message type number in network byte order with value 1
-        integerByteOrdered(wrapSeqNum, result, cipheredPart.length + 2, 4); // 4-byte sequence number in network byte order
+        DigestUtils.integerByteOrdered(1, result, cipheredPart.length, 2);  // 2-byte message type number in network byte order with value 1
+        DigestUtils.integerByteOrdered(wrapSeqNum, result, cipheredPart.length + 2, 4); // 4-byte sequence number in network byte order
 
         wrapSeqNum++;
         return result;
     }
 
-    private byte[] computeHMAC(byte[] kc, int sequenceNumber, byte[] message, int offset, int len) throws SaslException {
-        Mac mac = getHmac();
-        SecretKeySpec ks = new SecretKeySpec(kc, HMAC_algorithm);
-        try {
-            mac.init(ks);
-        } catch (InvalidKeyException e) {
-            throw new SaslException("Invalid key provided", e);
-        }
-        byte[] buffer = new byte[len + 4];
-        integerByteOrdered(sequenceNumber, buffer, 0, 4);
-        System.arraycopy(message, offset, buffer, 4, len);
-        return mac.doFinal(buffer);
-    }
-
     private byte[] unwrapConfidentialityProtectedMessage(byte[] message, int offset, int len) throws SaslException {
 
-        int messageType = decodeByteOrderedInteger(message, offset + len - 6, 2);
-        int extractedSeqNum = decodeByteOrderedInteger(message, offset + len - 4, 4);
+        int messageType = DigestUtils.decodeByteOrderedInteger(message, offset + len - 6, 2);
+        int extractedSeqNum = DigestUtils.decodeByteOrderedInteger(message, offset + len - 4, 4);
 
         if (messageType != 1) {
             throw new SaslException("MessageType must equal to 1, but is different");
@@ -517,7 +497,7 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
             System.arraycopy(clearText, 0, decryptedMessage, 0, clearText.length - 10);
         }
 
-        byte[] expectedHmac = computeHMAC(unwrapHmacKeyConfidentiality, extractedSeqNum, decryptedMessage, 0, decryptedMessage.length);
+        byte[] expectedHmac = DigestUtils.computeHMAC(unwrapHmacKeyConfidentiality, extractedSeqNum, hmacMD5, decryptedMessage, 0, decryptedMessage.length);
 
         // check hmac-s
         if (Arrays2.equals(expectedHmac, 0, hmac, 0, 10) == false) {
@@ -596,10 +576,10 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
             if (cipher.startsWith("rc")) {
                 cipherKey = new SecretKeySpec(cipherKeyBytes, alg);
             } else if (cipher.equals("des")) {
-                cipherKey = createDesSecretKey(cipherKeyBytes, 0, cipherKeyBytes.length);
+                cipherKey = DigestUtils.createDesSecretKey(cipherKeyBytes, 0, cipherKeyBytes.length);
             } else if (cipher.equals("3des")) {
                 //cipherKey = makeDesKeys(cipherKeyBytes, alg);
-                cipherKey = create3desSecretKey(cipherKeyBytes, 0, cipherKeyBytes.length);
+                cipherKey = DigestUtils.create3desSecretKey(cipherKeyBytes, 0, cipherKeyBytes.length);
             } else {
                 throw new SaslException("Unsupported cipher (" + cipher + ")");
             }
@@ -637,109 +617,5 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         }
     }
 
-    protected static void integerByteOrdered(int num, byte[] buf, int offset, int len) {
-        if (len > 4 || len < 1) {
-            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
-        }
-        for (int i = len - 1; i >= 0; i--) {
-            buf[offset + i] = (byte) (num & 0xff);
-            num >>>= 8;
-        }
-    }
 
-    protected static int decodeByteOrderedInteger(byte[] buf, int offset, int len) {
-        if (len > 4 || len < 1) {
-            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
-        }
-        int result = buf[offset];
-        for (int i = 1; i < len; i++) {
-            result <<= 8;
-            result |= buf[offset + i];
-        }
-        return result;
-    }
-
-    private byte[] create3desSubKey(byte[] keyBits, int offset, int len) {
-        if (len != 7) {
-            throw new InvalidParameterException("Only 7 byte long keyBits are transformable to 3des subkey");
-        }
-        int hiMask = 0x00;
-        int loMask = 0xfe;
-        byte[] subkey = new byte[8];
-
-        subkey[0] = (byte)(keyBits[0] & loMask);
-        subkey[0] = fixParityBit(subkey[0]);   // fix for real parity bit
-        for (int i = offset + 1; i < len; i++) {
-            int bitNumber = i - offset;
-            hiMask |= 2 ^ (bitNumber - 1);
-            loMask &= 2 ^ bitNumber;
-            int hibits = keyBits[i - 1] & hiMask;
-            hibits <<= 8 - i - 1;
-            int lobits = keyBits[i] & loMask;
-            lobits >>= i;
-            subkey[i] = (byte) (hibits | lobits);
-            subkey[i] = fixParityBit(subkey[i]);  // fix real parity bits
-        }
-
-        return subkey;
-    }
-
-    /**
-     * Create DES secret key according to http://www.cryptosys.net/3des.html.
-     *
-     * @param keyBits
-     * @param offset
-     * @param len
-     * @return
-     * @throws NoSuchAlgorithmException
-     * @throws InvalidKeyException
-     * @throws InvalidKeySpecException
-     */
-    private SecretKey createDesSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
-        if (len != 7) {
-            throw new InvalidParameterException("Only 7 bytes long keyBits are transformable to des key");
-        }
-
-        KeySpec spec = new DESKeySpec(create3desSubKey(keyBits, 0, 7), 0);
-        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DES");
-
-        return desFact.generateSecret(spec);
-    }
-
-    /**
-     * Create 3des secret key according to http://www.cryptosys.net/3des.html.
-     *
-     * @param keyBits
-     * @param offset
-     * @param len
-     * @return
-     * @throws NoSuchAlgorithmException
-     * @throws InvalidKeyException
-     * @throws InvalidKeySpecException
-     */
-    private SecretKey create3desSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
-        if (len != 14) {
-            throw new InvalidParameterException("Only 14 bytes long keyBits are transformable to 3des key option2");
-        }
-
-        byte[] key = new byte[24];
-        System.arraycopy(create3desSubKey(keyBits, 0, 7), 0, key, 0, 8);   // subkey1
-        System.arraycopy(create3desSubKey(keyBits, 7, 7), 0, key, 8, 8);   // subkey2
-        System.arraycopy(key, 0, key, 16, 8);                              // subkey3 == subkey1 (in option2 of 3des key
-
-        KeySpec spec = new DESedeKeySpec(key, 0);
-        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DESede");
-
-        return desFact.generateSecret(spec);
-    }
-
-    /**
-     * Fix the rightmost bit to maintain odd parity for the whole byte.
-     *
-     * @param toFix - byte to fix
-     * @return fixed byte with odd parity
-     */
-    private byte fixParityBit(byte toFix) {
-        return (Integer.bitCount(toFix & 0xff) & 1) == 0 ? (byte) (toFix ^ 1) : toFix;
-    }
 }

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
@@ -38,6 +38,8 @@ import org.wildfly.security.sasl.WildFlySasl;
 @MetaInfServices(value = SaslClientFactory.class)
 public class DigestClientFactory extends AbstractDigestFactory implements SaslClientFactory {
 
+    public static final String[] DEFAULT_CIPHERS = new String[]{ "3des", "rc4", "des", "rc4-56", "rc4-40" };
+
     public DigestClientFactory() {
     }
 
@@ -59,7 +61,7 @@ public class DigestClientFactory extends AbstractDigestFactory implements SaslCl
         String[] qops = qopsString==null ? null : qopsString.split(",");
 
         String supportedCipherOpts = (String)props.get(WildFlySasl.SUPPORTED_CIPHER_NAMES);
-        String[] ciphers = supportedCipherOpts == null ? null : supportedCipherOpts.split(",");
+        String[] ciphers = supportedCipherOpts == null ? DEFAULT_CIPHERS : supportedCipherOpts.split(",");
 
         final DigestSaslClient client = new DigestSaslClient(selectedMech, protocol, serverName, cbh, authorizationId, false, charset, qops, ciphers);
         client.init();

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslException;
@@ -54,10 +55,13 @@ public class DigestClientFactory extends AbstractDigestFactory implements SaslCl
         Boolean utf8 = (Boolean)props.get(WildFlySasl.USE_UTF8);
         Charset charset = (utf8==null || utf8.booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
 
-        String supportedCipherOpts = (String)props.get(WildFlySasl.SUPPORTED_CIPHER_NAMES);
-        String[] ciphers = (supportedCipherOpts == null ? null : supportedCipherOpts.split(","));
+        String qopsString = (String)props.get(Sasl.QOP);
+        String[] qops = qopsString==null ? null : qopsString.split(",");
 
-        final DigestSaslClient client = new DigestSaslClient(selectedMech, protocol, serverName, cbh, authorizationId, false, charset, ciphers);
+        String supportedCipherOpts = (String)props.get(WildFlySasl.SUPPORTED_CIPHER_NAMES);
+        String[] ciphers = supportedCipherOpts == null ? null : supportedCipherOpts.split(",");
+
+        final DigestSaslClient client = new DigestSaslClient(selectedMech, protocol, serverName, cbh, authorizationId, false, charset, qops, ciphers);
         client.init();
         return client;
     }

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -52,12 +52,12 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         try {
             this.messageDigest = MessageDigest.getInstance(DigestUtils.messageDigestAlgorithm(mechanismName));
         } catch (NoSuchAlgorithmException e) {
-            throw new SaslException("Expected message digest algorithm is not available", e);
+            throw new SaslException(getMechanismName() + ": Expected message digest algorithm is not available", e);
         }
     }
 
-    private static final int STEP_ONE = 1;
-    private static final int STEP_THREE = 3;
+    private static final byte STEP_ONE = 1;
+    private static final byte STEP_THREE = 3;
 
     private String[] realms;
     private String supportedCiphers;

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
@@ -167,9 +168,6 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         } else {
             authzid = null;
         }
-
-
-
     }
 
     private byte[] validateDigestResponse(HashMap<String, byte[]> parsedDigestResponse) throws SaslException {
@@ -216,7 +214,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         if (parsedDigestResponse.get("cnonce") == null) {
             throw new SaslException(getMechanismName() + ": missing cnonce");
         }
-        byte[] cnonce = parsedDigestResponse.get("cnonce");
+        cnonce = parsedDigestResponse.get("cnonce");
 
         if (parsedDigestResponse.get("nc") == null) {
             throw new SaslException(getMechanismName() + ": missing nonce-count");
@@ -247,8 +245,9 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         final NameCallback nameCallback = new NameCallback("User name", userName);
         final PasswordCallback passwordCallback = new PasswordCallback("User password", false);
         final RealmCallback realmCallback = new RealmCallback("User realm");
+        final AuthorizeCallback authorizeCallback = new AuthorizeCallback(userName, authzid==null ? userName : authzid);
 
-        handleCallbacks(realmCallback, nameCallback, passwordCallback);
+        handleCallbacks(realmCallback, nameCallback, passwordCallback, authorizeCallback);
 
         char[] passwd = passwordCallback.getPassword();
         passwordCallback.clearPassword();
@@ -256,7 +255,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
 
         hA1 = DigestUtils.H_A1(messageDigest, userName, clientRealm, passwd, nonce, cnonce, authzid, clientCharset);
 
-        byte[] expectedResponse = DigestUtils.digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        byte[] expectedResponse = DigestUtils.digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
         // wipe out the password
         if (passwd != null) {
             Arrays.fill(passwd, (char)0);
@@ -266,8 +265,10 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
 
         if (parsedDigestResponse.get("response") != null) {
             if (Arrays.equals(expectedResponse, parsedDigestResponse.get("response"))) {
-                if (authzid == null) {
-                    authzid = userName; // TODO: Check permission use given authzid!
+                if (authorizeCallback.isAuthorized()) {
+                    authzid = authorizeCallback.getAuthorizedID();
+                } else {
+                    throw new SaslException(getMechanismName() + ": " + userName + " not authorized to act as " + authzid);
                 }
                 return createResponseAuth(parsedDigestResponse);
             } else {
@@ -277,15 +278,13 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         } else {
             throw new SaslException(getMechanismName() + ": missing response directive");
         }
-
     }
 
     private byte[] createResponseAuth(HashMap<String, byte[]> parsedDigestResponse) {
         ByteStringBuilder responseAuth = new ByteStringBuilder();
         responseAuth.append("rspauth=");
 
-        // TODO
-        byte[] response_value = new byte[0];
+        byte[] response_value = DigestUtils.digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, false);
 
         responseAuth.append(response_value);
         return responseAuth.toArray();

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
@@ -44,7 +44,7 @@ import javax.security.sasl.SaslException;
 /**
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
  */
-public final class DigestUtils {
+public final class DigestUtil {
 
     public static final String QOP_AUTH = "auth";
     public static final String QOP_AUTH_INT = "auth-int";

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
@@ -243,29 +243,15 @@ public final class DigestUtil {
         if (len != 7) {
             throw new InvalidParameterException("Only 7 byte long keyBits are transformable to 3des subkey");
         }
-        int bit = 0x01;
-        int hiMask = 0x00;
-        int loMask = 0xfe;
         byte[] subkey = new byte[8];
-
-        subkey[0] = (byte)(keyBits[offset] & loMask);
-        subkey[0] = fixParityBit(subkey[0]);   // fix for real parity bit
-        for (int i = 1; i < 7; i++) {
-            hiMask |= bit;
-            bit <<= 1;
-            loMask -= bit;
-            int hibits = keyBits[offset + i - 1] & hiMask;
-            hibits <<= 8 - i;
-            int lobits = keyBits[offset + i] & loMask;
-            lobits >>= i;
-            subkey[i] = (byte) (hibits | lobits);
-            subkey[i] = fixParityBit(subkey[i]);  // fix real parity bits
-        }
-        hiMask |= bit;
-        subkey[7] = (byte)(keyBits[offset + 6] & hiMask);
-        subkey[7] <<= 1;
-        subkey[7] = fixParityBit(subkey[7]);   // fix for real parity bit
-
+        subkey[0] = fixParityBit((byte)                          (keyBits[offset]   & 0xFF));
+        subkey[1] = fixParityBit((byte)(keyBits[offset]   << 7 | (keyBits[offset+1] & 0xFF) >> 1));
+        subkey[2] = fixParityBit((byte)(keyBits[offset+1] << 6 | (keyBits[offset+2] & 0xFF) >> 2));
+        subkey[3] = fixParityBit((byte)(keyBits[offset+2] << 5 | (keyBits[offset+3] & 0xFF) >> 3));
+        subkey[4] = fixParityBit((byte)(keyBits[offset+3] << 4 | (keyBits[offset+4] & 0xFF) >> 4));
+        subkey[5] = fixParityBit((byte)(keyBits[offset+4] << 3 | (keyBits[offset+5] & 0xFF) >> 5));
+        subkey[6] = fixParityBit((byte)(keyBits[offset+5] << 2 | (keyBits[offset+6] & 0xFF) >> 6));
+        subkey[7] = fixParityBit((byte)(keyBits[offset+6] << 1));
         return subkey;
     }
 

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtils.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtils.java
@@ -25,8 +25,21 @@ import org.wildfly.security.sasl.util.HexConverter;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.sasl.SaslException;
 
 /**
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
@@ -42,6 +55,7 @@ public final class DigestUtils {
     public static final String SECURITY_MARK = "00000000000000000000000000000000";   // 32 zeros
 
     public static final String HASH_algorithm = "MD5";
+    public static final String HMAC_algorithm = "HmacMD5";
 
     public static String passwordAlgorithm(String digestAlgorithm) {
         switch (digestAlgorithm) {
@@ -186,5 +200,124 @@ public final class DigestUtils {
             retValue[from + i] = hex[i];
         }
         return retValue;
+    }
+
+    public static byte[] computeHMAC(byte[] kc, int sequenceNumber, Mac mac, byte[] message, int offset, int len) throws SaslException {
+        SecretKeySpec ks = new SecretKeySpec(kc, HMAC_algorithm);
+        try {
+            mac.init(ks);
+        } catch (InvalidKeyException e) {
+            throw new SaslException("Invalid key provided", e);
+        }
+        byte[] buffer = new byte[len + 4];
+        integerByteOrdered(sequenceNumber, buffer, 0, 4);
+        System.arraycopy(message, offset, buffer, 4, len);
+        return mac.doFinal(buffer);
+    }
+
+    public static void integerByteOrdered(int num, byte[] buf, int offset, int len) {
+        if (len > 4 || len < 1) {
+            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
+        }
+        for (int i = len - 1; i >= 0; i--) {
+            buf[offset + i] = (byte) (num & 0xff);
+            num >>>= 8;
+        }
+    }
+
+    public static int decodeByteOrderedInteger(byte[] buf, int offset, int len) {
+        if (len > 4 || len < 1) {
+            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
+        }
+        int result = buf[offset];
+        for (int i = 1; i < len; i++) {
+            result <<= 8;
+            result |= buf[offset + i];
+        }
+        return result;
+    }
+
+    static byte[] create3desSubKey(byte[] keyBits, int offset, int len) {
+        if (len != 7) {
+            throw new InvalidParameterException("Only 7 byte long keyBits are transformable to 3des subkey");
+        }
+        int hiMask = 0x00;
+        int loMask = 0xfe;
+        byte[] subkey = new byte[8];
+
+        subkey[0] = (byte)(keyBits[0] & loMask);
+        subkey[0] = fixParityBit(subkey[0]);   // fix for real parity bit
+        for (int i = offset + 1; i < len; i++) {
+            int bitNumber = i - offset;
+            hiMask |= 2 ^ (bitNumber - 1);
+            loMask &= 2 ^ bitNumber;
+            int hibits = keyBits[i - 1] & hiMask;
+            hibits <<= 8 - i - 1;
+            int lobits = keyBits[i] & loMask;
+            lobits >>= i;
+            subkey[i] = (byte) (hibits | lobits);
+            subkey[i] = fixParityBit(subkey[i]);  // fix real parity bits
+        }
+
+        return subkey;
+    }
+
+    /**
+     * Create DES secret key according to http://www.cryptosys.net/3des.html.
+     *
+     * @param keyBits
+     * @param offset
+     * @param len
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws InvalidKeySpecException
+     */
+    public static SecretKey createDesSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        if (len != 7) {
+            throw new InvalidParameterException("Only 7 bytes long keyBits are transformable to des key");
+        }
+
+        KeySpec spec = new DESKeySpec(create3desSubKey(keyBits, 0, 7), 0);
+        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DES");
+
+        return desFact.generateSecret(spec);
+    }
+
+    /**
+     * Create 3des secret key according to http://www.cryptosys.net/3des.html.
+     *
+     * @param keyBits
+     * @param offset
+     * @param len
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws InvalidKeySpecException
+     */
+    public static SecretKey create3desSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        if (len != 14) {
+            throw new InvalidParameterException("Only 14 bytes long keyBits are transformable to 3des key option2");
+        }
+
+        byte[] key = new byte[24];
+        System.arraycopy(create3desSubKey(keyBits, 0, 7), 0, key, 0, 8);   // subkey1
+        System.arraycopy(create3desSubKey(keyBits, 7, 7), 0, key, 8, 8);   // subkey2
+        System.arraycopy(key, 0, key, 16, 8);                              // subkey3 == subkey1 (in option2 of 3des key
+
+        KeySpec spec = new DESedeKeySpec(key, 0);
+        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DESede");
+
+        return desFact.generateSecret(spec);
+    }
+
+    /**
+     * Fix the rightmost bit to maintain odd parity for the whole byte.
+     *
+     * @param toFix - byte to fix
+     * @return fixed byte with odd parity
+     */
+    private static byte fixParityBit(byte toFix) {
+        return (Integer.bitCount(toFix & 0xff) & 1) == 0 ? (byte) (toFix ^ 1) : toFix;
     }
 }

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtils.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtils.java
@@ -127,7 +127,7 @@ public final class DigestUtils {
      */
     public static byte[] digestResponse(MessageDigest messageDigest, byte[] H_A1,
                                  byte[] nonce, int nonce_count, byte[] cnonce,
-                                 String authzid, String qop, String digest_uri) {
+                                 String authzid, String qop, String digest_uri, boolean auth) {
 
         // QOP
         String qop_value;
@@ -139,7 +139,7 @@ public final class DigestUtils {
 
         // A2
         ByteStringBuilder A2 = new ByteStringBuilder();
-        A2.append(AUTH_METHOD);
+        if(auth) A2.append(AUTH_METHOD); // for "response", but not for "rspauth"
         A2.append(':');
         A2.append(digest_uri);
         if (QOP_AUTH_CONF.equals(qop_value) || QOP_AUTH_INT.equals(qop_value)) {

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
@@ -208,6 +208,9 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         if (wrapper == null) {
             throw new IllegalStateException("Wrapping is not configured");
         }
+        if(len == 0) {
+            return NO_BYTES;
+        }
         return wrapper.wrap(outgoing, offset, len);
     }
 
@@ -225,6 +228,9 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         SaslWrapper wrapper = this.wrapper;
         if (wrapper == null) {
             throw new IllegalStateException("Wrapping is not configured");
+        }
+        if(len == 0) {
+            return NO_BYTES;
         }
         return wrapper.unwrap(incoming, offset, len);
     }

--- a/src/test/java/org/wildfly/security/keystore/UnmodifiableKeyStoreTest.java
+++ b/src/test/java/org/wildfly/security/keystore/UnmodifiableKeyStoreTest.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStore.PasswordProtection;
+import java.security.KeyStore.ProtectionParameter;
+import java.security.KeyStore.SecretKeyEntry;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test case to test support for the {@link UnmodifiableKeyStore}
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class UnmodifiableKeyStoreTest {
+
+    private static final String KEY_STORE_TYPE = "jceks";
+    private static final char[] STORE_PASSWORD = "password".toCharArray();
+    private static final String ALIAS = "one";
+
+    private ProtectionParameter protectionParameter = new PasswordProtection(STORE_PASSWORD);
+    private File workingDir = null;
+    private File keyStore = null;
+
+    @Before
+    public void beforeTest() throws GeneralSecurityException, IOException {
+        workingDir = getWorkingDir();
+
+        keyStore = new File(workingDir, "store.jceks");
+
+        KeyStore keyStore = emptyKeyStore();
+        addSecretKey(ALIAS, keyStore);
+        save(keyStore, this.keyStore);
+    }
+
+    @After
+    public void afterTest() {
+        keyStore.delete();
+        keyStore = null;
+        workingDir.delete();
+        workingDir = null;
+    }
+
+    @Test
+    public void verifyStoreUpdates() throws Exception {
+        KeyStore keyStore = load();
+        KeyStore unmodifiable = UnmodifiableKeyStore.unmodifiableKeyStore(keyStore);
+
+        assertEquals(1, unmodifiable.size());
+        assertTrue(unmodifiable.containsAlias(ALIAS));
+
+        testExpectUnsupportedOperationException(unmodifiable, (KeyStore k) -> k.deleteEntry(ALIAS));
+        testExpectUnsupportedOperationException(unmodifiable, (KeyStore k) -> k.setEntry(ALIAS, new SecretKeyEntry(getSecretKey()), protectionParameter));
+        testExpectUnsupportedOperationException(unmodifiable, (KeyStore k) -> k.setCertificateEntry(ALIAS, null));
+        testExpectUnsupportedOperationException(unmodifiable, (KeyStore k) -> k.load(null, null));
+
+        assertEquals(1, unmodifiable.size());
+        assertTrue(unmodifiable.containsAlias(ALIAS));
+
+        keyStore.deleteEntry(ALIAS);
+
+        assertEquals(0, unmodifiable.size());
+        assertFalse(unmodifiable.containsAlias(ALIAS));
+    }
+
+    interface TestTask {
+        void test(KeyStore keyStore) throws Exception;
+    }
+
+    private void testExpectUnsupportedOperationException(final KeyStore keyStore, TestTask test) throws Exception {
+        try {
+            test.test(keyStore);
+            fail("Expected Exception Not Thrown");
+        } catch (UnsupportedOperationException e) {
+        }
+    }
+
+    private KeyStore load() throws GeneralSecurityException, IOException {
+        KeyStore keyStore = KeyStore.getInstance(KEY_STORE_TYPE);
+        try (FileInputStream fis = new FileInputStream(this.keyStore)) {
+            keyStore.load(fis, STORE_PASSWORD);
+        }
+        return keyStore;
+    }
+
+    private KeyStore emptyKeyStore() throws GeneralSecurityException, IOException {
+        KeyStore theStore = KeyStore.getInstance(KEY_STORE_TYPE);
+        theStore.load(null, null);
+
+        return theStore;
+    }
+
+    private SecretKey getSecretKey() throws GeneralSecurityException {
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(128);
+
+        return keyGen.generateKey();
+    }
+
+    private void addSecretKey(final String alias, final KeyStore keyStore) throws GeneralSecurityException {
+        SecretKey key = getSecretKey();
+
+        keyStore.setEntry(alias, new SecretKeyEntry(key), protectionParameter);
+    }
+
+    private void save(KeyStore keyStore, File target) throws IOException, GeneralSecurityException {
+        try (FileOutputStream fos = new FileOutputStream(target)) {
+            keyStore.store(fos, STORE_PASSWORD);
+        }
+    }
+
+    private static File getWorkingDir() {
+        File workingDir = new File("./target/keystore");
+        if (workingDir.exists() == false) {
+            workingDir.mkdirs();
+        }
+
+        return workingDir;
+    }
+
+}

--- a/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
@@ -92,7 +92,12 @@ public class UserPasswordSuiteChild {
 
     @Test
     public void testMd5User() throws Exception {
-        performSimpleNameTest("md5USer", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_DIGEST_MD5, "md5Password".toCharArray());
+        performSimpleNameTest("md5User", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_DIGEST_MD5, "md5Password".toCharArray());
+    }
+
+    @Test
+    public void testSmd5User() throws Exception {
+        performSimpleNameTest("smd5User", SaltedSimpleDigestPassword.class, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "smd5Password".toCharArray());
     }
 
     @Test

--- a/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
@@ -91,6 +91,11 @@ public class UserPasswordSuiteChild {
     }
 
     @Test
+    public void testMd5User() throws Exception {
+        performSimpleNameTest("md5USer", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_DIGEST_MD5, "md5Password".toCharArray());
+    }
+
+    @Test
     public void testSha512User() throws Exception {
         performSimpleNameTest("sha512User", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_DIGEST_SHA_512, "sha512Password".toCharArray());
     }

--- a/src/test/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordTest.java
+++ b/src/test/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordTest.java
@@ -20,10 +20,12 @@ package org.wildfly.security.password.impl;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_SALT_PASSWORD_DIGEST_MD5;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384;
@@ -73,6 +75,11 @@ public class SaltedSimpleDigestPasswordTest {
     }
 
     @Test
+    public void testPasswordSaltMd5() throws Exception {
+        performTest(ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "swXK27O85U86pZxk/sAN6g==".toCharArray());
+    }
+
+    @Test
     public void testPasswordSaltSha1() throws Exception {
         performTest(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, "yI6cZwQadOA1e+/f+T+H3eCQQhQ".toCharArray());
     }
@@ -92,6 +99,11 @@ public class SaltedSimpleDigestPasswordTest {
     public void testPasswordSaltSha512() throws Exception {
         performTest(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512,
                 "+mohhbPgqahe9B/7Z+88H7b3SYD46/lw5OcuNT7ZU31ZMIPCAd/W5D4cinqsK8jbsRnH37fUuPExEROVvXDpfw".toCharArray());
+    }
+
+    @Test
+    public void testSaltPasswordMd5() throws Exception {
+        performTest(ALGORITHM_SALT_PASSWORD_DIGEST_MD5, "Z6Hgm7H4P1AH3BGcFNZjqg==".toCharArray());
     }
 
     @Test
@@ -119,7 +131,7 @@ public class SaltedSimpleDigestPasswordTest {
     /**
      * Perform a test for the specified algorithm with the pre-prepared digest for that algorithm.
      *
-     * @param algorithmName the agorithm to use to perform a test.
+     * @param algorithmName the algorithm to use to perform a test.
      * @param base64Digest the Base64 representation of the expected digest for this algorithm.
      */
     private void performTest(final String algorithmName, final char[] base64Digest) throws Exception {
@@ -161,6 +173,8 @@ public class SaltedSimpleDigestPasswordTest {
     }
 
     private class TestPasswordImpl implements SaltedSimpleDigestPassword {
+
+        private static final long serialVersionUID = 1L;
 
         private final String algorithm;
         private final byte[] salt;

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -634,11 +634,35 @@ public class CompatibilityClientTest extends BaseTestCase {
         assertEquals("charset=utf-8,username=\"chris\",realm=\"first realm\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"protocol name/server name\",maxbuf=65536,response=bf3dd710ee08b05c663456975c156075,qop=auth", new String(message2, "UTF-8"));
         assertFalse(client.isComplete());
 
-        byte[] message3 = "rspauth=9c4d137545617ba98c11aaea939b4381".getBytes(StandardCharsets.UTF_8);
+        byte[] message3 = "rspauth=05a18aff49b22e373bb91af7396ce345".getBytes(StandardCharsets.UTF_8);
         byte[] message4 = client.evaluateChallenge(message3);
         assertEquals(null, message4);
         assertTrue(client.isComplete());
 
     }
 
+    /**
+     * Test with wrong step three rspauth
+     */
+    @Test
+    public void testWrongStepThreeRspauth() throws Exception {
+        mockNonce("OA6MHXh6VqTrRk");
+
+        CallbackHandler clientCallback = new ClientCallbackHandler("chris", "secret".toCharArray());
+        client = Sasl.createSaslClient(new String[] { DIGEST }, null, "imap", "elwood.innosoft.com", Collections.<String, Object> emptyMap(), clientCallback);
+        assertFalse(client.isComplete());
+
+        byte[] message1 = "realm=\"elwood.innosoft.com\",nonce=\"OA6MG9tEQGm2hh\",qop=\"auth\",algorithm=md5-sess,charset=utf-8".getBytes(StandardCharsets.UTF_8);
+        byte[] message2 = client.evaluateChallenge(message1);
+        assertEquals("charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA6MG9tEQGm2hh\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"imap/elwood.innosoft.com\",maxbuf=65536,response=d388dad90d4bbd760a152321f2143af7,qop=auth", new String(message2, "UTF-8"));
+        assertFalse(client.isComplete());
+
+        byte[] message3 = "rspauth=ab66f60335c427b5527b84dbabcdaacc".getBytes(StandardCharsets.UTF_8);
+        try{
+            client.evaluateChallenge(message3);
+            fail("Not thrown SaslException!");
+        } catch (SaslException e) {}
+        assertFalse(client.isComplete());
+
+    }
 }

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -201,7 +201,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=default=3des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConf() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -257,7 +256,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc4() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -313,7 +311,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfDes() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -369,7 +366,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-56)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc456() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -425,7 +421,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-40)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc440() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -481,7 +476,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=unknown)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfUnknown() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 
@@ -593,6 +587,7 @@ public class CompatibilityClientTest extends BaseTestCase {
 
     }
 
+
     /**
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
@@ -617,6 +612,7 @@ public class CompatibilityClientTest extends BaseTestCase {
 
     }
 
+
     /**
      * Test successful authentication with escaped realms delimiters
      */
@@ -639,6 +635,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         assertTrue(client.isComplete());
 
     }
+
 
     /**
      * Test with wrong step three rspauth
@@ -664,6 +661,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         assertFalse(client.isComplete());
 
     }
+
 
     /**
      * Test QOP selection by client (Server allow auth, auth-int, client want 1.auth-conf, 2.auth-int, 3.auth)
@@ -691,6 +689,7 @@ public class CompatibilityClientTest extends BaseTestCase {
 
     }
 
+
     /**
      * Test QOP selection by client (Server allow auth-int, auth, client want 1.auth-conf, 2.auth, 3.auth-int)
      */
@@ -716,6 +715,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         assertTrue(client.isComplete());
 
     }
+
 
     /**
      * Test unsuccessful QOP selection by client (no common QOP)

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -146,7 +146,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test with authentication plus integrity protection (qop=auth-int)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthInt() throws Exception {
         mockNonce("OA9BSuZWMSpW8m");
 

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -86,7 +86,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA6MG9tEQGm2hh\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"imap/elwood.innosoft.com\",response=d388dad90d4bbd760a152321f2143af7,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=ea40f60335c427b5527b84dbabcdfffd", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=ea40f60335c427b5527b84dbabcdfffd", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -112,7 +112,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",response=6084c6db3fede7352c551284490fd0fc,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=2f0b3d7c3c2e486600ef710726aa2eae", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=2f0b3d7c3c2e486600ef710726aa2eae", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -123,7 +123,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authorization ID (authzid) of other user
      */
     @Test
-    @Ignore("ELY-90 : Permission check to use authorization id not implemented")
     public void testUnauthorizedAuthorizationId() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -168,7 +167,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",response=aa4e81f1c6656350f7bce05d436665de,qop=auth,authzid=\"chris\"".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
 
-        //assertEquals("rspauth=af3ca83a805d4cfa00675a17315475c4", new String(message3, "UTF-8"));
+        assertEquals("rspauth=af3ca83a805d4cfa00675a17315475c4", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -196,7 +195,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",maxbuf=65536,response=d8b17f55b410208c6ebb22f89f9d6cbb,qop=auth-int,authzid=\"chris\"".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=7a8794654d6d6de607e9143d52b554a8", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=7a8794654d6d6de607e9143d52b554a8", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -614,7 +613,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"\",digest-uri=\"acap/elwood.innosoft.com\",response=0ca21eafddf586f954909d2fd95b1ee7,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=2bf631e48acb9863e9f5518ccc804b3b", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=2bf631e48acb9863e9f5518ccc804b3b", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -638,7 +637,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"\u0438\u4F60\uD83C\uDCA1\",realm=\"realm.\u0438\u4F60\uD83C\uDCA1.com\",nonce=\"sn\u0438\u4F60\uD83C\uDCA1\",nc=00000001,cnonce=\"cn\u0438\u4F60\uD83C\uDCA1\",digest-uri=\"\u0438\u4F60\uD83C\uDCA1/realm.\u0438\u4F60\uD83C\uDCA1.com\",maxbuf=65536,response=420939e06d2d748c157c5e33499b41a9,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("\u0438\u4F60\uD83C\uDCA1", server.getAuthorizationID());
 
@@ -663,7 +662,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"first realm\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"protocol name/server name\",maxbuf=65536,response=bf3dd710ee08b05c663456975c156075,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=05a18aff49b22e373bb91af7396ce345", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -178,7 +178,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity protection (qop=auth-int)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthInt() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -36,7 +36,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -233,7 +232,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=default=3des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConf() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -289,7 +287,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc4() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -345,7 +342,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfDes() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -400,7 +396,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-56)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc456() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -456,7 +451,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-40)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc440() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -618,11 +612,11 @@ public class CompatibilityServerTest extends BaseTestCase {
 
     }
 
+
     /**
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
     @Test
-    @Ignore("Problem with encoding on Windows")
     public void testUtf8Charset() throws Exception {
         mockNonce("sn\u0438\u4F60\uD83C\uDCA1");
 
@@ -641,6 +635,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         assertEquals("\u0438\u4F60\uD83C\uDCA1", server.getAuthorizationID());
 
     }
+
 
     /**
      * More realms from server (realm="other-realm",realm="elwood.innosoft.com",realm="next-realm" -> elwood.innosoft.com)

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
@@ -30,28 +30,30 @@ import org.junit.Test;
 import org.wildfly.security.sasl.digest.Digest;
 import org.wildfly.security.sasl.util.HexConverter;
 
+import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
+
 /**
  * Digest SASL utilities tests
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
-public class DigestUtilsTest {
+public class DigestUtilTest {
 
     MessageDigest md;
 
     @Before
     public void init() throws Exception {
-        md = MessageDigest.getInstance(DigestUtils.messageDigestAlgorithm(Digest.DIGEST_MD5));
+        md = MessageDigest.getInstance(messageDigestAlgorithm(Digest.DIGEST_MD5));
     }
 
     @Test
     public void testH_A1() throws Exception {
 
         assertEquals("a2549853149b0536f01f0b850c643c57", HexConverter.convertToHexString(
-                DigestUtils.H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
                 "OA6MG9tEQGm2hh".getBytes(), "OA6MHXh6VqTrRk".getBytes(), null, StandardCharsets.UTF_8)));
 
         assertEquals("7f94ea5b1eb1b0573cca321e2b517b63", HexConverter.convertToHexString(
-                DigestUtils.H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
                 "OA9BSXrbuRhWay".getBytes(), "OA9BSuZWMSpW8m".getBytes(), "chris", StandardCharsets.UTF_8)));
 
     }
@@ -60,19 +62,19 @@ public class DigestUtilsTest {
     public void testDigestResponse() throws Exception {
 
         assertEquals("d388dad90d4bbd760a152321f2143af7", new String(
-                DigestUtils.digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
                 "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", true)));
 
         assertEquals("ea40f60335c427b5527b84dbabcdfffd", new String(
-                DigestUtils.digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
                 "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", false)));
 
         assertEquals("aa4e81f1c6656350f7bce05d436665de", new String(
-                DigestUtils.digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
                 "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", true)));
 
         assertEquals("af3ca83a805d4cfa00675a17315475c4", new String(
-                DigestUtils.digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
                 "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", false)));
 
     }
@@ -80,24 +82,24 @@ public class DigestUtilsTest {
     @Test
     /* LHEX = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "a" | "b" | "c" | "d" | "e" | "f" */
     public void testConvertToHexBytesWithLeftPadding() throws Exception {
-        assertEquals("00000001", new String(DigestUtils.convertToHexBytesWithLeftPadding(1, 8)));
-        assertEquals("0000002", new String(DigestUtils.convertToHexBytesWithLeftPadding(2, 7)));
-        assertEquals("000a", new String(DigestUtils.convertToHexBytesWithLeftPadding(10, 4)));
-        assertEquals("abc", new String(DigestUtils.convertToHexBytesWithLeftPadding(0xABC, 3)));
+        assertEquals("00000001", new String(convertToHexBytesWithLeftPadding(1, 8)));
+        assertEquals("0000002", new String(convertToHexBytesWithLeftPadding(2, 7)));
+        assertEquals("000a", new String(convertToHexBytesWithLeftPadding(10, 4)));
+        assertEquals("abc", new String(convertToHexBytesWithLeftPadding(0xABC, 3)));
     }
 
     @Test
     public void testCreate3desSubKey() throws Exception {
         byte[] input1 = HexConverter.convertFromHex("FFFFFFFFFFFFFF");
-        byte[] output1 = DigestUtils.create3desSubKey(input1, 0, 7);
+        byte[] output1 = create3desSubKey(input1, 0, 7);
         assertEquals("FEFEFEFEFEFEFEFE".toLowerCase(), HexConverter.convertToHexString(output1));
 
         byte[] input2 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
-        byte[] output2 = DigestUtils.create3desSubKey(input2, 0, 7);
+        byte[] output2 = create3desSubKey(input2, 0, 7);
         assertEquals("D6E54919F22A929D".toLowerCase(), HexConverter.convertToHexString(output2));
 
         byte[] input3 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
-        byte[] output3 = DigestUtils.create3desSubKey(input3, 7, 7);
+        byte[] output3 = create3desSubKey(input3, 7, 7);
         assertEquals("C2CE15E04986DFD5".toLowerCase(), HexConverter.convertToHexString(output3));
     }
 
@@ -106,45 +108,45 @@ public class DigestUtilsTest {
         Mac mac = Mac.getInstance("HmacMD5");
         byte[] message = HexConverter.convertFromHex("11223344");
         byte[] kc = HexConverter.convertFromHex("9fdbff3d48c87e74bd89460e2462c73a");
-        byte[] output = DigestUtils.computeHMAC(kc, 0, mac, message, 0, message.length);
+        byte[] output = computeHMAC(kc, 0, mac, message, 0, message.length);
         assertEquals("EF3E40D7B5A64C1DAE6B".toLowerCase(), HexConverter.convertToHexString(output));
     }
 
     @Test
     public void testIntegerByteOrdered() throws Exception {
         byte[] output0 = new byte[4];
-        DigestUtils.integerByteOrdered(0x0, output0, 0, 4);
+        integerByteOrdered(0x0, output0, 0, 4);
         assertEquals("00000000".toLowerCase(), HexConverter.convertToHexString(output0));
 
         byte[] output1 = new byte[4];
-        DigestUtils.integerByteOrdered(0x1, output1, 0, 4);
+        integerByteOrdered(0x1, output1, 0, 4);
         assertEquals("00000001".toLowerCase(), HexConverter.convertToHexString(output1));
 
         byte[] output1234 = new byte[6];
-        DigestUtils.integerByteOrdered(0x1234, output1234, 1, 4);
+        integerByteOrdered(0x1234, output1234, 1, 4);
         assertEquals("000000123400".toLowerCase(), HexConverter.convertToHexString(output1234));
 
         byte[] outputFFFFFFFF = new byte[4];
-        DigestUtils.integerByteOrdered(0xFFFFFFFF, outputFFFFFFFF, 0, 4);
+        integerByteOrdered(0xFFFFFFFF, outputFFFFFFFF, 0, 4);
         assertEquals("FFFFFFFF".toLowerCase(), HexConverter.convertToHexString(outputFFFFFFFF));
     }
 
     @Test
     public void testDecodeByteOrderedInteger() throws Exception {
         byte[] input0 = HexConverter.convertFromHex("00000000");
-        assertEquals(0x0, DigestUtils.decodeByteOrderedInteger(input0, 0, 4));
+        assertEquals(0x0, decodeByteOrderedInteger(input0, 0, 4));
 
         byte[] input1 = HexConverter.convertFromHex("00000001");
-        assertEquals(0x1, DigestUtils.decodeByteOrderedInteger(input1, 0, 4));
+        assertEquals(0x1, decodeByteOrderedInteger(input1, 0, 4));
 
         byte[] input1234 = HexConverter.convertFromHex("000000123400");
-        assertEquals(0x1234, DigestUtils.decodeByteOrderedInteger(input1234, 1, 4));
+        assertEquals(0x1234, decodeByteOrderedInteger(input1234, 1, 4));
 
         byte[] input1234b = HexConverter.convertFromHex("000000123400");
-        assertEquals(0x1234, DigestUtils.decodeByteOrderedInteger(input1234b, 3, 2));
+        assertEquals(0x1234, decodeByteOrderedInteger(input1234b, 3, 2));
 
         byte[] inputFFFFFFFF = HexConverter.convertFromHex("FFFFFFFF");
-        assertEquals(0xFFFFFFFF, DigestUtils.decodeByteOrderedInteger(inputFFFFFFFF, 0, 4));
+        assertEquals(0xFFFFFFFF, decodeByteOrderedInteger(inputFFFFFFFF, 0, 4));
     }
 
 }

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilsTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilsTest.java
@@ -26,7 +26,6 @@ import java.security.MessageDigest;
 import javax.crypto.Mac;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.digest.Digest;
 import org.wildfly.security.sasl.util.HexConverter;
@@ -79,7 +78,6 @@ public class DigestUtilsTest {
     }
 
     @Test
-    @Ignore("Fix of convertToHexBytesWithLeftPadding() required")
     /* LHEX = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "a" | "b" | "c" | "d" | "e" | "f" */
     public void testConvertToHexBytesWithLeftPadding() throws Exception {
         assertEquals("00000001", new String(DigestUtils.convertToHexBytesWithLeftPadding(1, 8)));
@@ -89,7 +87,6 @@ public class DigestUtilsTest {
     }
 
     @Test
-    @Ignore("Fix of create3desSubKey() required")
     public void testCreate3desSubKey() throws Exception {
         byte[] input1 = HexConverter.convertFromHex("FFFFFFFFFFFFFF");
         byte[] output1 = DigestUtils.create3desSubKey(input1, 0, 7);
@@ -105,7 +102,6 @@ public class DigestUtilsTest {
     }
 
     @Test
-    @Ignore("Fix of computeHMAC() required")
     public void testComputeHmac() throws Exception {
         Mac mac = Mac.getInstance("HmacMD5");
         byte[] message = HexConverter.convertFromHex("11223344");

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilsTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilsTest.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.digest._private;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import javax.crypto.Mac;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.security.sasl.digest.Digest;
+import org.wildfly.security.sasl.util.HexConverter;
+
+/**
+ * Digest SASL utilities tests
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class DigestUtilsTest {
+
+    MessageDigest md;
+
+    @Before
+    public void init() throws Exception {
+        md = MessageDigest.getInstance(DigestUtils.messageDigestAlgorithm(Digest.DIGEST_MD5));
+    }
+
+    @Test
+    public void testH_A1() throws Exception {
+
+        assertEquals("a2549853149b0536f01f0b850c643c57", HexConverter.convertToHexString(
+                DigestUtils.H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                "OA6MG9tEQGm2hh".getBytes(), "OA6MHXh6VqTrRk".getBytes(), null, StandardCharsets.UTF_8)));
+
+        assertEquals("7f94ea5b1eb1b0573cca321e2b517b63", HexConverter.convertToHexString(
+                DigestUtils.H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                "OA9BSXrbuRhWay".getBytes(), "OA9BSuZWMSpW8m".getBytes(), "chris", StandardCharsets.UTF_8)));
+
+    }
+
+    @Test
+    public void testDigestResponse() throws Exception {
+
+        assertEquals("d388dad90d4bbd760a152321f2143af7", new String(
+                DigestUtils.digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", true)));
+
+        assertEquals("ea40f60335c427b5527b84dbabcdfffd", new String(
+                DigestUtils.digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", false)));
+
+        assertEquals("aa4e81f1c6656350f7bce05d436665de", new String(
+                DigestUtils.digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", true)));
+
+        assertEquals("af3ca83a805d4cfa00675a17315475c4", new String(
+                DigestUtils.digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", false)));
+
+    }
+
+    @Test
+    @Ignore("Fix of convertToHexBytesWithLeftPadding() required")
+    /* LHEX = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "a" | "b" | "c" | "d" | "e" | "f" */
+    public void testConvertToHexBytesWithLeftPadding() throws Exception {
+        assertEquals("00000001", new String(DigestUtils.convertToHexBytesWithLeftPadding(1, 8)));
+        assertEquals("0000002", new String(DigestUtils.convertToHexBytesWithLeftPadding(2, 7)));
+        assertEquals("000a", new String(DigestUtils.convertToHexBytesWithLeftPadding(10, 4)));
+        assertEquals("abc", new String(DigestUtils.convertToHexBytesWithLeftPadding(0xABC, 3)));
+    }
+
+    @Test
+    @Ignore("Fix of create3desSubKey() required")
+    public void testCreate3desSubKey() throws Exception {
+        byte[] input1 = HexConverter.convertFromHex("FFFFFFFFFFFFFF");
+        byte[] output1 = DigestUtils.create3desSubKey(input1, 0, 7);
+        assertEquals("FEFEFEFEFEFEFEFE".toLowerCase(), HexConverter.convertToHexString(output1));
+
+        byte[] input2 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
+        byte[] output2 = DigestUtils.create3desSubKey(input2, 0, 7);
+        assertEquals("D6E54919F22A929D".toLowerCase(), HexConverter.convertToHexString(output2));
+
+        byte[] input3 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
+        byte[] output3 = DigestUtils.create3desSubKey(input3, 7, 7);
+        assertEquals("C2CE15E04986DFD5".toLowerCase(), HexConverter.convertToHexString(output3));
+    }
+
+    @Test
+    @Ignore("Fix of computeHMAC() required")
+    public void testComputeHmac() throws Exception {
+        Mac mac = Mac.getInstance("HmacMD5");
+        byte[] message = HexConverter.convertFromHex("11223344");
+        byte[] kc = HexConverter.convertFromHex("9fdbff3d48c87e74bd89460e2462c73a");
+        byte[] output = DigestUtils.computeHMAC(kc, 0, mac, message, 0, message.length);
+        assertEquals("EF3E40D7B5A64C1DAE6B".toLowerCase(), HexConverter.convertToHexString(output));
+    }
+
+    @Test
+    public void testIntegerByteOrdered() throws Exception {
+        byte[] output0 = new byte[4];
+        DigestUtils.integerByteOrdered(0x0, output0, 0, 4);
+        assertEquals("00000000".toLowerCase(), HexConverter.convertToHexString(output0));
+
+        byte[] output1 = new byte[4];
+        DigestUtils.integerByteOrdered(0x1, output1, 0, 4);
+        assertEquals("00000001".toLowerCase(), HexConverter.convertToHexString(output1));
+
+        byte[] output1234 = new byte[6];
+        DigestUtils.integerByteOrdered(0x1234, output1234, 1, 4);
+        assertEquals("000000123400".toLowerCase(), HexConverter.convertToHexString(output1234));
+
+        byte[] outputFFFFFFFF = new byte[4];
+        DigestUtils.integerByteOrdered(0xFFFFFFFF, outputFFFFFFFF, 0, 4);
+        assertEquals("FFFFFFFF".toLowerCase(), HexConverter.convertToHexString(outputFFFFFFFF));
+    }
+
+    @Test
+    public void testDecodeByteOrderedInteger() throws Exception {
+        byte[] input0 = HexConverter.convertFromHex("00000000");
+        assertEquals(0x0, DigestUtils.decodeByteOrderedInteger(input0, 0, 4));
+
+        byte[] input1 = HexConverter.convertFromHex("00000001");
+        assertEquals(0x1, DigestUtils.decodeByteOrderedInteger(input1, 0, 4));
+
+        byte[] input1234 = HexConverter.convertFromHex("000000123400");
+        assertEquals(0x1234, DigestUtils.decodeByteOrderedInteger(input1234, 1, 4));
+
+        byte[] input1234b = HexConverter.convertFromHex("000000123400");
+        assertEquals(0x1234, DigestUtils.decodeByteOrderedInteger(input1234b, 3, 2));
+
+        byte[] inputFFFFFFFF = HexConverter.convertFromHex("FFFFFFFF");
+        assertEquals(0xFFFFFFFF, DigestUtils.decodeByteOrderedInteger(inputFFFFFFFF, 0, 4));
+    }
+
+}

--- a/src/test/resources/Elytron.ldif
+++ b/src/test/resources/Elytron.ldif
@@ -27,6 +27,17 @@ uid: plainUser
 userPassword:: cGxhaW5QYXNzd29yZA==
 # Password plainPassword
 
+dn: uid=md5User,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: md5User
+sn: md5User
+uid: md5User
+userPassword:: e21kNX1IdWpYRmlxTFl0Q1g5RURIUUF6bytRPT0=
+# Password md5Password
+
 dn: uid=sha512User,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: inetOrgPerson

--- a/src/test/resources/Elytron.ldif
+++ b/src/test/resources/Elytron.ldif
@@ -38,6 +38,17 @@ uid: md5User
 userPassword:: e21kNX1IdWpYRmlxTFl0Q1g5RURIUUF6bytRPT0=
 # Password md5Password
 
+dn: uid=smd5User,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: smd5User
+sn: smd5User
+uid: smd5User
+userPassword:: e3NtZDV9RXBMOXdpZ21pU3VraTZ1VjlENkdQZ0VhL3JZbnNQbnE=
+# Password smd5Password
+
 dn: uid=sha512User,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: inetOrgPerson


### PR DESCRIPTION
* Implemented step three (rspauth generation and checking)
* authzid checking (checking permission to use authorization id)
* QOP selection improved to select by client preferences (order of options in property)
* Fixed integrity (bad seqNum)
* Refactored cipher selection (exception when no common cipher)
* Utils from AbstractDigestMechanism moved into _private.DigestUtils and covered by tests
* Fixed bugs in encryption (+ refactoring)
* Integrity key calculation only at begin of communication, not in every wrap/unwrap