### PR TITLE
[ELY-194] JaasSecurityRealm enhancements

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -289,4 +289,8 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 79, value = "SASL client refuses to initiate authentication")
     SaslException saslClientRefusesToInitiateAuthentication();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 80, value = "JAAS logout failed for principal %s")
+    void debugJAASLogoutFailure(Principal principal, @Cause Throwable cause);
 }

--- a/src/test/java/org/wildfly/security/sasl/gs2/Gs2Test.java
+++ b/src/test/java/org/wildfly/security/sasl/gs2/Gs2Test.java
@@ -19,8 +19,8 @@
 package org.wildfly.security.sasl.gs2;
 
 import static org.junit.Assert.*;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 import static org.wildfly.security.sasl.gs2.Gs2.*;
 
 import java.io.IOException;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
@@ -21,8 +21,8 @@ package org.wildfly.security.sasl.gssapi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JaasUtil.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JaasUtil.java
@@ -42,9 +42,9 @@ import org.jboss.logging.Logger;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class JAASUtil {
+public class JaasUtil {
 
-    private static Logger log = Logger.getLogger(JAASUtil.class);
+    private static Logger log = Logger.getLogger(JaasUtil.class);
 
     private static final boolean IS_IBM = System.getProperty("java.vendor").contains("IBM");
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientJdkServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientJdkServer.java
@@ -18,8 +18,8 @@
 
 package org.wildfly.security.sasl.gssapi;
 
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientWildFlyServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientWildFlyServer.java
@@ -18,8 +18,8 @@
 
 package org.wildfly.security.sasl.gssapi;
 
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientJdkServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientJdkServer.java
@@ -18,8 +18,8 @@
 
 package org.wildfly.security.sasl.gssapi;
 
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientWildFlyServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientWildFlyServer.java
@@ -18,8 +18,8 @@
 
 package org.wildfly.security.sasl.gssapi;
 
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginClient;
-import static org.wildfly.security.sasl.gssapi.JAASUtil.loginServer;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
+import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
@@ -53,7 +53,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.sasl.gssapi.BaseGssapiTests;
-import org.wildfly.security.sasl.gssapi.JAASUtil;
+import org.wildfly.security.sasl.gssapi.JaasUtil;
 import org.wildfly.security.sasl.gssapi.TestKDC;
 
 /*
@@ -112,8 +112,8 @@ public abstract class AbstractTest {
         testKdc.startDirectoryService();
         testKdc.startKDC();
 
-        clientSubject = JAASUtil.loginClient();
-        serverSubject = JAASUtil.loginServer();
+        clientSubject = JaasUtil.loginClient();
+        serverSubject = JaasUtil.loginServer();
 
     }
 


### PR DESCRIPTION
- JAAS logout is now done when AuthenticatedRealmIdentity is disposed
- Subject "CallerPrincipal" group is now used to setup the authenticated identity principal
- Classes have been renamed to follow the convention for acronyms (Jaas instead of JAAS)