### PR TITLE
[ELY-193] Allow a credential type to be obtainable but not verifiable or possibly obtainable but not verifiable.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/spi/CredentialSupport.java
+++ b/src/main/java/org/wildfly/security/auth/spi/CredentialSupport.java
@@ -39,6 +39,16 @@ public enum CredentialSupport {
     POSSIBLY_VERIFIABLE(SupportLevel.UNSUPPORTED, SupportLevel.POSSIBLY_SUPPORTED),
 
     /**
+     * The given credential type is possibly obtainable but never verifiable.
+     */
+    POSSIBLY_OBTAINABLE(SupportLevel.POSSIBLY_SUPPORTED, SupportLevel.UNSUPPORTED),
+
+    /**
+     * The given credential type can be obtained but not verified.
+     */
+    OBTAINABLE_ONLY(SupportLevel.SUPPORTED, SupportLevel.UNSUPPORTED),
+
+    /**
      * The given credential type is definitely verifiable but not obtainable.
      */
     VERIFIABLE_ONLY(SupportLevel.UNSUPPORTED, SupportLevel.SUPPORTED),


### PR DESCRIPTION
The only permutation not covered now is for a credential to be obtainable but possibly verifiable, I think by that point the realm will be making the verifiability decision based on the type of the credential type so if it is obtainable either the realm supports verification or it does not - no middle ground.