### PR TITLE
[ELY-145][ELY-90] Digest-MD5 - step three + integrity + encryption (corrected)

### DIFF
--- a/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
@@ -59,7 +59,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         this.qop = qop;
         this.digestURI = digestURI;
         this.utf8Encoded = utf8Encoded;
-        this.digestResponse = DigestUtil.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        this.digestResponse = DigestUtil.digestResponse(getMessageDigest(this.algorithm), hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
     }
 
     DigestPasswordImpl(byte[] clonedHA1, byte[] clonedNonce, int nonceCount, byte[] clonedCnonce, String authzid, String qop, String digestURI, final String algorithm) throws NoSuchAlgorithmException {
@@ -91,7 +91,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
         } catch (NoSuchAlgorithmException e) {
             throw new InvalidKeyException("No matching algorithm", e);
         }
-        byte[] guessBasedResponse = DigestUtil.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        byte[] guessBasedResponse = DigestUtil.digestResponse(messageDigest, guessedHashA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
         try {
             return Arrays.equals(digestResponse, guessBasedResponse);
         } catch (NullPointerException e) {

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslException;
@@ -36,6 +37,8 @@ import org.wildfly.security.sasl.WildFlySasl;
  */
 @MetaInfServices(value = SaslClientFactory.class)
 public class DigestClientFactory extends AbstractDigestFactory implements SaslClientFactory {
+
+    public static final String[] DEFAULT_CIPHERS = new String[]{ "3des", "rc4", "des", "rc4-56", "rc4-40" };
 
     public DigestClientFactory() {
     }
@@ -54,10 +57,13 @@ public class DigestClientFactory extends AbstractDigestFactory implements SaslCl
         Boolean utf8 = (Boolean)props.get(WildFlySasl.USE_UTF8);
         Charset charset = (utf8==null || utf8.booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
 
-        String supportedCipherOpts = (String)props.get(WildFlySasl.SUPPORTED_CIPHER_NAMES);
-        String[] ciphers = (supportedCipherOpts == null ? null : supportedCipherOpts.split(","));
+        String qopsString = (String)props.get(Sasl.QOP);
+        String[] qops = qopsString==null ? null : qopsString.split(",");
 
-        final DigestSaslClient client = new DigestSaslClient(selectedMech, protocol, serverName, cbh, authorizationId, false, charset, ciphers);
+        String supportedCipherOpts = (String)props.get(WildFlySasl.SUPPORTED_CIPHER_NAMES);
+        String[] ciphers = supportedCipherOpts == null ? DEFAULT_CIPHERS : supportedCipherOpts.split(",");
+
+        final DigestSaslClient client = new DigestSaslClient(selectedMech, protocol, serverName, cbh, authorizationId, false, charset, qops, ciphers);
         client.init();
         return client;
     }

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
@@ -46,10 +46,11 @@ import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
  */
 class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
-    private static final int STEP_TWO = 2;
-    private static final int STEP_FOUR = 4;
+    private static final byte STEP_TWO = 2;
+    private static final byte STEP_FOUR = 4;
 
     private String[] realms;
+    private String[] clientQops;
     private boolean stale = false;
     private int maxbuf = DEFAULT_MAXBUF;
     private String cipher_opts;
@@ -59,20 +60,21 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
     private final String[] demandedCiphers;
     private final MessageDigest messageDigest;
 
-    DigestSaslClient(String mechanism, String protocol, String serverName, CallbackHandler callbackHandler, String authorizationId, boolean hasInitialResponse, Charset charset, String[] ciphers) throws SaslException {
+    DigestSaslClient(String mechanism, String protocol, String serverName, CallbackHandler callbackHandler, String authorizationId, boolean hasInitialResponse, Charset charset, String[] qops, String[] ciphers) throws SaslException {
         super(mechanism, protocol, serverName, callbackHandler, FORMAT.CLIENT, charset, ciphers);
 
         this.hasInitialResponse = hasInitialResponse;
         this.authorizationId = authorizationId;
-        this.demandedCiphers = (ciphers == null ? new String[] {} : ciphers);
+        this.clientQops = qops == null ? new String[] {QOP_AUTH} : qops;
+        this.demandedCiphers = ciphers == null ? new String[] {} : ciphers;
         try {
             this.messageDigest = MessageDigest.getInstance(messageDigestAlgorithm(mechanism));
         } catch (NoSuchAlgorithmException e) {
-            throw new SaslException("Expected message digest algorithm is not available", e);
+            throw new SaslException(getMechanismName() + ": Expected message digest algorithm is not available", e);
         }
     }
 
-    private void noteChallengeData(HashMap<String, byte[]> parsedChallenge) {
+    private void noteChallengeData(HashMap<String, byte[]> parsedChallenge) throws SaslException {
 
         LinkedList<String> realmList = new LinkedList<String>();
         for (String keyWord: parsedChallenge.keySet()) {
@@ -81,8 +83,8 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
                 realmList.add(new String(parsedChallenge.get(keyWord), StandardCharsets.UTF_8));
             }
             else if (keyWord.equals("qop")) {
-                String qopServerOptions = new String(parsedChallenge.get(keyWord), StandardCharsets.UTF_8);
-                selectQop(qopServerOptions);
+                String serverQops = new String(parsedChallenge.get(keyWord), StandardCharsets.UTF_8);
+                this.qop = selectQop(serverQops.split(String.valueOf(DELIMITER)), clientQops);
             }
             else if (keyWord.equals("stale")) {
                 stale = Boolean.parseBoolean(new String(parsedChallenge.get(keyWord), StandardCharsets.UTF_8));
@@ -98,7 +100,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
             }
             else if (keyWord.equals("cipher")) {
                 cipher_opts = new String(parsedChallenge.get(keyWord), StandardCharsets.UTF_8);
-                selectCipher(cipher_opts);
+                cipher = selectCipher(cipher_opts);
             }
         }
 
@@ -110,23 +112,19 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         realmList.toArray(realms);
     }
 
-    private void selectQop(String qopServerOptions) {
-        // TODO: make this configurable
-        // for now choose the strongest one
-        String[] qops = qopServerOptions.split(String.valueOf(DELIMITER));
-        if (arrayContains(qops,  QOP_AUTH_CONF)) {
-            this.qop = QOP_AUTH_CONF;
-        } else if (arrayContains(qops, QOP_AUTH_INT)) {
-            this.qop = QOP_AUTH_INT;
-        } else {
-            this.qop = QOP_AUTH;
+    private String selectQop(String[] serverQops, String[] clientQops) throws SaslException {
+        // select by client preferences
+        for(String clientQop : clientQops){
+            if (arrayContains(serverQops, clientQop)) {
+                return clientQop;
+            }
         }
+        throw new SaslException(getMechanismName() + ": No common protection layer between client and server");
     }
 
-    private void selectCipher(String ciphersFromServer) {
+    private String selectCipher(String ciphersFromServer) throws SaslException {
         if (ciphersFromServer == null) {
-            cipher = "";
-            return;
+            throw new SaslException(getMechanismName() + ": No ciphers offered by server");
         }
 
         TransformationMapper trans = new DefaultTransformationMapper();
@@ -134,14 +132,13 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         for (TransformationSpec ts: trans.getTransformationSpecByStrength(Digest.DIGEST_MD5, tokensToChooseFrom)) {
             // take the strongest cipher
             for (String c: demandedCiphers) {
-               if (c.equals(ts.getToken())) {
-                   cipher = ts.getToken();
-                   return;
+                if (c.equals(ts.getToken())) {
+                   return ts.getToken();
                }
             }
         }
 
-        cipher = "";
+        throw new SaslException(getMechanismName() + ": No common cipher between client and server");
     }
 
 
@@ -242,7 +239,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
         // nonce
         if(nonce == null){
-            throw new SaslException("Nonce not provided by server");
+            throw new SaslException(getMechanismName() + ": Nonce not provided by server");
         }
         digestResponse.append("nonce=\"");
         digestResponse.append(nonce);
@@ -256,7 +253,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
         // cnonce
         digestResponse.append("cnonce=\"");
-        byte[] cnonce = generateNonce();
+        cnonce = generateNonce();
         digestResponse.append(cnonce);
         digestResponse.append("\"").append(DELIMITER);
 
@@ -278,7 +275,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
         hA1 = H_A1(messageDigest, userName, realm, passwd, nonce, cnonce, authorizationId, serverHashedURPUsingcharset);
 
-        byte[] response_value = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authorizationId, qop, digestURI);
+        byte[] response_value = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authorizationId, qop, digestURI, true);
         // wipe out the password
         if (passwd != null) {
             Arrays.fill(passwd, (char)0);
@@ -294,8 +291,9 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         // cipher
         if (cipher != null && cipher.length() != 0) {
             digestResponse.append(DELIMITER);
-            digestResponse.append("cipher=");
+            digestResponse.append("cipher=\"");
             digestResponse.append(cipher);
+            digestResponse.append("\"");
         }
 
         // authzid
@@ -319,6 +317,13 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         return 1;
     }
 
+    private void checkResponseAuth(HashMap<String, byte[]> parsedChallenge) throws SaslException {
+        byte[] expected = digestResponse(messageDigest, hA1, nonce, getNonceCount(), cnonce, authzid, qop, digestURI, false);
+        if(!Arrays.equals(expected, parsedChallenge.get("rspauth"))) {
+            throw new SaslException(getMechanismName() + ": Invalid rspauth from server");
+        }
+    }
+
     /* (non-Javadoc)
      * @see org.wildfly.sasl.util.AbstractSaslParticipant#init()
      */
@@ -339,15 +344,14 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
     @Override
     protected byte[] evaluateMessage(int state, final byte[] message) throws SaslException {
+        HashMap<String, byte[]> parsedChallenge = parseResponse(message);
         switch (state) {
             case STEP_TWO:
-                HashMap<String, byte[]> parsedChallenge = parseResponse(message);
                 noteChallengeData(parsedChallenge);
                 setNegotiationState(STEP_FOUR);
                 return createResponse(parsedChallenge);
             case STEP_FOUR:
-                // TODO: check rspauth
-
+                checkResponseAuth(parsedChallenge);
                 negotiationComplete();
                 return null;
         }

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
@@ -35,7 +36,6 @@ import javax.security.sasl.SaslServer;
 import org.wildfly.security.util.ByteStringBuilder;
 
 import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
-
 
 /**
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
@@ -53,12 +53,12 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         try {
             this.messageDigest = MessageDigest.getInstance(messageDigestAlgorithm(mechanismName));
         } catch (NoSuchAlgorithmException e) {
-            throw new SaslException("Expected message digest algorithm is not available", e);
+            throw new SaslException(getMechanismName() + ": Expected message digest algorithm is not available", e);
         }
     }
 
-    private static final int STEP_ONE = 1;
-    private static final int STEP_THREE = 3;
+    private static final byte STEP_ONE = 1;
+    private static final byte STEP_THREE = 3;
 
     private String[] realms;
     private String supportedCiphers;
@@ -169,9 +169,6 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         } else {
             authzid = null;
         }
-
-
-
     }
 
     private byte[] validateDigestResponse(HashMap<String, byte[]> parsedDigestResponse) throws SaslException {
@@ -218,7 +215,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         if (parsedDigestResponse.get("cnonce") == null) {
             throw new SaslException(getMechanismName() + ": missing cnonce");
         }
-        byte[] cnonce = parsedDigestResponse.get("cnonce");
+        cnonce = parsedDigestResponse.get("cnonce");
 
         if (parsedDigestResponse.get("nc") == null) {
             throw new SaslException(getMechanismName() + ": missing nonce-count");
@@ -249,8 +246,9 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         final NameCallback nameCallback = new NameCallback("User name", userName);
         final PasswordCallback passwordCallback = new PasswordCallback("User password", false);
         final RealmCallback realmCallback = new RealmCallback("User realm");
+        final AuthorizeCallback authorizeCallback = new AuthorizeCallback(userName, authzid==null ? userName : authzid);
 
-        handleCallbacks(realmCallback, nameCallback, passwordCallback);
+        handleCallbacks(realmCallback, nameCallback, passwordCallback, authorizeCallback);
 
         char[] passwd = passwordCallback.getPassword();
         passwordCallback.clearPassword();
@@ -258,7 +256,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
 
         hA1 = H_A1(messageDigest, userName, clientRealm, passwd, nonce, cnonce, authzid, clientCharset);
 
-        byte[] expectedResponse = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        byte[] expectedResponse = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, true);
         // wipe out the password
         if (passwd != null) {
             Arrays.fill(passwd, (char)0);
@@ -268,8 +266,10 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
 
         if (parsedDigestResponse.get("response") != null) {
             if (Arrays.equals(expectedResponse, parsedDigestResponse.get("response"))) {
-                if (authzid == null) {
-                    authzid = userName; // TODO: Check permission use given authzid!
+                if (authorizeCallback.isAuthorized()) {
+                    authzid = authorizeCallback.getAuthorizedID();
+                } else {
+                    throw new SaslException(getMechanismName() + ": " + userName + " not authorized to act as " + authzid);
                 }
                 return createResponseAuth(parsedDigestResponse);
             } else {
@@ -279,15 +279,13 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         } else {
             throw new SaslException(getMechanismName() + ": missing response directive");
         }
-
     }
 
     private byte[] createResponseAuth(HashMap<String, byte[]> parsedDigestResponse) {
         ByteStringBuilder responseAuth = new ByteStringBuilder();
         responseAuth.append("rspauth=");
 
-        // TODO
-        byte[] response_value = new byte[0];
+        byte[] response_value = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI, false);
 
         responseAuth.append(response_value);
         return responseAuth.toArray();

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -32,8 +32,9 @@ import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
-import org.wildfly.security.sasl.digest._private.DigestUtil;
 import org.wildfly.security.util.ByteStringBuilder;
+
+import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
 
 
 /**
@@ -50,7 +51,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         this.supportedCiphers = getSupportedCiphers(ciphers);
         this.qops = qops;
         try {
-            this.messageDigest = MessageDigest.getInstance(DigestUtil.messageDigestAlgorithm(mechanismName));
+            this.messageDigest = MessageDigest.getInstance(messageDigestAlgorithm(mechanismName));
         } catch (NoSuchAlgorithmException e) {
             throw new SaslException("Expected message digest algorithm is not available", e);
         }
@@ -136,7 +137,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         }
 
         // cipher
-        if (supportedCiphers != null && qops != null && arrayContains(qops, DigestUtil.QOP_AUTH_CONF)) {
+        if (supportedCiphers != null && qops != null && arrayContains(qops, QOP_AUTH_CONF)) {
             challenge.append("cipher=\"");
             challenge.append(supportedCiphers);
             challenge.append("\"").append(DELIMITER);
@@ -233,14 +234,14 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
             throw new SaslException(getMechanismName() + ": digest-uri directive is missing");
         }
 
-        qop = DigestUtil.QOP_AUTH;
+        qop = QOP_AUTH;
         if (parsedDigestResponse.get("qop") != null) {
             qop = new String(parsedDigestResponse.get("qop"), clientCharset);
-            if (!arrayContains(DigestUtil.QOP_VALUES, qop)) {
+            if (!arrayContains(QOP_VALUES, qop)) {
                 throw new SaslException(getMechanismName() + ": qop directive unexpected value " + qop);
             }
-            if (qop != null && qop.equals(DigestUtil.QOP_AUTH) == false) {
-                setWrapper(new DigestWrapper(qop.equals(DigestUtil.QOP_AUTH_CONF)));
+            if (qop != null && qop.equals(QOP_AUTH) == false) {
+                setWrapper(new DigestWrapper(qop.equals(QOP_AUTH_CONF)));
             }
         }
 
@@ -255,9 +256,9 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         passwordCallback.clearPassword();
 
 
-        hA1 = DigestUtil.H_A1(messageDigest, userName, clientRealm, passwd, nonce, cnonce, authzid, clientCharset);
+        hA1 = H_A1(messageDigest, userName, clientRealm, passwd, nonce, cnonce, authzid, clientCharset);
 
-        byte[] expectedResponse = DigestUtil.digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
+        byte[] expectedResponse = digestResponse(messageDigest, hA1, nonce, nonceCount, cnonce, authzid, qop, digestURI);
         // wipe out the password
         if (passwd != null) {
             Arrays.fill(passwd, (char)0);

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
@@ -141,7 +141,7 @@ public final class DigestUtil {
      */
     public static byte[] digestResponse(MessageDigest messageDigest, byte[] H_A1,
                                  byte[] nonce, int nonce_count, byte[] cnonce,
-                                 String authzid, String qop, String digest_uri) {
+                                 String authzid, String qop, String digest_uri, boolean auth) {
 
         // QOP
         String qop_value;
@@ -153,7 +153,7 @@ public final class DigestUtil {
 
         // A2
         ByteStringBuilder A2 = new ByteStringBuilder();
-        A2.append(AUTH_METHOD);
+        if(auth) A2.append(AUTH_METHOD); // for "response", but not for "rspauth"
         A2.append(':');
         A2.append(digest_uri);
         if (QOP_AUTH_CONF.equals(qop_value) || QOP_AUTH_INT.equals(qop_value)) {

--- a/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/_private/DigestUtil.java
@@ -25,8 +25,21 @@ import org.wildfly.security.util.ByteStringBuilder;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.InvalidParameterException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.Arrays;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.DESKeySpec;
+import javax.crypto.spec.DESedeKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.security.sasl.SaslException;
 
 /**
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
@@ -42,6 +55,7 @@ public final class DigestUtil {
     public static final String SECURITY_MARK = "00000000000000000000000000000000";   // 32 zeros
 
     public static final String HASH_algorithm = "MD5";
+    public static final String HMAC_algorithm = "HmacMD5";
 
     public static String passwordAlgorithm(String digestAlgorithm) {
         switch (digestAlgorithm) {
@@ -187,4 +201,124 @@ public final class DigestUtil {
         }
         return retValue;
     }
+
+    public static byte[] computeHMAC(byte[] kc, int sequenceNumber, Mac mac, byte[] message, int offset, int len) throws SaslException {
+        SecretKeySpec ks = new SecretKeySpec(kc, HMAC_algorithm);
+        try {
+            mac.init(ks);
+        } catch (InvalidKeyException e) {
+            throw new SaslException("Invalid key provided", e);
+        }
+        byte[] buffer = new byte[len + 4];
+        integerByteOrdered(sequenceNumber, buffer, 0, 4);
+        System.arraycopy(message, offset, buffer, 4, len);
+        return mac.doFinal(buffer);
+    }
+
+    public static void integerByteOrdered(int num, byte[] buf, int offset, int len) {
+        if (len > 4 || len < 1) {
+            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
+        }
+        for (int i = len - 1; i >= 0; i--) {
+            buf[offset + i] = (byte) (num & 0xff);
+            num >>>= 8;
+        }
+    }
+
+    public static int decodeByteOrderedInteger(byte[] buf, int offset, int len) {
+        if (len > 4 || len < 1) {
+            throw new IllegalArgumentException("integerByteOrdered can handle up to 4 bytes");
+        }
+        int result = buf[offset];
+        for (int i = 1; i < len; i++) {
+            result <<= 8;
+            result |= buf[offset + i];
+        }
+        return result;
+    }
+
+    static byte[] create3desSubKey(byte[] keyBits, int offset, int len) {
+        if (len != 7) {
+            throw new InvalidParameterException("Only 7 byte long keyBits are transformable to 3des subkey");
+        }
+        int hiMask = 0x00;
+        int loMask = 0xfe;
+        byte[] subkey = new byte[8];
+
+        subkey[0] = (byte)(keyBits[0] & loMask);
+        subkey[0] = fixParityBit(subkey[0]);   // fix for real parity bit
+        for (int i = offset + 1; i < len; i++) {
+            int bitNumber = i - offset;
+            hiMask |= 2 ^ (bitNumber - 1);
+            loMask &= 2 ^ bitNumber;
+            int hibits = keyBits[i - 1] & hiMask;
+            hibits <<= 8 - i - 1;
+            int lobits = keyBits[i] & loMask;
+            lobits >>= i;
+            subkey[i] = (byte) (hibits | lobits);
+            subkey[i] = fixParityBit(subkey[i]);  // fix real parity bits
+        }
+
+        return subkey;
+    }
+
+    /**
+     * Create DES secret key according to http://www.cryptosys.net/3des.html.
+     *
+     * @param keyBits
+     * @param offset
+     * @param len
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws InvalidKeySpecException
+     */
+    public static SecretKey createDesSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        if (len != 7) {
+            throw new InvalidParameterException("Only 7 bytes long keyBits are transformable to des key");
+        }
+
+        KeySpec spec = new DESKeySpec(create3desSubKey(keyBits, 0, 7), 0);
+        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DES");
+
+        return desFact.generateSecret(spec);
+    }
+
+    /**
+     * Create 3des secret key according to http://www.cryptosys.net/3des.html.
+     *
+     * @param keyBits
+     * @param offset
+     * @param len
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     * @throws InvalidKeySpecException
+     */
+    public static SecretKey create3desSecretKey(byte[] keyBits, int offset, int len) throws NoSuchAlgorithmException, InvalidKeyException, InvalidKeySpecException {
+        if (len != 14) {
+            throw new InvalidParameterException("Only 14 bytes long keyBits are transformable to 3des key option2");
+        }
+
+        byte[] key = new byte[24];
+        System.arraycopy(create3desSubKey(keyBits, 0, 7), 0, key, 0, 8);   // subkey1
+        System.arraycopy(create3desSubKey(keyBits, 7, 7), 0, key, 8, 8);   // subkey2
+        System.arraycopy(key, 0, key, 16, 8);                              // subkey3 == subkey1 (in option2 of 3des key
+
+        KeySpec spec = new DESedeKeySpec(key, 0);
+        SecretKeyFactory desFact = SecretKeyFactory.getInstance("DESede");
+
+        return desFact.generateSecret(spec);
+    }
+
+    /**
+     * Fix the rightmost bit to maintain odd parity for the whole byte.
+     *
+     * @param toFix - byte to fix
+     * @return fixed byte with odd parity
+     */
+    private static byte fixParityBit(byte toFix) {
+        return (Integer.bitCount(toFix & 0xff) & 1) == 0 ? (byte) (toFix ^ 1) : toFix;
+    }
+
 }

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
@@ -208,6 +208,9 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         if (wrapper == null) {
             throw new IllegalStateException("Wrapping is not configured");
         }
+        if(len == 0) {
+            return NO_BYTES;
+        }
         return wrapper.wrap(outgoing, offset, len);
     }
 
@@ -225,6 +228,9 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         SaslWrapper wrapper = this.wrapper;
         if (wrapper == null) {
             throw new IllegalStateException("Wrapping is not configured");
+        }
+        if(len == 0) {
+            return NO_BYTES;
         }
         return wrapper.unwrap(incoming, offset, len);
     }

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -37,7 +37,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -63,7 +62,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         new MockUp<AbstractDigestMechanism>(){
             @Mock
             byte[] generateNonce(){
-                return nonce.getBytes();
+                return nonce.getBytes(StandardCharsets.UTF_8);
             }
         };
     }
@@ -592,7 +591,6 @@ public class CompatibilityClientTest extends BaseTestCase {
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
     @Test
-    @Ignore("Problem with encoding on Windows")
     public void testUtf8Charset() throws Exception {
         mockNonce("cn\u0438\u4F60\uD83C\uDCA1");
 
@@ -602,7 +600,7 @@ public class CompatibilityClientTest extends BaseTestCase {
 
         byte[] message1 = "realm=\"realm.\u0438\u4F60\uD83C\uDCA1.com\",nonce=\"sn\u0438\u4F60\uD83C\uDCA1\",charset=utf-8,algorithm=md5-sess".getBytes(StandardCharsets.UTF_8);
         byte[] message2 = client.evaluateChallenge(message1);
-        assertEquals("charset=utf-8,username=\"\u0438\u4F60\uD83C\uDCA1\",realm=\"realm.\u0438\u4F60\uD83C\uDCA1.com\",nonce=\"sn\u0438\u4F60\uD83C\uDCA1\",nc=00000001,cnonce=\"cn\u0438\u4F60\uD83C\uDCA1\",digest-uri=\"\u0438\u4F60\uD83C\uDCA1/realm.\u0438\u4F60\uD83C\uDCA1.com\",maxbuf=65536,response=420939e06d2d748c157c5e33499b41a9,qop=auth", new String(message2, "UTF-8"));
+        assertEquals("charset=utf-8,username=\"\u0438\u4F60\uD83C\uDCA1\",realm=\"realm.\u0438\u4F60\uD83C\uDCA1.com\",nonce=\"sn\u0438\u4F60\uD83C\uDCA1\",nc=00000001,cnonce=\"cn\u0438\u4F60\uD83C\uDCA1\",digest-uri=\"\u0438\u4F60\uD83C\uDCA1/realm.\u0438\u4F60\uD83C\uDCA1.com\",maxbuf=65536,response=420939e06d2d748c157c5e33499b41a9,qop=auth", new String(message2, StandardCharsets.UTF_8));
         assertFalse(client.isComplete());
 
         byte[] message3 = "rspauth=9c4d137545617ba98c11aaea939b4381".getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -36,6 +36,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -617,6 +618,7 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
     @Test
+    @Ignore("Problem with encoding on Windows")
     public void testUtf8Charset() throws Exception {
         mockNonce("sn\u0438\u4F60\uD83C\uDCA1");
 

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -36,7 +36,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -62,7 +61,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         new MockUp<AbstractDigestMechanism>(){
             @Mock
             byte[] generateNonce(){
-                return nonce.getBytes();
+                return nonce.getBytes(StandardCharsets.UTF_8);
             }
         };
     }
@@ -618,7 +617,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
     @Test
-    @Ignore("Problem with encoding on Windows")
     public void testUtf8Charset() throws Exception {
         mockNonce("sn\u0438\u4F60\uD83C\uDCA1");
 

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -36,7 +36,6 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -86,7 +85,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA6MG9tEQGm2hh\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"imap/elwood.innosoft.com\",response=d388dad90d4bbd760a152321f2143af7,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=ea40f60335c427b5527b84dbabcdfffd", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=ea40f60335c427b5527b84dbabcdfffd", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -112,7 +111,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",response=6084c6db3fede7352c551284490fd0fc,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=2f0b3d7c3c2e486600ef710726aa2eae", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=2f0b3d7c3c2e486600ef710726aa2eae", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -123,7 +122,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authorization ID (authzid) of other user
      */
     @Test
-    @Ignore("ELY-90 : Permission check to use authorization id not implemented")
     public void testUnauthorizedAuthorizationId() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -168,7 +166,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",response=aa4e81f1c6656350f7bce05d436665de,qop=auth,authzid=\"chris\"".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
 
-        //assertEquals("rspauth=af3ca83a805d4cfa00675a17315475c4", new String(message3, "UTF-8"));
+        assertEquals("rspauth=af3ca83a805d4cfa00675a17315475c4", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -179,7 +177,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity protection (qop=auth-int)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthInt() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -196,7 +193,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA9BSuZWMSpW8m\",digest-uri=\"acap/elwood.innosoft.com\",maxbuf=65536,response=d8b17f55b410208c6ebb22f89f9d6cbb,qop=auth-int,authzid=\"chris\"".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=7a8794654d6d6de607e9143d52b554a8", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=7a8794654d6d6de607e9143d52b554a8", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
@@ -235,7 +232,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=default=3des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConf() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -291,7 +287,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc4() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -347,7 +342,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=des)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfDes() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -402,7 +396,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-56)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc456() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -458,7 +451,6 @@ public class CompatibilityServerTest extends BaseTestCase {
      * Test with authentication plus integrity and confidentiality protection (qop=auth-conf, cipher=rc4-40)
      */
     @Test
-    @Ignore("ELY-89 : Integrity and privacy not implemented")
     public void testQopAuthConfRc440() throws Exception {
         mockNonce("OA9BSXrbuRhWay");
 
@@ -614,17 +606,17 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"elwood.innosoft.com\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"\",digest-uri=\"acap/elwood.innosoft.com\",response=0ca21eafddf586f954909d2fd95b1ee7,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=2bf631e48acb9863e9f5518ccc804b3b", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=2bf631e48acb9863e9f5518ccc804b3b", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 
     }
 
+
     /**
      * Test successful authentication with Unicode chars (UTF-8 encoding)
      */
     @Test
-    @Ignore("Problem with encoding on Windows")
     public void testUtf8Charset() throws Exception {
         mockNonce("sn\u0438\u4F60\uD83C\uDCA1");
 
@@ -638,11 +630,12 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"\u0438\u4F60\uD83C\uDCA1\",realm=\"realm.\u0438\u4F60\uD83C\uDCA1.com\",nonce=\"sn\u0438\u4F60\uD83C\uDCA1\",nc=00000001,cnonce=\"cn\u0438\u4F60\uD83C\uDCA1\",digest-uri=\"\u0438\u4F60\uD83C\uDCA1/realm.\u0438\u4F60\uD83C\uDCA1.com\",maxbuf=65536,response=420939e06d2d748c157c5e33499b41a9,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("\u0438\u4F60\uD83C\uDCA1", server.getAuthorizationID());
 
     }
+
 
     /**
      * More realms from server (realm="other-realm",realm="elwood.innosoft.com",realm="next-realm" -> elwood.innosoft.com)
@@ -663,7 +656,7 @@ public class CompatibilityServerTest extends BaseTestCase {
 
         byte[] message2 = "charset=utf-8,username=\"chris\",realm=\"first realm\",nonce=\"OA9BSXrbuRhWay\",nc=00000001,cnonce=\"OA6MHXh6VqTrRk\",digest-uri=\"protocol name/server name\",maxbuf=65536,response=bf3dd710ee08b05c663456975c156075,qop=auth".getBytes(StandardCharsets.UTF_8);
         byte[] message3 = server.evaluateResponse(message2);
-        //assertEquals("rspauth=9c4d137545617ba98c11aaea939b4381", new String(message3, "UTF-8")); // TODO
+        assertEquals("rspauth=05a18aff49b22e373bb91af7396ce345", new String(message3, "UTF-8"));
         assertTrue(server.isComplete());
         assertEquals("chris", server.getAuthorizationID());
 

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
@@ -56,6 +56,10 @@ public class DigestUtilTest {
                 H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
                 "OA9BSXrbuRhWay".getBytes(), "OA9BSuZWMSpW8m".getBytes(), "chris", StandardCharsets.UTF_8)));
 
+        assertEquals("4e863a809aa7f7cc191be93705967394", HexConverter.convertToHexString(
+                H_A1(md, "\u0438\u4F60\uD83C\uDCA1", "realm.\u0438\u4F60\uD83C\uDCA1.com", "\u0438\u4F60\uD83C\uDCA1".toCharArray(),
+                "sn\u0438\u4F60\uD83C\uDCA1".getBytes(StandardCharsets.UTF_8), "cn\u0438\u4F60\uD83C\uDCA1".getBytes(StandardCharsets.UTF_8), null, StandardCharsets.UTF_8)));
+
     }
 
     @Test

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.digest._private;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import javax.crypto.Mac;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.security.sasl.digest.Digest;
+import org.wildfly.security.sasl.util.HexConverter;
+
+import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
+
+/**
+ * Digest SASL utilities tests
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class DigestUtilTest {
+
+    MessageDigest md;
+
+    @Before
+    public void init() throws Exception {
+        md = MessageDigest.getInstance(messageDigestAlgorithm(Digest.DIGEST_MD5));
+    }
+
+    @Test
+    public void testH_A1() throws Exception {
+
+        assertEquals("a2549853149b0536f01f0b850c643c57", HexConverter.convertToHexString(
+                H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                "OA6MG9tEQGm2hh".getBytes(), "OA6MHXh6VqTrRk".getBytes(), null, StandardCharsets.UTF_8)));
+
+        assertEquals("7f94ea5b1eb1b0573cca321e2b517b63", HexConverter.convertToHexString(
+                H_A1(md, "chris", "elwood.innosoft.com", "secret".toCharArray(),
+                "OA9BSXrbuRhWay".getBytes(), "OA9BSuZWMSpW8m".getBytes(), "chris", StandardCharsets.UTF_8)));
+
+    }
+
+    @Test
+    public void testDigestResponse() throws Exception {
+
+        assertEquals("d388dad90d4bbd760a152321f2143af7", new String(
+                digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", true)));
+
+        assertEquals("ea40f60335c427b5527b84dbabcdfffd", new String(
+                digestResponse(md, HexConverter.convertFromHex("a2549853149b0536f01f0b850c643c57"),
+                "OA6MG9tEQGm2hh".getBytes(), 1, "OA6MHXh6VqTrRk".getBytes(), null, "auth", "imap/elwood.innosoft.com", false)));
+
+        assertEquals("aa4e81f1c6656350f7bce05d436665de", new String(
+                digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", true)));
+
+        assertEquals("af3ca83a805d4cfa00675a17315475c4", new String(
+                digestResponse(md, HexConverter.convertFromHex("7f94ea5b1eb1b0573cca321e2b517b63"),
+                "OA9BSXrbuRhWay".getBytes(), 1, "OA9BSuZWMSpW8m".getBytes(), "chris", "auth", "acap/elwood.innosoft.com", false)));
+
+    }
+
+    @Test
+    /* LHEX = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "a" | "b" | "c" | "d" | "e" | "f" */
+    public void testConvertToHexBytesWithLeftPadding() throws Exception {
+        assertEquals("00000001", new String(convertToHexBytesWithLeftPadding(1, 8)));
+        assertEquals("0000002", new String(convertToHexBytesWithLeftPadding(2, 7)));
+        assertEquals("000a", new String(convertToHexBytesWithLeftPadding(10, 4)));
+        assertEquals("abc", new String(convertToHexBytesWithLeftPadding(0xABC, 3)));
+    }
+
+    @Test
+    public void testCreate3desSubKey() throws Exception {
+        byte[] input1 = HexConverter.convertFromHex("FFFFFFFFFFFFFF");
+        byte[] output1 = create3desSubKey(input1, 0, 7);
+        assertEquals("FEFEFEFEFEFEFEFE".toLowerCase(), HexConverter.convertToHexString(output1));
+
+        byte[] input2 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
+        byte[] output2 = create3desSubKey(input2, 0, 7);
+        assertEquals("D6E54919F22A929D".toLowerCase(), HexConverter.convertToHexString(output2));
+
+        byte[] input3 = HexConverter.convertFromHex("d7c920cf2564cec39c570490f7ea");
+        byte[] output3 = create3desSubKey(input3, 7, 7);
+        assertEquals("C2CE15E04986DFD5".toLowerCase(), HexConverter.convertToHexString(output3));
+    }
+
+    @Test
+    public void testComputeHmac() throws Exception {
+        Mac mac = Mac.getInstance("HmacMD5");
+        byte[] message = HexConverter.convertFromHex("11223344");
+        byte[] kc = HexConverter.convertFromHex("9fdbff3d48c87e74bd89460e2462c73a");
+        byte[] output = computeHMAC(kc, 0, mac, message, 0, message.length);
+        assertEquals("EF3E40D7B5A64C1DAE6B".toLowerCase(), HexConverter.convertToHexString(output));
+    }
+
+    @Test
+    public void testIntegerByteOrdered() throws Exception {
+        byte[] output0 = new byte[4];
+        integerByteOrdered(0x0, output0, 0, 4);
+        assertEquals("00000000".toLowerCase(), HexConverter.convertToHexString(output0));
+
+        byte[] output1 = new byte[4];
+        integerByteOrdered(0x1, output1, 0, 4);
+        assertEquals("00000001".toLowerCase(), HexConverter.convertToHexString(output1));
+
+        byte[] output1234 = new byte[6];
+        integerByteOrdered(0x1234, output1234, 1, 4);
+        assertEquals("000000123400".toLowerCase(), HexConverter.convertToHexString(output1234));
+
+        byte[] outputFFFFFFFF = new byte[4];
+        integerByteOrdered(0xFFFFFFFF, outputFFFFFFFF, 0, 4);
+        assertEquals("FFFFFFFF".toLowerCase(), HexConverter.convertToHexString(outputFFFFFFFF));
+    }
+
+    @Test
+    public void testDecodeByteOrderedInteger() throws Exception {
+        byte[] input0 = HexConverter.convertFromHex("00000000");
+        assertEquals(0x0, decodeByteOrderedInteger(input0, 0, 4));
+
+        byte[] input1 = HexConverter.convertFromHex("00000001");
+        assertEquals(0x1, decodeByteOrderedInteger(input1, 0, 4));
+
+        byte[] input1234 = HexConverter.convertFromHex("000000123400");
+        assertEquals(0x1234, decodeByteOrderedInteger(input1234, 1, 4));
+
+        byte[] input1234b = HexConverter.convertFromHex("000000123400");
+        assertEquals(0x1234, decodeByteOrderedInteger(input1234b, 3, 2));
+
+        byte[] inputFFFFFFFF = HexConverter.convertFromHex("FFFFFFFF");
+        assertEquals(0xFFFFFFFF, decodeByteOrderedInteger(inputFFFFFFFF, 0, 4));
+    }
+
+}


### PR DESCRIPTION
**Corrected version of #108:**
* Implemented step three (rspauth generation and checking)
* authzid checking (checking permission to use authorization id)
* QOP selection improved to select by client preferences (order of options in property)
* Fixed integrity (bad seqNum)
* Refactored cipher selection (exception when no common cipher)
* Utils from AbstractDigestMechanism moved into _private.DigestUtils and covered by tests
* Fixed bugs in encryption (+ refactoring)
* Integrity key calculation only at begin of communication, not in every wrap/unwrap