### PR TITLE
[ELY-179] Initial implementation (JACC-based authorization)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <version.org.jboss.modules>1.4.3.Final</version.org.jboss.modules>
         <version.org.jboss.slf4j>1.0.3.GA</version.org.jboss.slf4j>
         <version.org.jboss.spec.org.jboss.spec.javax.net.ssl>1.0.0.Final</version.org.jboss.spec.org.jboss.spec.javax.net.ssl>
+        <version.org.jboss.spec.org.jboss.spec.javax.security.jacc>1.0.0.Final</version.org.jboss.spec.org.jboss.spec.javax.security.jacc>
         <version.org.kohsuke.metainf-services.metainf-services>1.5-jboss-1</version.org.kohsuke.metainf-services.metainf-services>
         <version.junit.junit>4.11</version.junit.junit>
         <version.jmockit>1.10</version.jmockit>
@@ -250,6 +251,13 @@
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
             <version>${version.org.wildfly.common}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.security.jacc</groupId>
+            <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+            <version>${version.org.jboss.spec.org.jboss.spec.javax.security.jacc}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -24,17 +24,22 @@ import java.nio.file.Path;
 import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Permission;
 import java.security.Principal;
+import java.security.ProtectionDomain;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.security.auth.callback.Callback;
+import javax.security.jacc.PolicyContextException;
 import javax.security.sasl.SaslException;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamReader;
@@ -1162,4 +1167,36 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 8029, value = "Could not obtain key spec encoding identifier.")
     IllegalArgumentException couldNotObtainKeySpecEncodingIdentifier();
+
+    /* authz package */
+
+    @LogMessage(level = ERROR)
+    @Message(id = 8030, value = "Failed to check permissions for protection domain [%s] and permission [%s].")
+    void authzFailedToCheckPermission(ProtectionDomain domain, Permission permission, @Cause Throwable cause);
+
+    @Message(id = 8031, value = "Invalid state [%s] for operation.")
+    UnsupportedOperationException authzInvalidStateForOperation(String actualState);
+
+    @Message(id = 8032, value = "Can't link policy configuration [%s] to itself.")
+    IllegalArgumentException authzLinkSamePolicyConfiguration(String contextID);
+
+    @Message(id = 8033, value = "ContextID not set. Check if the context id was set using PolicyContext.setContextID.")
+    IllegalStateException authzContextIdentifierNotSet();
+
+    @Message(id = 8034, value = "Invalid policy context identifier [%s].")
+    IllegalArgumentException authzInvalidPolicyContextIdentifier(String contextID);
+
+    @Message(id = 8035, value = "Could not obtain PolicyConfiguration for contextID [%s].")
+    PolicyContextException authzUnableToObtainPolicyConfiguration(String contextId, @Cause Throwable cause);
+
+    @Message(id = 8036, value = "Policy configuration with contextID [%s] is not in service state.")
+    IllegalStateException authzPolicyConfigurationNotInService(String contextID);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 8037, value = "Could not obtain dynamic permissions.")
+    void authzFailedGetDynamicPermissions(@Cause Throwable cause);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 8038, value = "Could not obtain authorized identity.")
+    void authzCouldNotObtainSecurityIdentity(@Cause Throwable cause);
 }

--- a/src/main/java/org/wildfly/security/authz/jacc/ElytronPolicyConfiguration.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/ElytronPolicyConfiguration.java
@@ -1,0 +1,243 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyContextException;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.log;
+
+/**
+ * {@link javax.security.jacc.PolicyConfiguration} implementation.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ * @see org.wildfly.security.authz.jacc.ElytronPolicyConfigurationFactory
+ */
+class ElytronPolicyConfiguration implements PolicyConfiguration {
+
+    /**
+     * An enum with all the possible states accordingly with the specification.
+     */
+    enum State {
+        OPEN,
+        IN_SERVICE,
+        DELETED
+    }
+
+    private final String contextId;
+    private final Map<String, Permissions> rolePermissions = Collections.synchronizedMap(new HashMap<>());
+    private State state = State.OPEN;
+    private Permissions uncheckedPermissions = new Permissions();
+    private Permissions excludedPermissions = new Permissions();
+    private Set<PolicyConfiguration> linkedPolicies = Collections.synchronizedSet(new LinkedHashSet<>());
+
+    ElytronPolicyConfiguration(String contextID) {
+        checkNotNullParam("contextID", contextID);
+        this.contextId = contextID;
+    }
+
+    @Override
+    public void addToExcludedPolicy(Permission permission) throws PolicyContextException {
+        checkNotNullParam("permission", permission);
+
+        synchronized (this) {
+            checkIfInOpenState();
+            this.excludedPermissions.add(permission);
+        }
+    }
+
+    @Override
+    public void addToExcludedPolicy(PermissionCollection permissions) throws PolicyContextException {
+        checkNotNullParam("permissions", permissions);
+
+        Enumeration<Permission> elements = permissions.elements();
+
+        while (elements.hasMoreElements()) {
+            addToExcludedPolicy(elements.nextElement());
+        }
+    }
+
+    @Override
+    public void addToRole(String roleName, Permission permission) throws PolicyContextException {
+        checkNotNullParam("roleName", roleName);
+        checkNotNullParam("permission", permission);
+
+        synchronized (this) {
+            checkIfInOpenState();
+            this.rolePermissions.computeIfAbsent(roleName, s -> new Permissions()).add(permission);
+        }
+    }
+
+    @Override
+    public void addToRole(String roleName, PermissionCollection permissions) throws PolicyContextException {
+        checkNotNullParam("roleName", roleName);
+        checkNotNullParam("permissions", permissions);
+
+        Enumeration<Permission> elements = permissions.elements();
+
+        while (elements.hasMoreElements()) {
+            addToRole(roleName, elements.nextElement());
+        }
+    }
+
+    @Override
+    public void addToUncheckedPolicy(Permission permission) throws PolicyContextException {
+        checkNotNullParam("permission", permission);
+
+        synchronized (this) {
+            checkIfInOpenState();
+            this.uncheckedPermissions.add(permission);
+        }
+    }
+
+    @Override
+    public void addToUncheckedPolicy(PermissionCollection permissions) throws PolicyContextException {
+        checkNotNullParam("permissions", permissions);
+
+        Enumeration<Permission> elements = permissions.elements();
+
+        while (elements.hasMoreElements()) {
+            addToUncheckedPolicy(elements.nextElement());
+        }
+    }
+
+    @Override
+    public void commit() throws PolicyContextException {
+        synchronized (this) {
+            if (isDeleted()) {
+                throw log.authzInvalidStateForOperation(this.state.name());
+            }
+
+            transitionTo(State.IN_SERVICE);
+        }
+    }
+
+    @Override
+    public void delete() throws PolicyContextException {
+        synchronized (this) {
+            transitionTo(State.DELETED);
+            this.uncheckedPermissions = new Permissions();
+            this.excludedPermissions = new Permissions();
+            this.rolePermissions.clear();
+            this.linkedPolicies.remove(this);
+        }
+    }
+
+    @Override
+    public String getContextID() throws PolicyContextException {
+        return this.contextId;
+    }
+
+    @Override
+    public boolean inService() {
+        synchronized (this) {
+            return State.IN_SERVICE.equals(this.state);
+        }
+    }
+
+    @Override
+    public void linkConfiguration(PolicyConfiguration link) throws PolicyContextException {
+        checkNotNullParam("link", link);
+
+        synchronized (this) {
+            checkIfInOpenState();
+            if (getContextID().equals(link.getContextID())) {
+                throw log.authzLinkSamePolicyConfiguration(getContextID());
+            }
+
+            this.linkedPolicies.add(this);
+
+            if (!this.linkedPolicies.add(link)) {
+                return;
+            }
+
+            ElytronPolicyConfiguration linkedPolicyConfiguration = (ElytronPolicyConfiguration) link;
+
+            linkedPolicyConfiguration.linkConfiguration(this);
+            // policies share the same set of linked policies, so we can remove policies from the set when they are deleted.
+            this.linkedPolicies = linkedPolicyConfiguration.getLinkedPolicies();
+        }
+    }
+
+    @Override
+    public void removeExcludedPolicy() throws PolicyContextException {
+        synchronized (this) {
+            checkIfInOpenState();
+            this.excludedPermissions = new Permissions();
+        }
+    }
+
+    @Override
+    public void removeRole(String roleName) throws PolicyContextException {
+        checkNotNullParam("roleName", roleName);
+        checkNotNullParam("roleName", roleName);
+
+        synchronized (this) {
+            checkIfInOpenState();
+            this.rolePermissions.remove(roleName);
+        }
+    }
+
+    @Override
+    public void removeUncheckedPolicy() throws PolicyContextException {
+        synchronized (this) {
+            checkIfInOpenState();
+            this.uncheckedPermissions = new Permissions();
+        }
+    }
+
+    Set<PolicyConfiguration> getLinkedPolicies() {
+        return this.linkedPolicies;
+    }
+
+    Permissions getUncheckedPermissions() {
+        return this.uncheckedPermissions;
+    }
+
+    Permissions getExcludedPermissions() {
+        return this.excludedPermissions;
+    }
+
+    Map<String, Permissions> getRolePermissions() {
+        return this.rolePermissions;
+    }
+
+    void transitionTo(State state) {
+        this.state = state;
+    }
+
+    private void checkIfInOpenState() {
+        if (!State.OPEN.equals(this.state)) {
+            throw log.authzInvalidStateForOperation(this.state.name());
+        }
+    }
+
+    private boolean isDeleted() {
+        return State.DELETED.equals(this.state);
+    }
+}

--- a/src/main/java/org/wildfly/security/authz/jacc/ElytronPolicyConfigurationFactory.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/ElytronPolicyConfigurationFactory.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyConfigurationFactory;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
+import java.security.PrivilegedAction;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.security.AccessController.doPrivileged;
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.security.authz.jacc.ElytronPolicyConfiguration.State.OPEN;
+
+/**
+ * <p>A {@link javax.security.jacc.PolicyConfigurationFactory} implementation.
+ *
+ * <p>Accordingly with the JACC specification, a {@link PolicyConfigurationFactory} is a singleton, instantiate once during
+ * the application server startup. Thus, there is only one instance of this class for a given JRE of an application server.
+ *
+ * <p>The static method {@link #getCurrentPolicyConfiguration()} is necessary in order to keep compatibility with TCK, given that
+ * it will wrap both factory and policy provider into its own implementations and still should be possible to obtain the policy configuration
+ * created by this factory by the {@link JaccDelegatingPolicy}. This behavior is exactly the same as currently being used by RI implementation from
+ * GF and PicketBox.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ * @see org.wildfly.security.authz.jacc.JaccDelegatingPolicy
+ */
+public class ElytronPolicyConfigurationFactory extends PolicyConfigurationFactory {
+
+    public static final PrivilegedAction<String> GET_CONTEXT_ID = () -> PolicyContext.getContextID();
+
+    /**
+     * Holds all {@link javax.security.jacc.PolicyConfiguration} created in runtime.
+     */
+    private static final Map<String, ElytronPolicyConfiguration> configurationRegistry = new ConcurrentHashMap<>();
+
+    /**
+     * <p>Returns the {@link javax.security.jacc.PolicyConfiguration} associated with the current policy context identifier.
+     *
+     * <p>This method only returns {@link javax.security.jacc.PolicyConfiguration} transitioned to the <i>in service</i> state.
+     * If the configuration associated with the current policy context identifier is in a different state, a exception is thrown.
+     *
+     * @return this method always returns a configuration instance transitioned with the <i>in service</i> state and associated
+     *         with the current policy context identifier.
+     * @throws PolicyContextException if the configuration is in a different state than <i>in service</i>, no policy context identifier
+     * was set or if no configuration is found for the given identifier.
+     */
+    static <P extends PolicyConfiguration> P getCurrentPolicyConfiguration() throws PolicyContextException {
+        String contextID;
+
+        if (WildFlySecurityManager.isChecking()) {
+            contextID = doPrivileged(GET_CONTEXT_ID);
+        } else {
+            contextID = PolicyContext.getContextID();
+        }
+
+        if (contextID == null) {
+            throw log.authzContextIdentifierNotSet();
+        }
+
+        try {
+            P policyConfiguration = (P) configurationRegistry.get(contextID);
+
+            if (policyConfiguration == null) {
+                throw log.authzInvalidPolicyContextIdentifier(contextID);
+            }
+
+            if (!policyConfiguration.inService()) {
+                throw log.authzPolicyConfigurationNotInService(contextID);
+            }
+
+            return policyConfiguration;
+        } catch (Exception e) {
+            throw log.authzUnableToObtainPolicyConfiguration(contextID, e);
+        }
+    }
+
+    @Override
+    public PolicyConfiguration getPolicyConfiguration(String contextID, boolean remove) throws PolicyContextException {
+        checkNotNullParam("contextID", contextID);
+
+        synchronized (configurationRegistry) {
+            ElytronPolicyConfiguration policyConfiguration = configurationRegistry.get(contextID);
+
+            if (policyConfiguration == null) {
+                return createPolicyConfiguration(contextID);
+            }
+
+            if (remove) {
+                policyConfiguration.delete();
+            }
+
+            policyConfiguration.transitionTo(OPEN);
+
+            return policyConfiguration;
+        }
+    }
+
+    @Override
+    public boolean inService(String contextID) throws PolicyContextException {
+        checkNotNullParam("contextID", contextID);
+
+        synchronized (configurationRegistry) {
+            PolicyConfiguration policyConfiguration = configurationRegistry.get(contextID);
+
+            if (policyConfiguration == null) {
+                return false;
+            }
+
+            return policyConfiguration.inService();
+        }
+    }
+
+    private ElytronPolicyConfiguration createPolicyConfiguration(String contextID) {
+        return configurationRegistry.computeIfAbsent(contextID, ElytronPolicyConfiguration::new);
+    }
+}

--- a/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
@@ -1,0 +1,285 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import javax.security.jacc.EJBMethodPermission;
+import javax.security.jacc.EJBRoleRefPermission;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
+import javax.security.jacc.WebResourcePermission;
+import javax.security.jacc.WebRoleRefPermission;
+import javax.security.jacc.WebUserDataPermission;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.security.AccessController.doPrivileged;
+import static org.wildfly.security._private.ElytronMessages.log;
+
+/**
+ * <p>A {@link Policy} implementation that knows how to process JACC permissions.
+ *
+ * <p>Elytron's JACC implementation is fully integrated with the Permission Mapping API, which allows users to specify custom permissions
+ * for a {@link SecurityDomain} and its identities by configuring a {@link org.wildfly.security.authz.PermissionMapper}. In this case,
+ * the permissions are evaluated considering both JACC-specific permissions (as defined by the specs) and also the ones associated with the current
+ * and authorized {@link SecurityIdentity}.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class JaccDelegatingPolicy extends Policy {
+
+    public static final PrivilegedAction<Policy> GET_POLICY_ACTION = () -> Policy.getPolicy();
+    private static final String ANY_AUTHENTICATED_USER_ROLE = "**";
+
+    private final Policy delegate;
+    private final Set<Class<? extends Permission>> supportedPermissionTypes = new HashSet<>();
+
+    /**
+     * Create a new instance. In this case, the current policy will be automatically obtained and used to delegate method
+     * calls.
+     */
+    public JaccDelegatingPolicy() {
+        this(WildFlySecurityManager.isChecking() ? doPrivileged(GET_POLICY_ACTION) : Policy.getPolicy());
+        this.supportedPermissionTypes.add(WebResourcePermission.class);
+        this.supportedPermissionTypes.add(WebRoleRefPermission.class);
+        this.supportedPermissionTypes.add(WebUserDataPermission.class);
+        this.supportedPermissionTypes.add(EJBMethodPermission.class);
+        this.supportedPermissionTypes.add(EJBRoleRefPermission.class);
+    }
+
+    /**
+     * Create a new instance based on the given {@code delegate}.
+     *
+     * @param delegate the policy that will be used to delegate method calls
+     */
+    public JaccDelegatingPolicy(Policy delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean implies(ProtectionDomain domain, Permission permission) {
+        try {
+            if (isJaccPermission(permission)) {
+                ElytronPolicyConfiguration policyConfiguration = ElytronPolicyConfigurationFactory.getCurrentPolicyConfiguration();
+
+                if (impliesExcludedPermission(permission, policyConfiguration)) {
+                    return false;
+                }
+
+                if (impliesUncheckedPermission(permission, policyConfiguration)) {
+                    return true;
+                }
+
+                if (impliesRolePermission(domain, permission, policyConfiguration)) {
+                    return true;
+                }
+            }
+
+            // here we check the permissions mapped to the current identity.
+            if (impliesIdentityPermission(permission)) {
+                return true;
+            }
+        } catch (Exception e) {
+            log.authzFailedToCheckPermission(domain, permission, e);
+        }
+
+        return this.delegate.implies(domain, permission);
+    }
+
+    @Override
+    public PermissionCollection getPermissions(ProtectionDomain domain) {
+        PermissionCollection permissions = getPermissions(super.getPermissions(domain));
+
+        addPermissions(permissions, this.delegate.getPermissions(domain));
+
+        return permissions;
+    }
+
+    @Override
+    public PermissionCollection getPermissions(CodeSource codeSource) {
+        if (codeSource == null) {
+            return Policy.UNSUPPORTED_EMPTY_COLLECTION;
+        }
+
+        PermissionCollection permissions = getPermissions(super.getPermissions(codeSource));
+
+        addPermissions(permissions, this.delegate.getPermissions(codeSource));
+
+        return permissions;
+    }
+
+    @Override
+    public void refresh() {
+        //TODO: we can probably provide some caching for permissions and checks. In this case, we can use this method to refresh the cache.
+        this.delegate.refresh();
+    }
+
+    private boolean impliesIdentityPermission(Permission permission) {
+        SecurityIdentity actualIdentity = getCurrentSecurityIdentity();
+
+        if (actualIdentity != null) {
+            PermissionCollection permissions = actualIdentity.getPermissions();
+
+            if (permissions.implies(permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private SecurityIdentity getCurrentSecurityIdentity() {
+        try {
+            return (SecurityIdentity) PolicyContext.getContext(SecurityIdentityHandler.KEY);
+        } catch (Exception cause) {
+            log.authzCouldNotObtainSecurityIdentity(cause);
+        }
+
+        return null;
+    }
+
+    private void extractRolesFromCurrentIdentity(Set<String> roles) throws PolicyContextException, ClassNotFoundException {
+        SecurityIdentity identity = getCurrentSecurityIdentity();
+
+        if (identity != null) {
+            Set<String> identityRoles = identity.getRoles();
+
+            if (identityRoles != null) {
+                for (String roleName : identityRoles) {
+                    roles.add(roleName);
+                }
+            }
+        }
+    }
+
+    private void extractRolesFromProtectionDomain(ProtectionDomain domain, Set<String> roles) {
+        Principal[] domainPrincipals = domain.getPrincipals();
+
+        if (domainPrincipals != null) {
+            for (Principal principal : domainPrincipals) {
+                roles.add(principal.getName());
+            }
+        }
+    }
+
+    private PermissionCollection getPermissions(PermissionCollection staticPermissions) {
+        Permissions permissions = new Permissions();
+
+        addPermissions(permissions, staticPermissions);
+
+        try {
+            ElytronPolicyConfiguration elytronPolicyConfiguration = ElytronPolicyConfigurationFactory.getCurrentPolicyConfiguration();
+            Permissions uncheckedPermissions = elytronPolicyConfiguration.getUncheckedPermissions();
+
+            addPermissions(permissions, uncheckedPermissions);
+
+            Map<String, Permissions> rolePermissions = elytronPolicyConfiguration.getRolePermissions();
+
+            synchronized (rolePermissions) {
+                rolePermissions.values().forEach(actualPermission -> addPermissions(permissions, actualPermission));
+            }
+
+            SecurityIdentity securityIdentity = getCurrentSecurityIdentity();
+
+            if (securityIdentity != null) {
+                addPermissions(permissions, securityIdentity.getPermissions());
+            }
+        } catch (Exception e) {
+            log.authzFailedGetDynamicPermissions(e);
+        }
+
+        return permissions;
+    }
+
+    private boolean impliesRolePermission(ProtectionDomain domain, Permission permission, ElytronPolicyConfiguration policyConfiguration) throws PolicyContextException, ClassNotFoundException {
+        Set<String> roles = new HashSet<>();
+
+        // keep JACC behavior where roles are obtained as Principal instances from a ProtectionDomain
+        extractRolesFromProtectionDomain(domain, roles);
+
+        // obtain additional roles from the current authenticated identity.
+        // in this case the a RoleMapper will be used to map roles from the authenticated identity
+        extractRolesFromCurrentIdentity(roles);
+
+        roles.add(ANY_AUTHENTICATED_USER_ROLE);
+
+        Map<String, Permissions> rolePermissions = policyConfiguration.getRolePermissions();
+
+        synchronized (rolePermissions) {
+            for (String roleName : roles) {
+                Permissions permissions = rolePermissions.get(roleName);
+
+                if (permissions != null) {
+                    if (permissions.implies(permission)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean impliesUncheckedPermission(Permission permission, ElytronPolicyConfiguration policyConfiguration) {
+        Permissions uncheckedPermissions = policyConfiguration.getUncheckedPermissions();
+
+        synchronized (uncheckedPermissions) {
+            return uncheckedPermissions.implies(permission);
+        }
+    }
+
+    private boolean impliesExcludedPermission(Permission permission, ElytronPolicyConfiguration policyConfiguration) {
+        Permissions excludedPermissions = policyConfiguration.getExcludedPermissions();
+
+        synchronized (excludedPermissions) {
+            return excludedPermissions.implies(permission);
+        }
+    }
+
+    private boolean isJaccPermission(Permission permission) {
+        return this.supportedPermissionTypes.contains(permission.getClass());
+    }
+
+    private void addPermissions(PermissionCollection newPermissions, PermissionCollection toAdd) {
+        if (toAdd == null) {
+            return;
+        }
+
+        synchronized (toAdd) {
+            Enumeration<Permission> enumeration = toAdd.elements();
+
+            while (enumeration.hasMoreElements()) {
+                newPermissions.add(enumeration.nextElement());
+            }
+        }
+    }
+}
+

--- a/src/main/java/org/wildfly/security/authz/jacc/SecurityIdentityHandler.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/SecurityIdentityHandler.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyContextException;
+import javax.security.jacc.PolicyContextHandler;
+import java.util.Map;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+/**
+ * <p>A {@link PolicyContextHandler} that holds the relationship between a {@link SecurityDomain} and its corresponding
+ * context identifier in JACC.
+ *
+ * <p>This handler should be installed wherever is necessary to perform permission checks based on the permissions associated
+ * with the {@link SecurityIdentity} instances obtained and associated with a given {@link SecurityDomain}. In this case,
+ * permission checks will be done based on the permissions managed by JACC and also on those associated with an authorized identity in Elytron.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class SecurityIdentityHandler implements PolicyContextHandler {
+
+    static final String KEY = SecurityIdentity.class.getName();
+
+    private final Map<String, SecurityDomain> securityDomains;
+
+    public SecurityIdentityHandler(Map<String, SecurityDomain> securityDomains) {
+        checkNotNullParam("securityDomains", securityDomains);
+        this.securityDomains = securityDomains;
+    }
+
+    @Override
+    public Object getContext(String key, Object data) throws PolicyContextException {
+        if (supports(key)) {
+            PolicyConfiguration policyConfiguration = ElytronPolicyConfigurationFactory.getCurrentPolicyConfiguration();
+            SecurityDomain securityDomain = this.securityDomains.get(policyConfiguration.getContextID());
+
+            if (securityDomain != null) {
+                return securityDomain.getCurrentSecurityIdentity();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public String[] getKeys() throws PolicyContextException {
+        return new String[] {KEY};
+    }
+
+    @Override
+    public boolean supports(String key) throws PolicyContextException {
+        return KEY.equalsIgnoreCase(key);
+    }
+}

--- a/src/main/java/org/wildfly/security/authz/jacc/package-info.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JSR-115 Java Authorization Contract for Containers (JACC) implementation.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+package org.wildfly.security.authz.jacc;
+

--- a/src/main/java/org/wildfly/security/authz/package-info.java
+++ b/src/main/java/org/wildfly/security/authz/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Elytron's Authorization API
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+package org.wildfly.security.authz;
+

--- a/src/test/java/org/wildfly/security/authz/jacc/AbstractAuthorizationTestCase.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/AbstractAuthorizationTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.wildfly.security.auth.provider.LegacyPropertiesSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityRealm;
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyConfigurationFactory;
+import javax.security.jacc.PolicyContextException;
+import java.io.IOException;
+import java.security.Policy;
+import java.security.Principal;
+import java.security.ProtectionDomain;
+import java.util.HashSet;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public abstract class AbstractAuthorizationTestCase {
+
+    @BeforeClass
+    public static void onBeforeClass() {
+        System.setProperty("javax.security.jacc.PolicyConfigurationFactory.provider", ElytronPolicyConfigurationFactory.class.getName());
+        Policy.setPolicy(new JaccDelegatingPolicy());
+    }
+
+    @Rule
+    public SecurityIdentityRule securityIdentityRule;
+    private final SecurityDomain securityDomain;
+
+    public AbstractAuthorizationTestCase() {
+        this.securityDomain = createSecurityDomain();
+        this.securityIdentityRule = new SecurityIdentityRule(securityDomain);
+    }
+
+    protected SecurityDomain createSecurityDomain() {
+        SecurityDomain.Builder builder = SecurityDomain.builder();
+        SecurityRealm realm;
+
+        try {
+            realm = LegacyPropertiesSecurityRealm.builder()
+                    .setPasswordsStream(getClass().getResourceAsStream("clear.properties"))
+                    .setPlainText(true)
+                    .build();
+        } catch (IOException e) {
+            throw new RuntimeException("Error creating security realm.", e);
+        }
+
+        builder.setDefaultRealmName("default");
+
+        builder.addRealm("default",realm).setRoleMapper(rolesToMap -> {
+            HashSet<String> roles = new HashSet<>();
+
+            roles.add("Administrator");
+            roles.add("Manager");
+
+            return roles;
+        });
+
+        return builder.build();
+    }
+
+    protected ElytronPolicyConfiguration createPolicyConfiguration(String contextID, ConfigurePoliciesAction configurationAction) throws ClassNotFoundException, PolicyContextException {
+        ElytronPolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID);
+
+        configurationAction.configure(policyConfiguration);
+
+        return policyConfiguration;
+    }
+
+    protected ElytronPolicyConfiguration createPolicyConfiguration(String contextID) throws ClassNotFoundException, PolicyContextException {
+        ElytronPolicyConfigurationFactory policyConfigurationFactory = (ElytronPolicyConfigurationFactory) PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+        return (ElytronPolicyConfiguration) policyConfigurationFactory.getPolicyConfiguration(contextID, false);
+    }
+
+    protected ElytronPolicyConfiguration createPolicyConfiguration(String contextID, boolean create) throws ClassNotFoundException, PolicyContextException {
+        ElytronPolicyConfigurationFactory policyConfigurationFactory = (ElytronPolicyConfigurationFactory) PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+        return (ElytronPolicyConfiguration) policyConfigurationFactory.getPolicyConfiguration(contextID, create);
+    }
+
+    protected ProtectionDomain createProtectionDomain(Principal... principals) {
+        return new ProtectionDomain(null, getClass().getProtectionDomain().getPermissions(), null, principals);
+    }
+
+    protected interface ConfigurePoliciesAction {
+        void configure(PolicyConfiguration toConfigure) throws PolicyContextException;
+    }
+}

--- a/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.provider.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.provider.SimpleRealmEntry;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.authz.RoleDecoder;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.PolicyContextException;
+import javax.security.jacc.WebResourcePermission;
+import java.security.Permission;
+import java.security.PermissionCollection;
+import java.security.Policy;
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * <p>This test case provides policy enforcement tests based on the JACC specification as well relying on Elytron's Permission
+ * Mapping API in order to define and enforce additional permissions.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class ElytronPolicyEnforcementTest extends AbstractAuthorizationTestCase {
+
+    private static final Provider provider = new WildFlyElytronProvider();
+
+    @BeforeClass
+    public static void onBeforeClass() {
+        System.setProperty("javax.security.jacc.PolicyConfigurationFactory.provider", ElytronPolicyConfigurationFactory.class.getName());
+        Policy.setPolicy(new JaccDelegatingPolicy());
+        Security.addProvider(provider);
+    }
+
+    @AfterClass
+    public static void onAfter() throws Exception {
+        Security.removeProvider(provider.getName());
+    }
+
+    private static final String CONTEXT_ID = "third-party-app";
+    private HashMap<String, SecurityDomain> securityDomains;
+
+    @Override
+    protected SecurityDomain createSecurityDomain() {
+        SecurityDomain.Builder builder = SecurityDomain.builder();
+        SimpleMapBackedSecurityRealm securityRealm = new SimpleMapBackedSecurityRealm();
+        Map<String, SimpleRealmEntry> users = new HashMap<>();
+
+        addUser(users, "user-admin", "Administrator");
+        addUser(users, "user-manager", "Manager");
+        addUser(users, "user-user", "User");
+
+        securityRealm.setPasswordMap(users);
+
+        builder.addRealm("default", securityRealm);
+        builder.setDefaultRealmName("default");
+
+        builder.setPermissionMapper((principal, roles) -> new PermissionCollection() {
+            @Override
+            public void add(Permission permission) {
+
+            }
+
+            @Override
+            public boolean implies(Permission impliedPermission) {
+                Enumeration<Permission> elements = elements();
+
+                while (elements.hasMoreElements()) {
+                    Permission permission = elements.nextElement();
+                    if (impliedPermission.implies(permission)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            @Override
+            public Enumeration<Permission> elements() {
+                List<Permission> permissions = new ArrayList<>();
+
+                if (roles.contains("Administrator")) {
+                    permissions.add(new WebResourcePermission("/webResource", "GET"));
+                    permissions.add(new WebResourcePermission("/webResource", "PUT"));
+                    permissions.add(new WebResourcePermission("/webResource", "POST"));
+                } else if (roles.contains("Manager")) {
+                    permissions.add(new WebResourcePermission("/webResource", "GET"));
+                    permissions.add(new WebResourcePermission("/webResource", "POST"));
+                } else if (roles.contains("User")) {
+                    permissions.add(new WebResourcePermission("/webResource", "GET"));
+                }
+
+                return Collections.enumeration(permissions);
+            }
+        });
+
+        SecurityDomain securityDomain = builder.build();
+
+        this.securityDomains = new HashMap<>();
+        this.securityDomains.computeIfAbsent(CONTEXT_ID, s -> securityDomain);
+
+        try {
+            PolicyContext.registerHandler(SecurityIdentityHandler.KEY, new SecurityIdentityHandler(this.securityDomains), true);
+        } catch (PolicyContextException e) {
+            e.printStackTrace();
+            fail("Could not register [" + SecurityIdentityHandler.class + "].");
+        }
+
+        return securityDomain;
+    }
+
+    @Test
+    @SecurityIdentityRule.RunAs("user-admin")
+    public void testAdministratorRoleBasedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+            toConfigure.addToRole("Administrator", new WebResourcePermission("/webResource", "HEAD"));
+        });
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // this permission was defined using a PermissionMapper and it should be granted for user-admin
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "POST")));
+        // however, this one was set using JACC API, via PolicyConfiguration. It should be valid as well.
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "HEAD")));
+        // this one was not granted for user-admin
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "OPTIONS")));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    @SecurityIdentityRule.RunAs("user-manager")
+    public void testManagerRoleBasedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {});
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // these permissions were defined using a PermissionMapper and they should be granted for user-manager
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "POST")));
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "GET")));
+        // this one was not granted for user-manager
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "PUT")));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    @SecurityIdentityRule.RunAs("user-user")
+    public void testUserRoleBasedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {});
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // this permissions was defined using a PermissionMapper and they should be granted for user-user
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "GET")));
+        // this one was not granted for user-manager
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "PUT")));
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "POST")));
+
+        policyConfiguration.delete();
+    }
+
+    private void addUser(Map<String, SimpleRealmEntry> securityRealm, String userName, String roles) {
+        Password defaultUnsecurePassword;
+
+        try {
+            defaultUnsecurePassword = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR)
+                    .generatePassword(new ClearPasswordSpec("password".toCharArray()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        MapAttributes attributes = new MapAttributes();
+
+        attributes.addAll(RoleDecoder.KEY_ROLES, Arrays.asList(roles));
+
+        securityRealm.put(userName, new SimpleRealmEntry(defaultUnsecurePassword, attributes));
+    }
+}

--- a/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
@@ -1,0 +1,207 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.provider.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.auth.server.ServerAuthenticationContext;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.authz.RoleDecoder;
+import org.wildfly.security.authz.RoleMapper;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyConfigurationFactory;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.WebResourcePermission;
+import java.security.Policy;
+import java.security.Principal;
+import java.security.ProtectionDomain;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@Ignore
+public class LinkPolicyConfigurationTest {
+
+    private static final Provider provider = new WildFlyElytronProvider();
+
+    @BeforeClass
+    public static void onBeforeClass() {
+        System.setProperty("javax.security.jacc.PolicyConfigurationFactory.provider", ElytronPolicyConfigurationFactory.class.getName());
+        Policy.setPolicy(new JaccDelegatingPolicy());
+        Security.addProvider(provider);
+    }
+
+    @AfterClass
+    public static void onAfter() throws Exception {
+        Security.removeProvider(provider.getName());
+    }
+
+    @Test
+    public void testLinkPolicyConfigurationSharingRoleMapping() throws Exception {
+        ElytronPolicyConfigurationFactory policyConfigurationFactory = (ElytronPolicyConfigurationFactory) PolicyConfigurationFactory.getPolicyConfigurationFactory();
+        // let's create the parent module policy
+        final WebResourcePermission parentPermission = new WebResourcePermission("/webResource", "PUT");
+        String parentContextID = "parent-module";
+
+        SecurityDomain parentSecurityDomain = createSecurityDomain("mary", "Administrator");
+        PolicyConfiguration parentPolicyConfiguration = policyConfigurationFactory.getPolicyConfiguration(parentContextID, false);
+
+        parentPolicyConfiguration.addToRole("Administrator", parentPermission);
+        parentPolicyConfiguration.addToRole("User", parentPermission);
+
+        // let's create the first child module
+        final WebResourcePermission child1Permission = new WebResourcePermission("/webResource", "POST");
+        String child1ContextID = "child-module-1";
+        SecurityDomain child1SecurityDomain = createSecurityDomain("john", "User");
+        PolicyConfiguration child1PolicyConfiguration = policyConfigurationFactory.getPolicyConfiguration(child1ContextID, false);
+
+        child1PolicyConfiguration.addToRole("Administrator", child1Permission);
+        child1PolicyConfiguration.addToRole("User", child1Permission);
+        child1PolicyConfiguration.addToRole("Manager", child1Permission);
+
+        // let's create the second child module
+        final WebResourcePermission child2Permission = new WebResourcePermission("/webResource", "GET");
+        String child2ContextID = "child-module-2";
+        SecurityDomain child2SecurityDomain = createSecurityDomain("smith", "Manager");
+        PolicyConfiguration child2PolicyConfiguration = policyConfigurationFactory.getPolicyConfiguration(child2ContextID, false);
+
+        child2PolicyConfiguration.addToRole("User", child2Permission);
+        child2PolicyConfiguration.addToRole("Manager", child2Permission);
+
+        // link first child module with parent
+        parentPolicyConfiguration.linkConfiguration(child1PolicyConfiguration);
+
+        // link second child module with parent
+        parentPolicyConfiguration.linkConfiguration(child2PolicyConfiguration);
+
+        parentPolicyConfiguration.commit();
+        child1PolicyConfiguration.commit();
+        child2PolicyConfiguration.commit();
+
+        // let's check now permissions for first child module
+        PolicyContext.setContextID(child1ContextID);
+        Policy policy = Policy.getPolicy();
+
+        ServerAuthenticationContext authenticationContext = child1SecurityDomain.createNewAuthenticationContext();
+        authenticationContext.setAuthenticationName("john");
+        authenticationContext.succeed();
+        SecurityIdentity johnIdentity = authenticationContext.getAuthorizedIdentity();
+
+        // john is known by first child module, it should pass
+        johnIdentity.runAs(() -> {
+            assertTrue(policy.implies(createProtectionDomain(), child1Permission));
+        });
+
+        authenticationContext = child2SecurityDomain.createNewAuthenticationContext();
+        authenticationContext.setAuthenticationName("smith");
+        authenticationContext.succeed();
+        SecurityIdentity smithIdentity = authenticationContext.getAuthorizedIdentity();
+        PolicyContext.setContextID(child2ContextID);
+
+        // smith is not know by first module, but by second module. As they share the same role mapping, smith should be known by first module as well
+        smithIdentity.runAs(() -> {
+            assertTrue(policy.implies(createProtectionDomain(), child1Permission));
+        });
+
+        // same thing above, but using mary which is known only by parent module
+        assertTrue(policy.implies(createProtectionDomain(), child1Permission));
+
+        PolicyContext.setContextID(child2ContextID);
+
+        // smith is known by first child module, it should pass
+        assertTrue(policy.implies(createProtectionDomain(), child2Permission));
+
+        // john is not know by first module, but by first module. As they share the same role mapping, john should be known by second module as well
+        assertTrue(policy.implies(createProtectionDomain(), child2Permission));
+
+        // same thing above, but using mary which is known only by parent module. However, in this case we don't have a permission for mary/Administrator in the second module
+        assertFalse(policy.implies(createProtectionDomain(), child2Permission));
+
+        PolicyContext.setContextID(parentContextID);
+
+        assertTrue(policy.implies(createProtectionDomain(), parentPermission));
+        assertFalse(policy.implies(createProtectionDomain(), parentPermission));
+
+        parentPolicyConfiguration.delete();
+
+        PolicyContext.setContextID(child1ContextID);
+
+        // parent module was deleted, mary is longer resolvable
+        assertFalse(policy.implies(createProtectionDomain(), child1Permission));
+    }
+
+    private SecurityDomain createSecurityDomain(String userName, String... roles) throws Exception {
+        SecurityDomain.Builder builder = SecurityDomain.builder();
+        SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
+        MapAttributes attributes = new MapAttributes();
+
+        attributes.addAll(RoleDecoder.KEY_ROLES, Arrays.asList(roles));
+
+        realm.setPasswordMap(userName, PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(new ClearPasswordSpec(userName.toCharArray())), attributes);
+
+        builder.setDefaultRealmName("default");
+
+        builder.addRealm("default",realm).setRoleMapper(RoleMapper.IDENTITY_ROLE_MAPPER);
+
+        return builder.build();
+    }
+
+    @Test
+    public void testFailLinkSamePolicyConfiguration() throws Exception {
+        ElytronPolicyConfigurationFactory policyConfigurationFactory = (ElytronPolicyConfigurationFactory) PolicyConfigurationFactory.getPolicyConfigurationFactory();
+        String parentContextID = "parent-module";
+        PolicyConfiguration parentPolicyConfiguration = policyConfigurationFactory.getPolicyConfiguration(parentContextID, false);
+
+        try {
+            parentPolicyConfiguration.linkConfiguration(parentPolicyConfiguration);
+            fail("Should not be possible to link the same policy with itself");
+        } catch (Exception e) {
+            assertThat(e, new IsInstanceOf(IllegalArgumentException.class));
+        }
+
+        parentPolicyConfiguration.commit();
+    }
+
+    private Principal createPrincipal(final String name) {
+        return new NamePrincipal(name);
+    }
+
+    private ProtectionDomain createProtectionDomain(Principal... principals) {
+        return new ProtectionDomain(null, getClass().getProtectionDomain().getPermissions(), null, principals);
+    }
+}

--- a/src/test/java/org/wildfly/security/authz/jacc/PolicyConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/PolicyConfigurationTest.java
@@ -1,0 +1,421 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.hamcrest.core.IsInstanceOf;
+import org.hamcrest.core.IsSame;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyConfigurationFactory;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.WebResourcePermission;
+import java.security.PermissionCollection;
+import java.security.Policy;
+
+import static java.security.AccessController.doPrivileged;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.wildfly.security.authz.jacc.JaccDelegatingPolicy.GET_POLICY_ACTION;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@SecurityIdentityRule.RunAs("elytron")
+public class PolicyConfigurationTest extends AbstractAuthorizationTestCase {
+
+    @Test
+    public void testCreateElytronPolicyConfigurationFactory() throws Exception {
+        PolicyConfigurationFactory policyConfigurationFactory = PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+        Assert.assertThat(policyConfigurationFactory, new IsInstanceOf(ElytronPolicyConfigurationFactory.class));
+
+        PolicyConfigurationFactory sameInstance = PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+        Assert.assertThat(policyConfigurationFactory, new IsSame<>(sameInstance));
+    }
+
+    @Test
+    public void testCreateAndInstallDelegatingPolicy() throws Exception {
+        Policy policy = Policy.getPolicy();
+
+        assertThat(policy, new IsSame<>(doPrivileged(GET_POLICY_ACTION)));
+
+        Policy mustBeTheSame = Policy.getPolicy();
+
+        assertThat(mustBeTheSame, new IsSame<>(doPrivileged(GET_POLICY_ACTION)));
+    }
+
+    @Test
+    public void testCreatePolicyConfiguration() throws Exception {
+        final WebResourcePermission dynamicPermission1 = new WebResourcePermission("/webResource", "GET,PUT");
+        final WebResourcePermission dynamicPermission2 = new WebResourcePermission("/webResource", "PUT");
+        final WebResourcePermission dynamicPermission3 = new WebResourcePermission("/webResource", "HEAD");
+        String contextID = "third-party-app";
+        ElytronPolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+                    toConfigure.addToUncheckedPolicy(dynamicPermission1);
+                    toConfigure.addToRole("Administrator", dynamicPermission2);
+                    toConfigure.addToExcludedPolicy(dynamicPermission3);
+                }
+        );
+
+        PolicyConfigurationFactory policyConfigurationFactory = PolicyConfigurationFactory.getPolicyConfigurationFactory();
+
+        // must be in open state
+        assertFalse(policyConfigurationFactory.inService(contextID));
+        assertFalse(policyConfiguration.inService());
+
+        // we now set the context id
+        PolicyContext.setContextID(contextID);
+
+        Policy policy = doPrivileged(GET_POLICY_ACTION);
+
+        PermissionCollection permissions = policy.getPermissions(createProtectionDomain(new NamePrincipal("Administrator")));
+
+        policyConfiguration.commit();
+
+        assertTrue(policyConfiguration.inService());
+        assertTrue(policyConfigurationFactory.inService(contextID));
+
+        permissions = policy.getPermissions(createProtectionDomain(new NamePrincipal("Administrator")));
+
+        assertTrue(permissions.implies(dynamicPermission1));
+        assertTrue(permissions.implies(dynamicPermission2));
+
+        // excluded permissions are never returned
+        assertFalse(permissions.implies(dynamicPermission3));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    public void testRemovePolicyConfiguration() throws Exception {
+        final WebResourcePermission dynamicPermission1 = new WebResourcePermission("/webResource", "GET,PUT");
+        final WebResourcePermission dynamicPermission2 = new WebResourcePermission("/webResource", "PUT");
+        final WebResourcePermission dynamicPermission3 = new WebResourcePermission("/webResource", "HEAD");
+        String contextID = "third-party-app";
+        ElytronPolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+                    toConfigure.addToUncheckedPolicy(dynamicPermission1);
+                    toConfigure.addToRole("Administrator", dynamicPermission2);
+                    toConfigure.addToExcludedPolicy(dynamicPermission3);
+                }
+        );
+
+        assertFalse(policyConfiguration.inService());
+
+        policyConfiguration.commit();
+
+        assertTrue(policyConfiguration.inService());
+
+        PolicyConfiguration removedPolicyConfiguration = createPolicyConfiguration("third-party-app", true);
+
+        assertFalse(policyConfiguration.inService());
+        assertThat(policyConfiguration, new IsSame<>(removedPolicyConfiguration));
+
+        Policy policy = doPrivileged(GET_POLICY_ACTION);
+
+        PolicyContext.setContextID(contextID);
+
+        PermissionCollection permissions = policy.getPermissions(createProtectionDomain(new NamePrincipal("Administrator")));
+
+        assertFalse(permissions.implies(dynamicPermission1));
+        assertFalse(permissions.implies(dynamicPermission2));
+        assertFalse(permissions.implies(dynamicPermission3));
+    }
+
+    @Test
+    public void testInServiceToOpenState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        PolicyConfiguration openPolicyConfiguration = createPolicyConfiguration("third-party-app");
+
+        assertThat(policyConfiguration, new IsSame<>(openPolicyConfiguration));
+
+        assertFalse(openPolicyConfiguration.inService());
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        openPolicyConfiguration.addToUncheckedPolicy(dynamicPermission);
+    }
+
+    @Test
+    public void testDeletedToOpenState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        PolicyConfiguration openPolicyConfiguration = createPolicyConfiguration("third-party-app", true);
+
+        assertThat(policyConfiguration, new IsSame<>(openPolicyConfiguration));
+
+        assertFalse(openPolicyConfiguration.inService());
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        openPolicyConfiguration.addToUncheckedPolicy(dynamicPermission);
+    }
+
+    @Test
+    public void testFailToAddUncheckedPermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToUncheckedPolicy(dynamicPermission);
+            fail("Permissions can not be added when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToAddExcludedPermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToExcludedPolicy(dynamicPermission);
+            fail("Permissions can not be added when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToAddRolePermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToRole("Administrator", dynamicPermission);
+            fail("Permissions can not be added when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveUncheckedPermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        try {
+            policyConfiguration.removeUncheckedPolicy();
+            fail("Permissions can not be removed when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveExcludedPermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        try {
+            policyConfiguration.removeExcludedPolicy();
+            fail("Permissions can not be removed when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveRolePermissionInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        try {
+            policyConfiguration.removeRole("Administrator");
+            fail("Permissions can not be removed when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToLinkInServiceState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.commit();
+
+        try {
+            PolicyConfiguration linkedPolicyConfiguration = createPolicyConfiguration("third-pary-app/ejb", false);
+
+            policyConfiguration.linkConfiguration(linkedPolicyConfiguration);
+
+            fail("Links can not be added when policy configuration is inService state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToAddUncheckedPermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToUncheckedPolicy(dynamicPermission);
+            fail("Permissions can not be added when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToAddExcludedPermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToExcludedPolicy(dynamicPermission);
+            fail("Permissions can not be added when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToAddRolePermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        WebResourcePermission dynamicPermission = new WebResourcePermission("/webResource", "PUT");
+
+        try {
+            policyConfiguration.addToRole("Administrator", dynamicPermission);
+            fail("Permissions can not be added when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveUncheckedPermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        try {
+            policyConfiguration.removeUncheckedPolicy();
+            fail("Permissions can not be removed when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveExcludedPermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        try {
+            policyConfiguration.removeExcludedPolicy();
+            fail("Permissions can not be removed when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToRemoveRolePermissionInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        try {
+            policyConfiguration.removeRole("Administrator");
+            fail("Permissions can not be removed when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToLinkInDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        try {
+            PolicyConfiguration linkedPolicyConfiguration = createPolicyConfiguration("third-pary-app/ejb", false);
+
+            policyConfiguration.linkConfiguration(linkedPolicyConfiguration);
+
+            fail("Links can not be added when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+
+    @Test
+    public void testFailToCommitDeletedState() throws Exception {
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration("third-party-app");
+
+        policyConfiguration.delete();
+
+        try {
+            policyConfiguration.commit();
+            fail("Commit can not be called when policy configuration is in deleted state.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(e, new IsInstanceOf(UnsupportedOperationException.class));
+        }
+    }
+}

--- a/src/test/java/org/wildfly/security/authz/jacc/SecurityIdentityRule.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/SecurityIdentityRule.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.auth.server.ServerAuthenticationContext;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.security.PrivilegedAction;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class SecurityIdentityRule implements TestRule {
+
+    private SecurityDomain securityDomain;
+
+    public SecurityIdentityRule(SecurityDomain securityDomain) {
+        this.securityDomain = securityDomain;
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        RunAs runAs = description.getAnnotation(RunAs.class);
+
+        if (runAs == null) {
+            runAs = description.getTestClass().getAnnotation(RunAs.class);
+        }
+
+        if (runAs == null) {
+            throw new RuntimeException("@RunAs is missing on test method or test class.");
+        }
+
+        ServerAuthenticationContext authenticationContext = this.securityDomain.createNewAuthenticationContext();
+
+        try {
+            authenticationContext.setAuthenticationName(runAs.value());
+            authenticationContext.succeed();
+        } catch (RealmUnavailableException e) {
+            throw new RuntimeException("Error while authenticating.", e);
+        }
+
+        return new RunAsSecurityIdentity(base, authenticationContext.getAuthorizedIdentity());
+    }
+
+    public class RunAsSecurityIdentity extends Statement {
+
+        private final SecurityIdentity authorizedIdentity;
+        private final Statement delegate;
+
+        public RunAsSecurityIdentity(Statement delegate, SecurityIdentity authorizedIdentity) {
+            this.delegate = delegate;
+            this.authorizedIdentity = authorizedIdentity;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            this.authorizedIdentity.runAs((PrivilegedAction<Void>) () -> {
+                try {
+                    this.delegate.evaluate();
+                } catch (Throwable cause) {
+                    throw new RuntimeException("Error while evaluating test method.", cause);
+                }
+
+                return null;
+            });
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    public @interface RunAs {
+        String value();
+    }
+}

--- a/src/test/java/org/wildfly/security/authz/jacc/StandardPolicyEnforcementTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/StandardPolicyEnforcementTest.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.authz.jacc;
+
+import org.junit.Test;
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+import javax.security.jacc.PolicyConfiguration;
+import javax.security.jacc.PolicyContext;
+import javax.security.jacc.WebResourcePermission;
+import java.security.Policy;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * <p>This test case provides policy enforcement tests solely based on the JACC specification.
+ *
+ * <p>In this case, all the permissions being evaluated are defined using JACC API without necessarily using any
+ * additional permission mapping provided by Elytron. For instance, when configuring a {@link org.wildfly.security.authz.PermissionMapper} for a {@link org.wildfly.security.auth.server.SecurityDomain}.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+@SecurityIdentityRule.RunAs("elytron")
+public class StandardPolicyEnforcementTest extends AbstractAuthorizationTestCase {
+
+    @Test
+    public void testUncheckedPolicy() throws Exception {
+        String contextID = "third-party-app";
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> toConfigure.addToUncheckedPolicy(new WebResourcePermission("/webResource", "GET")));
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        assertTrue(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "GET")));
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "HEAD")));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    public void testExcludedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+                    toConfigure.addToUncheckedPolicy(new WebResourcePermission("/webResource", "GET,PUT"));
+                    toConfigure.addToExcludedPolicy(new WebResourcePermission("/webResource", "PUT"));
+            }
+        );
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // excluded policies have precedence over any other
+        assertFalse(policy.implies(createProtectionDomain(), new WebResourcePermission("/webResource", "PUT")));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    public void testRoleBasedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+            toConfigure.addToRole("Administrator", new WebResourcePermission("/webResource", "POST"));
+        });
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // as defined by JACC specification, roles are specified as principals within a ProtectionDomain and evaluated accordingly.
+        assertTrue(policy.implies(createProtectionDomain(new NamePrincipal("Administrator")), new WebResourcePermission("/webResource", "POST")));
+        assertFalse(policy.implies(createProtectionDomain(new NamePrincipal("Manager")), new WebResourcePermission("/webResource", "OPTIONS")));
+
+        policyConfiguration.delete();
+    }
+
+    @Test
+    public void testMultipleRolesBasedPolicy() throws Exception {
+        String contextID = "third-party-app";
+
+        PolicyConfiguration policyConfiguration = createPolicyConfiguration(contextID, toConfigure -> {
+            toConfigure.addToRole("Administrator", new WebResourcePermission("/webResource", "POST"));
+            toConfigure.addToRole("Administrator", new WebResourcePermission("/webResource", "PUT"));
+            toConfigure.addToRole("Manager", new WebResourcePermission("/webResource", "PUT"));
+        });
+
+        policyConfiguration.commit();
+
+        PolicyContext.setContextID(contextID);
+        Policy policy = Policy.getPolicy();
+
+        // as defined by JACC specification, roles are specified as principals within a ProtectionDomain and evaluated accordingly.
+        assertTrue(policy.implies(createProtectionDomain(new NamePrincipal("Administrator")), new WebResourcePermission("/webResource", "POST")));
+        assertTrue(policy.implies(createProtectionDomain(new NamePrincipal("Administrator")), new WebResourcePermission("/webResource", "PUT")));
+        assertTrue(policy.implies(createProtectionDomain(new NamePrincipal("Manager")), new WebResourcePermission("/webResource", "PUT")));
+        assertFalse(policy.implies(createProtectionDomain(new NamePrincipal("Administrator")), new WebResourcePermission("/webResource", "GET")));
+
+        policyConfiguration.delete();
+    }
+}

--- a/src/test/resources/org/wildfly/security/authz/jacc/clear.properties
+++ b/src/test/resources/org/wildfly/security/authz/jacc/clear.properties
@@ -1,0 +1,27 @@
+#
+# Properties declaration of users for the realm 'ManagementRealm' which is the default realm
+# for new installations. Further authentication mechanism can be configured
+# as part of the <management /> in standalone.xml.
+#
+# Users can be added to this properties file at any time, updates after the server has started
+# will be automatically detected.
+#
+# By default the properties realm expects the entries to be in the format: -
+#
+# A utility script is provided which can be executed from the bin folder to add the users: -
+# - Linux
+#  bin/add-user.sh
+#
+# - Windows
+#  bin\add-user.bat
+# On start-up the server will also automatically add a user $local - this user is specifically
+# for local tools running against this AS installation.
+#
+# The following illustrates how an admin user could be defined, this
+# is for illustration only and does not correspond to a usable password.
+#
+elytron=passwd12#$
+#javajoe=29964e13022479e4db09c2b8a0e67b0f
+#
+#$REALM_NAME=ManagementRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#


### PR DESCRIPTION
### References
* https://issues.jboss.org/browse/ELY-179

### Overview
Provides an implementation of the JSR-115, Java Authorization Contract for Containers (JACC).

#### Backward Compatibility in WildFly

These changes were tested to check backward compatibility with the existing support provided by PicketBox in WildFly. Testes were executed based on:

* Wildfly 10.0.0.Beta1-SNAPSHOT (latest upstream)
* [TCK 7](https://developer.jboss.org/wiki/TCK7Guide)
* [JavaEE 7 Samples](https://github.com/javaee-samples/javaee7-samples/tree/master/jacc)
* Existing integration tests in WildFly test suite