### PR TITLE
Fix of few minor build warnings

### DIFF
--- a/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
+++ b/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
@@ -529,6 +529,7 @@ public final class WildFlySecurityManager extends SecurityManager {
         return false;
     }
 
+    @Deprecated
     public void checkMemberAccess(final Class<?> clazz, final int which) {
         final Context ctx = CTX.get();
         if (doCheck(ctx)) {

--- a/src/main/java/org/wildfly/security/util/NumericIterator.java
+++ b/src/main/java/org/wildfly/security/util/NumericIterator.java
@@ -362,7 +362,7 @@ abstract class NumericIterator {
     public ByteIterator base64Decode(final Alphabet alphabet, boolean requirePadding) {
         if (! hasNext()) return ByteIterator.EMPTY;
         if (alphabet.littleEndian) {
-            return new Base64ByteIterator(requirePadding) {
+            return this.new Base64ByteIterator(requirePadding) {
                 int calc0(final int b0, final int b1) {
                     final int d0 = alphabet.decode(b0);
                     final int d1 = alphabet.decode(b1);
@@ -391,7 +391,7 @@ abstract class NumericIterator {
                 }
             };
         } else {
-            return new Base64ByteIterator(requirePadding) {
+            return this.new Base64ByteIterator(requirePadding) {
                 int calc0(final int b0, final int b1) {
                     final int d0 = alphabet.decode(b0);
                     final int d1 = alphabet.decode(b1);


### PR DESCRIPTION
Fix of few minor build warnings:
* `[WARNING] .../WildFlySecurityManager.java:[532,17] checkMemberAccess(java.lang.Class<?>,int) in java.lang.SecurityManager has been deprecated`
 * in JDK 8 is this method deprecated, so it must be deprecated in subclass too
* `No enclosing instance of type NumericIterator is available due to some intermediate constructor invocation`
 * constructor must be called with `this`