### PR TITLE
Scram SASL server - gs2-header and authorization checking

### DIFF
--- a/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
@@ -34,6 +34,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslServer;
@@ -98,6 +99,11 @@ public class BasicScramSelfTest extends BaseTestCase {
                         if (credentialCallback.isCredentialSupported(password)) {
                             credentialCallback.setCredential(password);
                         }
+                    } else if (callback instanceof AuthorizeCallback) {
+                        AuthorizeCallback acb = (AuthorizeCallback) callback;
+                        assertEquals("login-name", acb.getAuthenticationID());
+                        assertEquals("user", acb.getAuthorizationID());
+                        acb.setAuthorized(true);
                     } else {
                         CallbackUtil.unsupported(callback);
                     }

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Random;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
@@ -85,6 +86,180 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         assertEquals("v=rmF9pqV8S7suAoZWja4dJRkFsKQ=", new String(message));
 
         assertTrue(saslServer.isComplete());
+    }
+
+    /**
+     * Test rejection of bad username
+     */
+    @Test
+    public void testBadUsername() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j", "4125c247e43ab1e93c6dff76");
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+        CallbackHandler cbh = new ServerCallbackHandler("baduser", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        try {
+            saslServer.evaluateResponse(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslServer.isComplete());
+    }
+
+    /**
+     * Test rejection of bad password
+     */
+    @Test
+    public void testBadPassword() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j", "4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pen".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        message = "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts="
+                .getBytes(StandardCharsets.UTF_8);
+        try {
+            saslServer.evaluateResponse(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslServer.isComplete());
+    }
+
+    /**
+     * Test allowing of authorized authorization id
+     */
+    @Test
+    public void testAllowedAuthorizationId() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j", "4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,a=user,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        //         c="n,a=user,"
+        message = "c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ="
+                .getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("v=n1qgUn3vi9dh7nG1+Giie5qsaVQ=", new String(message));
+
+        assertTrue(saslServer.isComplete());
+    }
+
+    /**
+     * Test rejection of unauthorized authorization id
+     */
+    @Test
+    public void testUnallowedAuthorizationId() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j", "4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        //         c="n,a=admin,"
+        message = "c=bixhPWFkbWluLA==,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NtV1dHUQfWdxjTl95JmKKGVQJSQ="
+                .getBytes(StandardCharsets.UTF_8);
+        try {
+            saslServer.evaluateResponse(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslServer.isComplete());
+    }
+
+    /**
+     * Test rejection of different authorization id in FIRST and FINAL message
+     */
+    @Test
+    public void testMismatchedAuthorizationId() throws Exception {
+        mockNonceSalt("3rfcNHYJY1ZVvWVs7j", "4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        //         c="n,a=user,"
+        message = "c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ="
+                .getBytes(StandardCharsets.UTF_8);
+        try {
+            saslServer.evaluateResponse(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslServer.isComplete());
+    }
+
+    /**
+     * Test rejection of correct credentials and non-corresponding nonce
+     */
+    @Test
+    public void testDifferentNonceAttack() throws Exception {
+        mockNonceSalt("differentNonceVs7j", "4125c247e43ab1e93c6dff76");
+
+        final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
+        assertNotNull(serverFactory);
+
+        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
+                Collections.emptyMap(), cbh);
+        assertNotNull(saslServer);
+        assertTrue(saslServer instanceof ScramSaslServer);
+
+        byte[] message = "n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawLdifferentNonceVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        message = "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts="
+                .getBytes(StandardCharsets.UTF_8);
+        try {
+            saslServer.evaluateResponse(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslServer.isComplete());
     }
 
 }

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -81,6 +81,7 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         message = saslServer.evaluateResponse(message);
         assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
 
+        //        c="n,,"
         message = "c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
         assertEquals("v=rmF9pqV8S7suAoZWja4dJRkFsKQ=", new String(message));
@@ -187,12 +188,6 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         assertTrue(saslServer instanceof ScramSaslServer);
 
         byte[] message = "n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
-        message = saslServer.evaluateResponse(message);
-        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
-
-        //         c="n,a=admin,"
-        message = "c=bixhPWFkbWluLA==,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NtV1dHUQfWdxjTl95JmKKGVQJSQ="
-                .getBytes(StandardCharsets.UTF_8);
         try {
             saslServer.evaluateResponse(message);
             fail("SaslException not throwed");
@@ -217,12 +212,12 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         assertNotNull(saslServer);
         assertTrue(saslServer instanceof ScramSaslServer);
 
-        byte[] message = "n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        byte[] message = "n,a=user,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
         assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
 
-        //         c="n,a=user,"
-        message = "c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ="
+        //         c="n,a=admin,"
+        message = "c=bixhPWFkbWluLA==,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ="
                 .getBytes(StandardCharsets.UTF_8);
         try {
             saslServer.evaluateResponse(message);


### PR DESCRIPTION
Tests and fixes of Scram SASL server:
* checking of equality gs2-header in FIRST and FINAL message
* checking of user authorization (to act as given authorization id) (!)

Note: Checking of gs2-header equality could be more efficient, but it would require modification of ByteIterator (adding possibility of go through one field twice - setOffset or similar) or big changes of Scram server (all parsing of gs2-header in first message and only checking in parsing of final message).