### PR TITLE
Scram tests and fix + testing callback handler scram support

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
@@ -126,7 +126,7 @@ class ScramSaslClient extends AbstractSaslClient {
                 StringPrep.encode(nameCallback.getName(), b, StringPrep.PROFILE_SASL_STORED | StringPrep.MAP_SCRAM_LOGIN_CHARS);
                 b.append(',').append('r').append('=');
                 Random random = secureRandom != null ? secureRandom : ThreadLocalRandom.current();
-                b.append(nonce = ScramUtil.generateRandomString(48, random));
+                b.append(nonce = ScramUtil.generateNonce(48, random));
                 if (DEBUG) System.out.printf("[C] Client nonce: %s%n", convertToHexString(nonce));
                 setNegotiationState(ST_R1_SENT);
                 if (DEBUG) System.out.printf("[C] Client first message: %s%n", convertToHexString(b.toArray()));

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -245,7 +245,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                                 throw new SaslException("Callback handler does not support credential acquisition", e);
                             } else if (callback == parameterCallback) {
                                 // one more try, with default parameters
-                                salt = ScramUtil.generateRandomBytes(16, getRandom());
+                                salt = ScramUtil.generateSalt(16, getRandom());
                                 if (DEBUG) System.out.printf("[S] Salt (random): %s%n", convertToHexString(salt));
                                 algorithmSpec = new HashedPasswordAlgorithmSpec(minimumIterationCount, salt);
                                 try {
@@ -305,7 +305,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                     // nonce (client + server nonce)
                     b.append('r').append('=');
                     b.append(nonce);
-                    b.append(ScramUtil.generateRandomString(28, getRandom()));
+                    b.append(ScramUtil.generateNonce(28, getRandom()));
                     b.append(',');
 
                     // salt

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -193,8 +193,7 @@ final class ScramSaslServer extends AbstractSaslServer {
 
                     // get password
 
-                    final NameCallback nameCallback = new NameCallback("Remote authentication name");
-                    nameCallback.setName(loginName);
+                    final NameCallback nameCallback = new NameCallback("Remote authentication name", loginName);
 
                     // first try pre-digested
 
@@ -246,8 +245,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                                 throw new SaslException("Callback handler does not support credential acquisition", e);
                             } else if (callback == parameterCallback) {
                                 // one more try, with default parameters
-                                salt = new byte[16];
-                                getRandom().nextBytes(salt);
+                                salt = ScramUtil.generateRandomBytes(16, getRandom());
                                 if (DEBUG) System.out.printf("[S] Salt (random): %s%n", convertToHexString(salt));
                                 algorithmSpec = new HashedPasswordAlgorithmSpec(minimumIterationCount, salt);
                                 try {

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramUtil.java
@@ -47,13 +47,7 @@ class ScramUtil {
         randomCharDictionary = dict;
     }
 
-    public static void generateRandomString(StringBuilder b, int length, Random random) {
-        for (int i = 0; i < length; i ++) {
-            b.append(randomCharDictionary[random.nextInt(93)]);
-        }
-    }
-
-    public static byte[] generateRandomString(int length, Random random) {
+    public static byte[] generateNonce(int length, Random random) {
         final byte[] chars = new byte[length];
         for (int i = 0; i < length; i ++) {
             chars[i] = randomCharDictionary[random.nextInt(93)];
@@ -61,7 +55,7 @@ class ScramUtil {
         return chars;
     }
 
-    public static byte[] generateRandomBytes(int length, Random random){
+    public static byte[] generateSalt(int length, Random random){
         byte[] bytes = new byte[length];
         random.nextBytes(bytes);
         return bytes;

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramUtil.java
@@ -61,6 +61,12 @@ class ScramUtil {
         return chars;
     }
 
+    public static byte[] generateRandomBytes(int length, Random random){
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
     public static int parsePosInt(final ByteIterator i) {
         int a, c;
         if (! i.hasNext()) {
@@ -217,10 +223,10 @@ class ScramUtil {
             StringPrep.encode(password, b, StringPrep.PROFILE_SASL_QUERY);
             mac.init(new SecretKeySpec(b.toArray(), mac.getAlgorithm()));
             mac.update(salt, saltOffs, saltLen);
+            mac.update((byte) 0);
+            mac.update((byte) 0);
+            mac.update((byte) 0);
             mac.update((byte) 1);
-            mac.update((byte) 0);
-            mac.update((byte) 0);
-            mac.update((byte) 0);
             byte[] h = mac.doFinal();
             byte[] u = h;
             for (int i = 2; i <= iterationCount; i ++) {

--- a/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
@@ -91,7 +91,7 @@ public class BasicScramSelfTest extends BaseTestCase {
             public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (Callback callback : callbacks) {
                     if (callback instanceof NameCallback) {
-                        final String loginName = ((NameCallback) callback).getName();
+                        final String loginName = ((NameCallback) callback).getDefaultName();
                         assertEquals("Wrong login name", "login-name", loginName);
                     } else if (callback instanceof CredentialCallback) {
                         final CredentialCallback credentialCallback = (CredentialCallback) callback;

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2015 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.scram;
+
+import static org.junit.Assert.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Random;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.sasl.test.BaseTestCase;
+import org.wildfly.security.sasl.test.ClientCallbackHandler;
+import org.wildfly.security.sasl.util.AbstractSaslParticipant;
+
+/**
+ * Test of client side of SCRAM mechanism.
+ * JMockit ensure same generated nonce in every test run.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+@RunWith(JMockit.class)
+public class ScramClientCompatibilityTest extends BaseTestCase {
+
+    private void mockNonce(final String nonce){
+        new MockUp<ScramUtil>(){
+            @Mock
+            public byte[] generateRandomString(int length, Random random){
+                return nonce.getBytes(StandardCharsets.UTF_8);
+            }
+        };
+    }
+
+    /**
+     * Test communication by example in RFC 5802
+     */
+    @Test
+    public void testRfc5802example() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("user", "pencil".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, null, "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=", new String(message));
+
+        message = "v=rmF9pqV8S7suAoZWja4dJRkFsKQ=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -50,7 +50,7 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
     private void mockNonce(final String nonce){
         new MockUp<ScramUtil>(){
             @Mock
-            public byte[] generateRandomString(int length, Random random){
+            public byte[] generateNonce(int length, Random random){
                 return nonce.getBytes(StandardCharsets.UTF_8);
             }
         };

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2015 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,9 +18,7 @@
 
 package org.wildfly.security.sasl.scram;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -1,0 +1,74 @@
+package org.wildfly.security.sasl.scram;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Random;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.sasl.test.BaseTestCase;
+import org.wildfly.security.sasl.test.ServerCallbackHandler;
+import org.wildfly.security.sasl.util.HexConverter;
+
+/**
+ * Test of server side of SCRAM mechanism.
+ * JMockit ensure same generated nonce in every test run.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+@RunWith(JMockit.class)
+public class ScramServerCompatibilityTest extends BaseTestCase {
+
+    private void mockNonceSalt(final String nonce, final String salt){
+        new MockUp<ScramUtil>(){
+            @Mock
+            public byte[] generateRandomString(int length, Random random){
+                return nonce.getBytes(StandardCharsets.UTF_8);
+            }
+            @Mock
+            public byte[] generateRandomBytes(int length, Random random){
+                return HexConverter.convertFromHex(salt);
+            }
+        };
+    }
+
+    /**
+     * Test communication by example in RFC 5802
+     */
+    @Test
+    public void testRfc5802example() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j","4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        message = "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("v=rmF9pqV8S7suAoZWja4dJRkFsKQ=", new String(message));
+
+        assertTrue(saslServer.isComplete());
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -35,11 +35,11 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
     private void mockNonceSalt(final String nonce, final String salt){
         new MockUp<ScramUtil>(){
             @Mock
-            public byte[] generateRandomString(int length, Random random){
+            public byte[] generateNonce(int length, Random random){
                 return nonce.getBytes(StandardCharsets.UTF_8);
             }
             @Mock
-            public byte[] generateRandomBytes(int length, Random random){
+            public byte[] generateSalt(int length, Random random){
                 return HexConverter.convertFromHex(salt);
             }
         };

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wildfly.security.sasl.scram;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
@@ -1,0 +1,28 @@
+package org.wildfly.security.sasl.scram;
+
+import static org.junit.Assert.*;
+
+import javax.crypto.Mac;
+
+import org.junit.Test;
+import org.wildfly.security.sasl.util.HexConverter;
+
+/**
+ * Test of SCRAM mechanism utils.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class ScramUtilTest {
+
+    @Test
+    public void testCalculateHi() throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA1");
+        char[] password = "pencil".toCharArray();
+        byte[] salt = HexConverter.convertFromHex("4125C247E43AB1E93C6DFF76");
+
+        byte[] saltedPassword = ScramUtil.calculateHi(mac, password, salt, 0, salt.length, 4096);
+
+        assertEquals("1d96ee3a529b5a5f9e47c01f229a2cb8a6e15f7d", HexConverter.convertToHexString(saltedPassword));
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wildfly.security.sasl.scram;
 
 import static org.junit.Assert.*;

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2015 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Scram fixes
* Integer endianing in Hi() calculation
* NameCallback usage (callback handlers use "defaultName" as input in other SASL mechanisms, setName() should be called only by callback handler, not by SaslServer)

Tests
* Basic scram client and server compatibility test by example in RFC
* Testing callback handlers in common sasl.test modified to support non-Digest CredentialCallback
* Digest test changed to work with modified testing callbacks