### PR TITLE
[ELY-81] Differentiate between Unix DES Crypt and the BSD variant of Unix DES Crypt in {crypt} userPassword representations

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
@@ -22,6 +22,7 @@ import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.U
 import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.parseUserPassword;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 import static org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES;
+import static org.wildfly.security.password.interfaces.UnixDESCryptPassword.ALGORITHM_CRYPT_DES;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -40,6 +41,7 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.PasswordSpec;
 import org.wildfly.security.password.spec.SimpleDigestPasswordSpec;
 import org.wildfly.security.password.spec.SaltedSimpleDigestPasswordSpec;
+import org.wildfly.security.password.spec.UnixDESCryptPasswordSpec;
 
 /**
  * A {@link CredentialLoader} for loading credentials stored within the 'userPassword' attribute of LDAP entries.
@@ -137,6 +139,8 @@ class UserPasswordCredentialLoader implements CredentialLoader {
                 return ((SaltedSimpleDigestPasswordSpec) passwordSpec).getAlgorithm();
             } else if (passwordSpec instanceof BSDUnixDESCryptPasswordSpec) {
                 return ALGORITHM_BSD_CRYPT_DES;
+            } else if (passwordSpec instanceof UnixDESCryptPasswordSpec) {
+                return ALGORITHM_CRYPT_DES;
             }
 
             return null;

--- a/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/UserPasswordSuiteChild.java
@@ -41,6 +41,7 @@ import org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.SimpleDigestPassword;
 import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
+import org.wildfly.security.password.interfaces.UnixDESCryptPassword;
 
 /**
  * Test case to test access to passwords stored in LDAP using the 'userPassword' attribute.
@@ -76,6 +77,7 @@ public class UserPasswordSuiteChild {
                 .addCredentialSupport(SimpleDigestPassword.class, CredentialSupport.UNKNOWN)
                 .addCredentialSupport(SaltedSimpleDigestPassword.class, CredentialSupport.UNKNOWN)
                 .addCredentialSupport(BSDUnixDESCryptPassword.class, CredentialSupport.UNKNOWN)
+                .addCredentialSupport(UnixDESCryptPassword.class, CredentialSupport.UNKNOWN)
                 .build()
                 .build();
     }
@@ -112,7 +114,17 @@ public class UserPasswordSuiteChild {
 
     @Test
     public void testCryptUser() throws Exception {
-        performSimpleNameTest("cryptUser", BSDUnixDESCryptPassword.class, BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES, "cryptIt".toCharArray());
+        performSimpleNameTest("cryptUser", UnixDESCryptPassword.class, UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptIt".toCharArray());
+    }
+
+    @Test
+    public void testCryptUserLongPassword() throws Exception {
+        performSimpleNameTest("cryptUserLong", UnixDESCryptPassword.class, UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptPassword".toCharArray());
+    }
+
+    @Test
+    public void testBsdCryptUser() throws Exception {
+        performSimpleNameTest("bsdCryptUser", BSDUnixDESCryptPassword.class, BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES, "cryptPassword".toCharArray());
     }
 
     private void performSimpleNameTest(String simpleName, Class<?> credentialType, String algorithm, char[] password) throws NoSuchAlgorithmException, InvalidKeyException, RealmUnavailableException {

--- a/src/test/resources/Elytron.ldif
+++ b/src/test/resources/Elytron.ldif
@@ -80,7 +80,28 @@ cn: cryptUser
 sn: cryptUser
 uid: cryptUser
 userPassword:: e2NyeXB0fWI0Ym5OZVI4VmVjNkk=
+# Password cryptIt
+
+dn: uid=cryptUserLong,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: cryptUserLong
+sn: cryptUserLong
+uid: cryptUserLong
+userPassword:: e2NyeXB0fUZjb3B0aG9ybUlBcE0=
 # Password cryptPassword
 
+dn: uid=bsdCryptUser,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: bsdCryptUser
+sn: bsdCryptUser
+uid: bsdCryptUser
+userPassword:: e2NyeXB0fV9OLi4uL1RUcHlCeVRWdmRtV0dv
+# Password cryptPassword
 
 


### PR DESCRIPTION
{crypt} passwords in Apache DS longer than 8 characters weren't compatible with Elytron because Apache DS uses the standard Unix DES Crypt algorithm instead of the BSD variant of the algorithm (the standard algorithm ignores all characters after the 8th character unlike the BSD variant). I've updated UserPasswordPasswordUtil so that it can now handle both of these password types. 

https://issues.jboss.org/browse/ELY-81 