### PR TITLE
Checkstyle plugin issue with Java 8 syntax checking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
-        <checkstyle.skip>false</checkstyle.skip>
+
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,14 @@
         <version.org.kohsuke.metainf-services.metainf-services>1.5-jboss-1</version.org.kohsuke.metainf-services.metainf-services>
         <version.junit.junit>4.11</version.junit.junit>
         <version.jmockit>1.10</version.jmockit>
-        <version.org.wildfly.checkstyle-config>1.0.2.Final</version.org.wildfly.checkstyle-config>
+        <version.org.wildfly.checkstyle-config>1.0.3.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.0.Alpha2</version.org.wildfly.client.config>
-        <version.com.puppycrawl.tools.checkstyle>6.0</version.com.puppycrawl.tools.checkstyle>
+        <version.com.puppycrawl.tools.checkstyle>6.3</version.com.puppycrawl.tools.checkstyle>
 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
-
+        <checkstyle.skip>false</checkstyle.skip>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -227,7 +227,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- 
+        <!--
               Test Scope Only
          -->
         <dependency>


### PR DESCRIPTION
"Got an exception - expecting EOF, found 'String'"
"unexpected token: >"

Upgrading to newer version of com.puppycrawl.tools.checkstyle and org.wildfly.checkstyle-config.