### PR TITLE
[ELY-151] Association of additional type with a Password so it can be passed to getCredentialSupport and getCredential calls.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/provider/RealmIdentity.java
@@ -20,6 +20,8 @@ package org.wildfly.security.auth.provider;
 
 import java.security.Principal;
 
+import org.wildfly.security.password.AugmentedPassword;
+
 /**
  * A representation of a pre-authentication identity.
  *
@@ -42,14 +44,25 @@ public interface RealmIdentity {
     Principal getPrincipal() throws RealmUnavailableException;
 
     /**
-     * Determine whether a given credential is definitely supported, possibly supported, or definitely not supported for this
-     * identity.
+     * Determine level of credential support for this identity.
      *
      * @param credentialType the credential type
      * @return the level of support for this credential type
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
      */
     CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException;
+
+    /**
+     * Determine level of credential support for this identity.
+     *
+     * @param credentialType the credential type
+     * @param metaData additional credential specific meta-data.
+     * @return the level of support for this credential type
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
+     */
+    default <M> CredentialSupport getCredentialSupport(Class<? extends AugmentedPassword<M>> credentialType, M metaData) throws RealmUnavailableException {
+        return getCredentialSupport(credentialType);
+    }
 
     /**
      * Acquire a credential of the given type.
@@ -60,6 +73,19 @@ public interface RealmIdentity {
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
      */
     <C> C getCredential(Class<C> credentialType) throws RealmUnavailableException;
+
+    /**
+     * Acquire a credential of the given type.
+     *
+     * @param credentialType the credential type class
+     * @param <C> the credential type
+     * @param metaData additional credential specific meta-data.
+     * @return the credential, or {@code null} if the principal has no credential of that type
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason.
+     */
+    default <C extends AugmentedPassword<M>, M> C getCredential(Class<C> credentialType, M metaData) throws RealmUnavailableException {
+        return getCredential(credentialType);
+    }
 
     /**
      * Verify the given credential.

--- a/src/main/java/org/wildfly/security/auth/provider/SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/SecurityRealm.java
@@ -20,6 +20,8 @@ package org.wildfly.security.auth.provider;
 
 import java.security.Principal;
 
+import org.wildfly.security.password.AugmentedPassword;
+
 
 /**
  * A single authentication realm. A realm is backed by a single homogeneous store of identities and credentials.
@@ -61,5 +63,9 @@ public interface SecurityRealm {
      * @return the level of support for this credential type
      */
     CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException;
+
+    default <M> CredentialSupport getCredentialSupport(Class<? extends AugmentedPassword<M>> credentialType, M metaData) throws RealmUnavailableException {
+        return getCredentialSupport(credentialType);
+    }
 
 }

--- a/src/main/java/org/wildfly/security/password/AugmentedPassword.java
+++ b/src/main/java/org/wildfly/security/password/AugmentedPassword.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.password;
+
+/**
+ * Special interface to allow a meta data type to be associated with a {@link Password} so that the specified type can be passed to calls
+ * on the {@link SecurityRealm} and {@link RealmIdentity}.
+ *
+ * One example where this may be used is where a {@link Password} type supports multiple algorithms
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface AugmentedPassword<M> extends Password {
+
+}

--- a/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
@@ -38,6 +38,8 @@ import org.wildfly.security.password.spec.EncryptablePasswordSpec;
  */
 class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword {
 
+    private static final long serialVersionUID = -6865263194048232853L;
+
     private final String algorithm;
     private final String username;
     private final String realm;

--- a/src/main/java/org/wildfly/security/password/interfaces/DigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/DigestPassword.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.password.interfaces;
 
+import org.wildfly.security.password.AugmentedPassword;
 import org.wildfly.security.password.OneWayPassword;
 
 /**
@@ -25,7 +26,7 @@ import org.wildfly.security.password.OneWayPassword;
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public interface DigestPassword extends OneWayPassword {
+public interface DigestPassword extends OneWayPassword, AugmentedPassword<DigestPassword.MetaData> {
 
     String ALGORITHM_DIGEST_MD5 = "digest-md5";
     String ALGORITHM_DIGEST_SHA = "digest-sha";
@@ -58,5 +59,29 @@ public interface DigestPassword extends OneWayPassword {
      * @return The digest represented by this {@link Password}
      */
     byte[] getDigest();
+
+    /**
+     * Additional MetaData that can be specified when querying support for a credential type or obtaining the credential type.
+     *
+     * In the case of the {@link DigestPassword} the realm and or algorithm can be specified.
+     */
+    static class MetaData {
+        private final String realm;
+        private final String algorithm;
+
+        public MetaData(final String realm, final String algorithm) {
+            this.realm = realm;
+            this.algorithm = algorithm;
+        }
+
+        public String getRealm() {
+            return realm;
+        }
+
+        public String getAlgorithm() {
+            return algorithm;
+        }
+
+    }
 
 }

--- a/src/test/java/org/wildfly/security/api/DigestRealmSelectionTest.java
+++ b/src/test/java/org/wildfly/security/api/DigestRealmSelectionTest.java
@@ -110,6 +110,7 @@ public class DigestRealmSelectionTest {
     /**
      * Test case where users have multiple credentials, each for a different realm but all users share the same set.
      */
+    @Test
     public void testMultipleConsistentRealms() throws GeneralSecurityException {
         SecurityRealm realm = RealmBuilder.newInstance()
                 .addUser("user1").addPassword(digestPassword("user1", "realm1", "password")).addPassword(digestPassword("user1", "realm2", "password")).build()
@@ -126,7 +127,7 @@ public class DigestRealmSelectionTest {
         assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class));
         assertEquals("realm1 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
         assertEquals("realm2 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
-        assertEquals("realm3 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+        assertEquals("realm3 support", CredentialSupport.UNSUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
 
         DigestPassword digestPassword = identity2.getCredential(DigestPassword.class);
         assertEquals("user2", digestPassword.getUsername());
@@ -146,6 +147,7 @@ public class DigestRealmSelectionTest {
      *
      * For this test there will be one common realm in addition.
      */
+    @Test
     public void testRealmVariety() throws GeneralSecurityException {
         SecurityRealm realm = RealmBuilder.newInstance()
                 .addUser("user1").addPassword(digestPassword("user1", "realm1", "password")).addPassword(digestPassword("user1", "realm2", "password")).build()
@@ -163,7 +165,7 @@ public class DigestRealmSelectionTest {
         assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class));
         assertEquals("realm1 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
         assertEquals("realm2 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
-        assertEquals("realm3 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+        assertEquals("realm3 support", CredentialSupport.UNSUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
 
         DigestPassword digestPassword = identity2.getCredential(DigestPassword.class);
         assertEquals("user2", digestPassword.getUsername());

--- a/src/test/java/org/wildfly/security/api/DigestRealmSelectionTest.java
+++ b/src/test/java/org/wildfly/security/api/DigestRealmSelectionTest.java
@@ -1,0 +1,400 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.security.GeneralSecurityException;
+import java.security.Principal;
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.provider.AuthenticatedRealmIdentity;
+import org.wildfly.security.auth.provider.CredentialSupport;
+import org.wildfly.security.auth.provider.RealmIdentity;
+import org.wildfly.security.auth.provider.RealmUnavailableException;
+import org.wildfly.security.auth.provider.SecurityRealm;
+import org.wildfly.security.auth.provider.SupportLevel;
+import org.wildfly.security.password.AugmentedPassword;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.impl.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.DigestPassword;
+import org.wildfly.security.password.interfaces.DigestPassword.MetaData;
+import org.wildfly.security.password.spec.DigestPasswordAlgorithmSpec;
+import org.wildfly.security.password.spec.EncryptablePasswordSpec;
+
+/**
+ * Test case to verify that a digest based authentication mechanism can follow a couple of different approaches when it comes to
+ * selecting a realm name to use for authentication.
+ *
+ * For the purpose of this test I am deliberately not covering clear text representations, these need to be considered in some
+ * form of translation layer - this test is specifically about the additional information specified to identify if there is a
+ * stored representation for a specific realm.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class DigestRealmSelectionTest {
+
+    private static final Provider provider = new WildFlyElytronPasswordProvider();
+
+    @BeforeClass
+    public static void registerProvider() {
+        Security.addProvider(provider);
+    }
+
+    @AfterClass
+    public static void removeProvider() {
+        Security.removeProvider(provider.getName());
+    }
+
+    /**
+     * Test case where all users in a realm are associated with a single realm name and the authentication mechanism is able to
+     * discover that using the Elytron APIs.
+     *
+     * @throws GeneralSecurityException
+     */
+    @Test
+    public void testSingleRealm() throws GeneralSecurityException {
+        SecurityRealm realm = RealmBuilder.newInstance()
+                .addUser("user1").addPassword(digestPassword("user1", "realm1", "password")).build()
+                .addUser("user2").addPassword(digestPassword("user2", "realm1", "password")).build()
+                .addUser("user3").addPassword(digestPassword("user3", "realm1", "password")).build()
+                .build();
+
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 Support", CredentialSupport.UNSUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+
+        RealmIdentity identity2 = realm.createRealmIdentity("user2");
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 support", CredentialSupport.UNSUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+
+        DigestPassword digestPassword = identity2.getCredential(DigestPassword.class);
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm1", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm1", null));
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm1", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm2", null));
+        assertNull(digestPassword);
+    }
+
+    /**
+     * Test case where users have multiple credentials, each for a different realm but all users share the same set.
+     */
+    public void testMultipleConsistentRealms() throws GeneralSecurityException {
+        SecurityRealm realm = RealmBuilder.newInstance()
+                .addUser("user1").addPassword(digestPassword("user1", "realm1", "password")).addPassword(digestPassword("user1", "realm2", "password")).build()
+                .addUser("user2").addPassword(digestPassword("user2", "realm1", "password")).addPassword(digestPassword("user2", "realm2", "password")).build()
+                .addUser("user3").addPassword(digestPassword("user3", "realm1", "password")).addPassword(digestPassword("user3", "realm2", "password")).build()
+                .build();
+
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+        assertEquals("realm3 Support", CredentialSupport.UNSUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+
+        RealmIdentity identity2 = realm.createRealmIdentity("user2");
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+        assertEquals("realm3 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+
+        DigestPassword digestPassword = identity2.getCredential(DigestPassword.class);
+        assertEquals("user2", digestPassword.getUsername());
+        assertTrue("Realm Name", "realm1".equals(digestPassword.getRealm()) || "realm2".equals(digestPassword.getRealm()));
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm1", null));
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm1", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm2", null));
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm2", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm3", null));
+        assertNull(digestPassword);
+    }
+
+    /**
+     * Test case where different users have different realms.
+     *
+     * For this test there will be one common realm in addition.
+     */
+    public void testRealmVariety() throws GeneralSecurityException {
+        SecurityRealm realm = RealmBuilder.newInstance()
+                .addUser("user1").addPassword(digestPassword("user1", "realm1", "password")).addPassword(digestPassword("user1", "realm2", "password")).build()
+                .addUser("user2").addPassword(digestPassword("user2", "realm1", "password")).addPassword(digestPassword("user2", "realm2", "password")).build()
+                .addUser("user3").addPassword(digestPassword("user3", "realm1", "password")).addPassword(digestPassword("user3", "realm3", "password")).build()
+                .build();
+
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 Support", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 Support", CredentialSupport.UNKNOWN, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+        assertEquals("realm3 Support", CredentialSupport.UNKNOWN, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+        assertEquals("realm4 Support", CredentialSupport.UNSUPPORTED, realm.getCredentialSupport(DigestPassword.class, new MetaData("realm4", null)));
+
+        RealmIdentity identity2 = realm.createRealmIdentity("user2");
+        assertEquals("General Credential Support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class));
+        assertEquals("realm1 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm1", null)));
+        assertEquals("realm2 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm2", null)));
+        assertEquals("realm3 support", CredentialSupport.FULLY_SUPPORTED, identity2.getCredentialSupport(DigestPassword.class, new MetaData("realm3", null)));
+
+        DigestPassword digestPassword = identity2.getCredential(DigestPassword.class);
+        assertEquals("user2", digestPassword.getUsername());
+        assertTrue("Realm Name", "realm1".equals(digestPassword.getRealm()) || "realm2".equals(digestPassword.getRealm()));
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm1", null));
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm1", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm2", null));
+        assertEquals("user2", digestPassword.getUsername());
+        assertEquals("realm2", digestPassword.getRealm());
+        digestPassword = identity2.getCredential(DigestPassword.class, new MetaData("realm3", null));
+        assertNull(digestPassword);
+    }
+
+    private static DigestPassword digestPassword(String username, String realm, String password) throws GeneralSecurityException {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(DigestPassword.ALGORITHM_DIGEST_MD5);
+
+        DigestPasswordAlgorithmSpec dpas = new DigestPasswordAlgorithmSpec(DigestPassword.ALGORITHM_DIGEST_MD5, username, realm);
+        EncryptablePasswordSpec encryptable = new EncryptablePasswordSpec(password.toCharArray(), dpas);
+
+        return (DigestPassword) passwordFactory.generatePassword(encryptable);
+    }
+
+    private interface CredentialMatcher {
+        boolean matches(final String realmName, final String algorithm);
+    }
+
+    private static class RealmBuilder {
+
+        private Map<String, List<DigestPassword>> userPasswordsMap = new HashMap<String, List<DigestPassword>>();
+
+        private RealmBuilder() {
+
+        }
+
+        public static RealmBuilder newInstance() {
+            return new RealmBuilder();
+        }
+
+        public UserBuilder addUser(final String username) {
+            return new UserBuilder(this, username);
+        }
+
+        private void storeUser(final String username, final List<DigestPassword> passwords) {
+            userPasswordsMap.put(username, passwords);
+        }
+
+        public SecurityRealm build() {
+            return new SecurityRealm() {
+
+                private boolean matches(DigestPassword password, CredentialMatcher credentialMatcher) {
+                    return credentialMatcher.matches(password.getRealm(), password.getAlgorithm());
+                }
+
+                private boolean obtainable(List<DigestPassword> passwords, CredentialMatcher credentialMatcher) {
+                    for (DigestPassword current : passwords) {
+                        if (matches(current, credentialMatcher)) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                private SupportLevel obtainable(CredentialMatcher credentialMatcher) {
+                    SupportLevel obtainable = null;
+                    for (List<DigestPassword> entry : userPasswordsMap.values()) {
+                        if (obtainable(entry, credentialMatcher)) {
+                            if (obtainable == null) {
+                                obtainable = SupportLevel.SUPPORTED;
+                            } else if (obtainable == SupportLevel.UNSUPPORTED) {
+                                obtainable = SupportLevel.POSSIBLY_SUPPORTED;
+                            }
+                        } else if (obtainable == null) {
+                            obtainable = SupportLevel.UNSUPPORTED;
+                        } else if (obtainable == SupportLevel.SUPPORTED) {
+                            obtainable = SupportLevel.POSSIBLY_SUPPORTED;
+                        }
+                    }
+
+                    return obtainable;
+                }
+
+                private CredentialSupport getCredentialSupport(Class<?> credentialType, CredentialMatcher credentialMatcher) {
+                    CredentialSupport support = CredentialSupport.UNSUPPORTED;
+                    if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                        SupportLevel obtainable = obtainable(credentialMatcher);
+
+                        support = CredentialSupport.getCredentialSupport(obtainable, obtainable);
+                    }
+                    return support;
+                }
+
+                @Override
+                public CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException {
+                    return getCredentialSupport(credentialType, (String realmName, String algorithm) -> true);
+                }
+
+                @Override
+                public <M> CredentialSupport getCredentialSupport(Class<? extends AugmentedPassword<M>> credentialType, M metaData) throws RealmUnavailableException {
+                    final String requiredRealm;
+                    final String requiredAlgorithm;
+                    if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                        MetaData digestMetaData = (MetaData) metaData;
+                        requiredRealm = digestMetaData.getRealm();
+                        requiredAlgorithm = digestMetaData.getAlgorithm();
+                    } else {
+                        requiredRealm = null;
+                        requiredAlgorithm = null;
+                    }
+
+                    return getCredentialSupport(credentialType, (CredentialMatcher)
+                            (String realmName, String algorithm) -> (requiredRealm == null || requiredRealm.equals(realmName))
+                                    && (requiredAlgorithm == null || requiredAlgorithm.equals(algorithm)));
+                }
+
+                @Override
+                public RealmIdentity createRealmIdentity(Principal principal) throws RealmUnavailableException {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public RealmIdentity createRealmIdentity(final String name) throws RealmUnavailableException {
+                    final List<DigestPassword> passwords = userPasswordsMap.containsKey(name) ? userPasswordsMap.get(name) : Collections.emptyList();
+
+                    return new RealmIdentity() {
+
+                        @Override
+                        public Principal getPrincipal() throws RealmUnavailableException {
+                            return new NamePrincipal(name);
+                        }
+
+                        @Override
+                        public CredentialSupport getCredentialSupport(Class<?> credentialType) throws RealmUnavailableException {
+                            CredentialSupport support = CredentialSupport.UNSUPPORTED;
+                            if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                                support = getCredentialSupport((Class<DigestPassword>)credentialType, new MetaData(null, null));
+                            }
+                            return support;
+                        }
+
+                        @Override
+                        public <M> CredentialSupport getCredentialSupport(Class<? extends AugmentedPassword<M>> credentialType, M metaData) throws RealmUnavailableException {
+                            CredentialSupport support = CredentialSupport.UNSUPPORTED;
+                            if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                                MetaData digestMetaData = (MetaData)metaData;
+                                final String requiredRealm = digestMetaData.getRealm();
+                                final String requiredAlgorithm = digestMetaData.getAlgorithm();
+
+                                if (obtainable(passwords, (String realmName, String algorithm) -> (requiredRealm == null || requiredRealm.equals(realmName))
+                                        && (requiredAlgorithm == null || requiredAlgorithm.equals(algorithm)))) {
+                                    support = CredentialSupport.FULLY_SUPPORTED;
+                                }
+
+                            }
+                            return support;
+                        }
+
+                        private DigestPassword getCredential(CredentialMatcher credentialMatcher) {
+                            for (DigestPassword current : passwords) {
+                                if (matches(current, credentialMatcher)) {
+                                    return current;
+                                }
+                            }
+
+                            return null;
+                        }
+
+                        @Override
+                        public <C> C getCredential(Class<C> credentialType) throws RealmUnavailableException {
+                            if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                                return credentialType.cast(getCredential( (Class<DigestPassword>)credentialType , new MetaData(null, null) ));
+                            }
+                            return null;
+                        }
+
+                        @Override
+                        public <C extends AugmentedPassword<M>, M> C getCredential(Class<C> credentialType, M metaData)
+                                throws RealmUnavailableException {
+                            if (credentialType.isAssignableFrom(DigestPassword.class)) {
+                                MetaData digestMetaData = (MetaData)metaData;
+                                final String requiredRealm = digestMetaData.getRealm();
+                                final String requiredAlgorithm = digestMetaData.getAlgorithm();
+
+                                return credentialType.cast(getCredential((String realmName, String algorithm) -> (requiredRealm == null || requiredRealm.equals(realmName))
+                                        && (requiredAlgorithm == null || requiredAlgorithm.equals(algorithm))));
+                            }
+                            return null;
+                        }
+
+                        @Override
+                        public AuthenticatedRealmIdentity getAuthenticatedRealmIdentity() throws RealmUnavailableException {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public boolean verifyCredential(Object credential) throws RealmUnavailableException {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public void dispose() {
+                            throw new UnsupportedOperationException();
+                        }
+                    };
+                }
+
+            };
+        }
+    }
+
+    private static class UserBuilder {
+
+        private final RealmBuilder realmBuilder;
+        private final String username;
+        private final List<DigestPassword> passwords = new ArrayList<DigestPassword>();
+
+        private UserBuilder(RealmBuilder realmBuilder, final String username) {
+            this.realmBuilder = realmBuilder;
+            this.username = username;
+        }
+
+        public UserBuilder addPassword(final DigestPassword password) {
+            passwords.add(password);
+
+            return this;
+        }
+
+        public RealmBuilder build() {
+            realmBuilder.storeUser(username, passwords);
+            return realmBuilder;
+        }
+    }
+}

--- a/src/test/java/org/wildfly/security/api/package-info.java
+++ b/src/test/java/org/wildfly/security/api/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package for API specific tests.
+ *
+ * i.e. The tests here verify the API rather than the implementation.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+package org.wildfly.security.api;


### PR DESCRIPTION
An alternative attempt without the use of a CallbackHandler.

This is now following the approach of enabling one additional piece of meta data to be used in querying the credentials support and credential acquisition.

 