### PR TITLE
[RFC] [ELY-151] Allow a CallbackHandler to be supplied to the SecurityRealm and RealmIdentity.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/provider/RealmIdentity.java
@@ -20,6 +20,8 @@ package org.wildfly.security.auth.provider;
 
 import java.security.Principal;
 
+import javax.security.auth.callback.CallbackHandler;
+
 /**
  * A representation of a pre-authentication identity.
  *
@@ -52,6 +54,26 @@ public interface RealmIdentity {
     CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException;
 
     /**
+     * Determine whether a given credential is definitely supported, possibly supported, or definitely not supported for this
+     * identity.
+     *
+     * By default if a realm does not implement this method {@link #getCredentialSupport(Class)} will be called instead and the
+     * supplied {@link CallbackHandler} ignored.
+     *
+     * Note: Where the {@link CallbackHandler} supplies information to the realm it should not be assumed that information is
+     * permanently valid, i.e. the client of the {@link SecurityRealm} and this {@link RealmIdentity} may be querying if a
+     * specific capability is supported and subsequently decide not to use that capability.
+     *
+     * @param credentialType the credential type
+     * @param callbackHandler the {@link CallbackHandler} that can supply additional information to the realm.
+     * @return the level of support for this credential type
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
+     */
+    default CredentialSupport getCredentialSupport(Class<?> credentialType, CallbackHandler callbackHandler) throws RealmUnavailableException {
+        return getCredentialSupport(credentialType);
+    }
+
+    /**
      * Acquire a credential of the given type.
      *
      * @param credentialType the credential type class
@@ -60,6 +82,26 @@ public interface RealmIdentity {
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
      */
     <C> C getCredential(Class<C> credentialType) throws RealmUnavailableException;
+
+    /**
+     * Acquire a credential of the given type.
+     *
+     * By default if a realm does not implement this method {@link #getCredential(Class)} will be called instead and the
+     * supplied {@link CallbackHandler} ignored.
+     *
+     * Note: Where the {@link CallbackHandler} supplies information to the realm it should not be assumed that information is
+     * permanently valid, i.e. the client of the {@link SecurityRealm} and this {@link RealmIdentity} may be querying if a
+     * specific capability is supported and subsequently decide not to use that capability.
+     *
+     * @param credentialType the credential type class
+     * @param <C> the credential type
+     * @param callbackHandler the {@link CallbackHandler} that can supply additional information to the realm.
+     * @return the credential, or {@code null} if the principal has no credential of that type
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
+     */
+    default <C> C getCredential(Class<C> credentialType, CallbackHandler callbackHandler) throws RealmUnavailableException {
+        return getCredential(credentialType);
+    }
 
     /**
      * Verify the given credential.

--- a/src/main/java/org/wildfly/security/auth/provider/SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/SecurityRealm.java
@@ -20,6 +20,8 @@ package org.wildfly.security.auth.provider;
 
 import java.security.Principal;
 
+import javax.security.auth.callback.CallbackHandler;
+
 
 /**
  * A single authentication realm. A realm is backed by a single homogeneous store of identities and credentials.
@@ -40,6 +42,7 @@ public interface SecurityRealm {
      *
      * @param name The name to use when creating the {@link RealmIdentity}
      * @return The {@link RealmIdentity} for the provided {@code name} or {@code null}
+     * @throws RealmUnavailableException if this realm is currently unable to handle requests.
      */
     RealmIdentity createRealmIdentity(String name) throws RealmUnavailableException;
 
@@ -50,6 +53,7 @@ public interface SecurityRealm {
      *
      * @param principal The principal to use to create the {@link RealmIdentity}
      * @return The {@link RealmIdentity} for the provided {@code principal} or {@code null}
+     * @throws RealmUnavailableException if this realm is currently unable to handle requests.
      */
     RealmIdentity createRealmIdentity(Principal principal) throws RealmUnavailableException;
 
@@ -59,7 +63,23 @@ public interface SecurityRealm {
      *
      * @param credentialType the credential type
      * @return the level of support for this credential type
+     * @throws RealmUnavailableException if this realm is currently unable to handle requests.
      */
     CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException;
+
+    /**
+     * Determine whether a given credential is definitely supported, possibly supported (for some identities), or definitely not
+     * supported.
+     *
+     * By default if a realm does not implement this method {@link #getCredentialSupport(Class)} will be called instead and the supplied {@link CallbackHandler} ignored.
+     *
+     * @param credentialType the credential type.
+     * @param callbackHandler the {@link CallbackHandler} that can supply additional information to the realm.
+     * @return the level of support for this credential type.
+     * @throws RealmUnavailableException if this realm is currently unable to handle requests.
+     */
+    default CredentialSupport getCredentialSupport(Class<?> credentialType, CallbackHandler callbackHandler) throws RealmUnavailableException {
+        return getCredentialSupport(credentialType);
+    }
 
 }


### PR DESCRIPTION
Sending this PR in early whilst I am exploring the overall capabilities of this API.

Following on from this PR I will create a test case for ELY-153 which is about verifying the API can accomplish a number of tasks, in that case it is in the context of Digest authentication where there are currently some gaps in how we can work with the realm names associated with the credentials and also how we can work with different MessageDigest algorithms.

Following on from that I will undertake a similar exercise for ELY-154 where the same requirements for ELY-153 need to be taken into account but now the credential generated also needs to take in some additional information to make session specific.
