### PR TITLE
Add SASL server and client factories which allow the server name and/or protocol to be overridden

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/util/ProtocolSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/ProtocolSaslClientFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.util;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+/**
+ * A {@code SaslClientFactory} which sets the protocol name to a fixed value, disregarding the passed in value.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class ProtocolSaslClientFactory extends AbstractDelegatingSaslClientFactory {
+    private final String protocol;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param delegate the delegate client factory
+     * @param protocol the protocol name to use
+     */
+    public ProtocolSaslClientFactory(final SaslClientFactory delegate, final String protocol) {
+        super(delegate);
+        this.protocol = protocol;
+    }
+
+    public SaslClient createSaslClient(final String[] mechanisms, final String authorizationId, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        return super.createSaslClient(mechanisms, authorizationId, this.protocol, serverName, props, cbh);
+    }
+}

--- a/src/main/java/org/wildfly/security/sasl/util/ProtocolSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/ProtocolSaslServerFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.util;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+import javax.security.sasl.SaslException;
+
+/**
+ * A {@code SaslServerFactory} which sets the protocol name to a fixed value, disregarding the passed in value.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class ProtocolSaslServerFactory extends AbstractDelegatingSaslServerFactory {
+    private final String protocol;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param delegate the delegate server factory
+     * @param protocol the protocol name to use
+     */
+    public ProtocolSaslServerFactory(final SaslServerFactory delegate, final String protocol) {
+        super(delegate);
+        this.protocol = protocol;
+    }
+
+    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        return super.createSaslServer(mechanism, this.protocol, serverName, props, cbh);
+    }
+}

--- a/src/main/java/org/wildfly/security/sasl/util/ServerNameSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/ServerNameSaslClientFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.util;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+/**
+ * A {@code SaslClientFactory} which sets the server name to a fixed value, disregarding the passed in value.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class ServerNameSaslClientFactory extends AbstractDelegatingSaslClientFactory {
+    private final String serverName;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param delegate the delegate client factory
+     * @param serverName the server name to use
+     */
+    public ServerNameSaslClientFactory(final SaslClientFactory delegate, final String serverName) {
+        super(delegate);
+        this.serverName = serverName;
+    }
+
+    public SaslClient createSaslClient(final String[] mechanisms, final String authorizationId, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        return super.createSaslClient(mechanisms, authorizationId, protocol, this.serverName, props, cbh);
+    }
+}

--- a/src/main/java/org/wildfly/security/sasl/util/ServerNameSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/ServerNameSaslServerFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.util;
+
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+import javax.security.sasl.SaslException;
+
+/**
+ * A {@code SaslServerFactory} which sets the server name to a fixed value, disregarding the passed in value.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class ServerNameSaslServerFactory extends AbstractDelegatingSaslServerFactory {
+    private final String serverName;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param delegate the delegate server factory
+     * @param serverName the server name to use
+     */
+    public ServerNameSaslServerFactory(final SaslServerFactory delegate, final String serverName) {
+        super(delegate);
+        this.serverName = serverName;
+    }
+
+    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        return super.createSaslServer(mechanism, protocol, this.serverName, props, cbh);
+    }
+}


### PR DESCRIPTION
Makes client and server code somewhat more elegant.