### PR TITLE
[ELY-157] Add checks that the algorithm does match where conversion to a different algorithm is not possible.

### DIFF
--- a/src/main/java/org/wildfly/security/password/spec/AlgorithmPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/AlgorithmPasswordSpec.java
@@ -1,6 +1,6 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2013 Red Hat, Inc., and individual contributors
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,21 +18,18 @@
 
 package org.wildfly.security.password.spec;
 
-public final class SimpleDigestPasswordSpec implements AlgorithmPasswordSpec {
-    private final String algorithm;
-    private final byte[] digest;
+/**
+ * An extension of {@link PasswordSpec} where the spec is tied to a specific algorithm.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface AlgorithmPasswordSpec extends PasswordSpec {
 
-    public SimpleDigestPasswordSpec(final String algorithm, final byte[] digest) {
-        this.algorithm = algorithm;
-        this.digest = digest;
-    }
+    /**
+     * Get the algorithm this spec instance is for.
+     *
+     * @return the algorithm this spec instance is for.
+     */
+    String getAlgorithm();
 
-    @Override
-    public String getAlgorithm() {
-        return algorithm;
-    }
-
-    public byte[] getDigest() {
-        return digest;
-    }
 }

--- a/src/main/java/org/wildfly/security/password/spec/SaltedSimpleDigestPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/SaltedSimpleDigestPasswordSpec.java
@@ -23,7 +23,7 @@ package org.wildfly.security.password.spec;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public final class SaltedSimpleDigestPasswordSpec implements PasswordSpec {
+public final class SaltedSimpleDigestPasswordSpec implements AlgorithmPasswordSpec {
 
     private final String algorithm;
     private final byte[] digest;
@@ -35,6 +35,7 @@ public final class SaltedSimpleDigestPasswordSpec implements PasswordSpec {
         this.salt = salt;
     }
 
+    @Override
     public String getAlgorithm() {
         return algorithm;
     }

--- a/src/main/java/org/wildfly/security/password/spec/ScramDigestPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/ScramDigestPasswordSpec.java
@@ -23,7 +23,7 @@ package org.wildfly.security.password.spec;
  *
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
  */
-public final class ScramDigestPasswordSpec implements PasswordSpec {
+public final class ScramDigestPasswordSpec implements AlgorithmPasswordSpec {
 
     private final String algorithm;
     private final byte[] digest;
@@ -45,6 +45,7 @@ public final class ScramDigestPasswordSpec implements PasswordSpec {
         this.iterationCount = iterationCount;
     }
 
+    @Override
     public String getAlgorithm() {
         return this.algorithm;
     }

--- a/src/main/java/org/wildfly/security/password/spec/SunUnixMD5CryptPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/SunUnixMD5CryptPasswordSpec.java
@@ -21,7 +21,7 @@ package org.wildfly.security.password.spec;
 /**
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-public final class SunUnixMD5CryptPasswordSpec implements PasswordSpec {
+public final class SunUnixMD5CryptPasswordSpec implements AlgorithmPasswordSpec {
     private final String algorithm;
     private final byte[] hash;
     private final byte[] salt;
@@ -34,6 +34,7 @@ public final class SunUnixMD5CryptPasswordSpec implements PasswordSpec {
         this.iterationCount = iterationCount;
     }
 
+    @Override
     public String getAlgorithm() {
         return algorithm;
     }

--- a/src/main/java/org/wildfly/security/password/spec/UnixSHACryptPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/UnixSHACryptPasswordSpec.java
@@ -18,7 +18,7 @@
 
 package org.wildfly.security.password.spec;
 
-public final class UnixSHACryptPasswordSpec implements PasswordSpec {
+public final class UnixSHACryptPasswordSpec implements AlgorithmPasswordSpec {
     private final byte[] hashBytes;
     private final byte[] salt;
     private final int iterationCount;
@@ -52,6 +52,7 @@ public final class UnixSHACryptPasswordSpec implements PasswordSpec {
         return iterationCount;
     }
 
+    @Override
     public String getAlgorithm() {
         return algorithm;
     }


### PR DESCRIPTION
PasswordFactorySpi does not currently feel like a clean place to convert Password instances from an alternative PasswordFactorySpi implementation - maybe the correct approach is to go to KeySpec first anyway if using two different providers.

Without these checks if someone say requests a SHA PasswordFactorySpi and passed in a MD5 variant of a password we claim we can support conversion to SHA, we then pretend conversion happened but in the end we pass back the MD5 variant 

However where conversion is really possible (so far only for clear) then that can continue to be supported.