### PR TITLE
Sasl scram username quoting, gs-header checking, base64 fix

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
@@ -181,7 +181,8 @@ class ScramSaslClient extends AbstractSaslClient {
                                     }
                                     b2.append(',');
                                     if (getAuthorizationId() != null) {
-                                        b2.append("a=").append(getAuthorizationId());
+                                        b2.append("a=");
+                                        StringPrep.encode(getAuthorizationId(), b2, StringPrep.PROFILE_SASL_STORED | StringPrep.MAP_SCRAM_LOGIN_CHARS);
                                     }
                                     b2.append(',');
                                     if (plus) {
@@ -192,7 +193,8 @@ class ScramSaslClient extends AbstractSaslClient {
                                     b2.append('n');
                                     b2.append(',');
                                     if (getAuthorizationId() != null) {
-                                        b2.append("a=").append(getAuthorizationId());
+                                        b2.append("a=");
+                                        StringPrep.encode(getAuthorizationId(), b2, StringPrep.PROFILE_SASL_STORED | StringPrep.MAP_SCRAM_LOGIN_CHARS);
                                     }
                                     b2.append(',');
                                     assert !plus;

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -74,13 +74,13 @@ final class ScramSaslServer extends AbstractSaslServer {
     private final String bindingType;
     private final byte[] bindingData;
 
+    private String userName;
     private String authorizationID;
     private byte[] clientFirstMessage;
     private byte[] serverFirstMessage;
     private byte[] saltedPassword;
     private final boolean sendErrors = false;
     private int clientFirstMessageBareStart;
-    private ByteIterator gs2Header;
 
     ScramSaslServer(final String mechanismName, final String protocol, final String serverName, final CallbackHandler callbackHandler, final boolean plus, final Map<String, ?> props, final MessageDigest messageDigest, final Mac mac, final SecureRandom secureRandom, final String bindingType, final byte[] bindingData) {
         super(mechanismName, protocol, serverName, callbackHandler);
@@ -165,15 +165,13 @@ final class ScramSaslServer extends AbstractSaslServer {
                     }
 
                     clientFirstMessageBareStart = bi.offset();
-                    gs2Header = ByteIterator.ofBytes(response).limitedTo(clientFirstMessageBareStart);
 
-                    // login name
-                    String loginName;
+                    // user name
                     if (bi.next() == 'n') {
                         if (bi.next() != '=') {
                             throw invalidClientMessage();
                         }
-                        loginName = StringPrep.decode(cpi, new StringBuilder()).toString();
+                        userName = StringPrep.decode(cpi, new StringBuilder()).toString();
                         bi.next(); // skip delimiter
                     } else {
                         throw invalidClientMessage();
@@ -196,7 +194,7 @@ final class ScramSaslServer extends AbstractSaslServer {
 
                     // get password
 
-                    final NameCallback nameCallback = new NameCallback("Remote authentication name", loginName);
+                    final NameCallback nameCallback = new NameCallback("Remote authentication name", userName);
 
                     // first try pre-digested
 
@@ -306,16 +304,6 @@ final class ScramSaslServer extends AbstractSaslServer {
                         }
                     }
 
-                    final AuthorizeCallback authorizeCallback = new AuthorizeCallback(loginName, authorizationID==null ? loginName : authorizationID);
-                    try {
-                        tryHandleCallbacks(authorizeCallback);
-                    } catch (UnsupportedCallbackException e) {
-                        throw new SaslException("Callback handler does not support authorization", e);
-                    }
-                    if ( ! authorizeCallback.isAuthorized()) {
-                        throw new SaslException(loginName + " not authorized to act as " + authorizationID);
-                    }
-
                     // nonce (client + server nonce)
                     b.append('r').append('=');
                     b.append(nonce);
@@ -346,18 +334,11 @@ final class ScramSaslServer extends AbstractSaslServer {
                         throw invalidClientMessage();
                     }
 
-                    // check equality of gs2-header in FIRST and FINAL
-                    ByteIterator gs2HeaderIt = ByteIterator.ofBytes(response).delimitedBy(',');
-                    gs2HeaderIt.next(); gs2HeaderIt.next(); // skip "c="
-                    if(!gs2Header.contentEquals(gs2HeaderIt.base64Decode())){
-                        throw invalidClientMessage();
-                    }
-
                     final ByteIterator bindingIterator = di.base64Decode();
 
                     // -- sub-parse of binding data --
                     switch (bindingIterator.next()) {
-                        case 'n': {
+                        case 'n': case 'y': { // n,[a=authzid],
                             if (plus) throw new SaslException("Channel binding not provided by client for mechanism " + getMechanismName());
                             if (bindingIterator.next() != ',') {
                                 throw invalidClientMessage();
@@ -368,40 +349,22 @@ final class ScramSaslServer extends AbstractSaslServer {
                                     if (bindingIterator.next() != '=') {
                                         throw invalidClientMessage();
                                     }
-                                    authorizationID = bindingIterator.delimitedBy(',').asUtf8String().drainToString();
-                                    break;
-                                }
-                                default: throw invalidClientMessage();
-                            }
-                            if (bindingIterator.hasNext() && (bindingIterator.next() != ',' || bindingIterator.hasNext())) {
-                                // extra data
-                                throw invalidClientMessage();
-                            }
-                            break;
-                        }
-                        case 'y': {
-                            if (plus) throw new SaslException("Channel binding not provided by client for mechanism " + getMechanismName());
-                            if (bindingIterator.next() != ',') {
-                                throw invalidClientMessage();
-                            }
-                            switch (bindingIterator.next()) {
-                                case ',': break;
-                                case 'a': {
-                                    if (bindingIterator.next() != '=') {
+                                    if(! bindingIterator.delimitedBy(',').asUtf8String().drainToString().equals(authorizationID)) {
                                         throw invalidClientMessage();
                                     }
-                                    authorizationID = bindingIterator.delimitedBy(',').asUtf8String().drainToString();
+                                    if (bindingIterator.next() != ',') {
+                                        throw invalidClientMessage();
+                                    }
                                     break;
                                 }
                                 default: throw invalidClientMessage();
                             }
-                            if (bindingIterator.hasNext() && (bindingIterator.next() != ',' || bindingIterator.hasNext())) {
-                                // extra data
+                            if (bindingIterator.hasNext()) { // require end
                                 throw invalidClientMessage();
                             }
                             break;
                         }
-                        case 'p': {
+                        case 'p': { // p=bindingType,[a=authzid],bindingData
                             if (! plus) {
                                 throw new SaslException("Channel binding not supported for mechanism " + getMechanismName());
                             }
@@ -420,20 +383,23 @@ final class ScramSaslServer extends AbstractSaslServer {
                                     if (bindingIterator.next() != '=') {
                                         throw invalidClientMessage();
                                     }
-                                    authorizationID = bindingIterator.delimitedBy(',').asUtf8String().drainToString();
+                                    if(! bindingIterator.delimitedBy(',').asUtf8String().drainToString().equals(authorizationID)) {
+                                        throw invalidClientMessage();
+                                    }
                                     break;
                                 }
                                 default: throw invalidClientMessage();
+                            }
+                            if (bindingIterator.next() != ',') {
+                                throw invalidClientMessage();
                             }
                             // following is the raw channel binding data
                             if (! bindingIterator.contentEquals(ByteIterator.ofBytes(bindingData))) {
                                 throw new SaslException("Channel binding data mismatch for mechanism " + getMechanismName());
                             }
-                            if (bindingIterator.hasNext() && (bindingIterator.next() != ',' || bindingIterator.hasNext())) {
-                                // extra data
+                            if (bindingIterator.next() != ',' || bindingIterator.hasNext()) { // require end
                                 throw invalidClientMessage();
                             }
-                            // all clear!
                             break;
                         }
                     }
@@ -446,7 +412,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                     while (di.hasNext()) { di.next(); }
 
                     // proof
-                    final int s = bi.offset();
+                    final int proofOffset = bi.offset();
                     bi.next(); // skip delimiter
                     if (bi.next() != 'p' || bi.next() != '=') {
                         throw invalidClientMessage();
@@ -482,8 +448,8 @@ final class ScramSaslServer extends AbstractSaslServer {
                     mac.update(serverFirstMessage);
                     if (DEBUG) System.out.printf("[S] Using server first message: %s%n", ByteIterator.ofBytes(serverFirstMessage).hexEncode().drainToString());
                     mac.update((byte) ',');
-                    mac.update(response, 0, s); // client-final-message-without-proof
-                    if (DEBUG) System.out.printf("[S] Using client final message without proof: %s%n", ByteIterator.ofBytes(copyOfRange(response, 0, s)).hexEncode().drainToString());
+                    mac.update(response, 0, proofOffset); // client-final-message-without-proof
+                    if (DEBUG) System.out.printf("[S] Using client final message without proof: %s%n", ByteIterator.ofBytes(copyOfRange(response, 0, proofOffset)).hexEncode().drainToString());
                     byte[] clientSignature = mac.doFinal();
                     if (DEBUG) System.out.printf("[S] Client signature: %s%n", ByteIterator.ofBytes(clientSignature).hexEncode().drainToString());
 
@@ -503,7 +469,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                     mac.update((byte) ',');
                     mac.update(serverFirstMessage);
                     mac.update((byte) ',');
-                    mac.update(response, 0, s); // client-final-message-without-proof
+                    mac.update(response, 0, proofOffset); // client-final-message-without-proof
                     serverSignature = mac.doFinal();
                     if (DEBUG) System.out.printf("[S] Server signature: %s%n", ByteIterator.ofBytes(serverSignature).hexEncode().drainToString());
 
@@ -525,6 +491,19 @@ final class ScramSaslServer extends AbstractSaslServer {
                             return b.toArray();
                         }
                         throw new SaslException("Authentication rejected (invalid proof)");
+                    }
+
+                    if (authorizationID == null) {
+                        authorizationID = userName;
+                    }
+                    final AuthorizeCallback authorizeCallback = new AuthorizeCallback(userName, authorizationID);
+                    try {
+                        tryHandleCallbacks(authorizeCallback);
+                    } catch (UnsupportedCallbackException e) {
+                        throw new SaslException("Callback handler does not support authorization", e);
+                    }
+                    if ( ! authorizeCallback.isAuthorized()) {
+                        throw new SaslException(userName + " not authorized to act as " + authorizationID);
                     }
 
                     // == send response ==

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -173,7 +173,7 @@ final class ScramSaslServer extends AbstractSaslServer {
                         if (bi.next() != '=') {
                             throw invalidClientMessage();
                         }
-                        loginName = cpi.drainToString();
+                        loginName = StringPrep.decode(cpi, new StringBuilder()).toString();
                         bi.next(); // skip delimiter
                     } else {
                         throw invalidClientMessage();
@@ -284,9 +284,10 @@ final class ScramSaslServer extends AbstractSaslServer {
                             throw new SaslException("Unsupported password algorithm type");
                         }
                         // get the clear password
-                        StringPrep.encode(passwordChars, b, StringPrep.NORMALIZE_KC);
+                        StringPrep.encode(passwordChars, b, StringPrep.PROFILE_SASL_STORED);
                         passwordChars = new String(b.toArray(), StandardCharsets.UTF_8).toCharArray();
                         b.setLength(0);
+
                         iterationCount = algorithmSpec.getIterationCount();
                         salt = algorithmSpec.getSalt();
                         if (iterationCount < minimumIterationCount) {

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -346,29 +346,9 @@ final class ScramSaslServer extends AbstractSaslServer {
                     switch (cbindFlag) {
                         case 'n': case 'y': { // n,[a=authzid],
                             if (plus) throw new SaslException("Channel binding not provided by client for mechanism " + getMechanismName());
-                            if (bindingIterator.next() != ',') {
-                                throw invalidClientMessage();
-                            }
-                            switch (bindingIterator.next()) {
-                                case ',':
-                                    if (authorizationID != null) {
-                                        throw invalidClientMessage();
-                                    }
-                                    break;
-                                case 'a': {
-                                    if (bindingIterator.next() != '=') {
-                                        throw invalidClientMessage();
-                                    }
-                                    if (! bindingIterator.delimitedBy(',').asUtf8String().drainToString().equals(authorizationID)) {
-                                        throw invalidClientMessage();
-                                    }
-                                    if (bindingIterator.next() != ',') {
-                                        throw invalidClientMessage();
-                                    }
-                                    break;
-                                }
-                                default: throw invalidClientMessage();
-                            }
+
+                            parseAuthorizationId(bindingIterator);
+
                             if (bindingIterator.hasNext()) { // require end
                                 throw invalidClientMessage();
                             }
@@ -384,34 +364,13 @@ final class ScramSaslServer extends AbstractSaslServer {
                             if (! bindingType.equals(bindingIterator.delimitedBy(',').asUtf8String().drainToString())) {
                                 throw new SaslException("Channel binding type mismatch for mechanism " + getMechanismName());
                             }
-                            if (bindingIterator.next() != ',') {
-                                throw invalidClientMessage();
-                            }
-                            switch (bindingIterator.next()) {
-                                case ',':
-                                    if (authorizationID != null) {
-                                        throw invalidClientMessage();
-                                    }
-                                    break;
-                                case 'a': {
-                                    if (bindingIterator.next() != '=') {
-                                        throw invalidClientMessage();
-                                    }
-                                    if (! bindingIterator.delimitedBy(',').asUtf8String().drainToString().equals(authorizationID)) {
-                                        throw invalidClientMessage();
-                                    }
-                                    break;
-                                }
-                                default: throw invalidClientMessage();
-                            }
-                            if (bindingIterator.next() != ',') {
-                                throw invalidClientMessage();
-                            }
+                            parseAuthorizationId(bindingIterator);
+
                             // following is the raw channel binding data
                             if (! bindingIterator.contentEquals(ByteIterator.ofBytes(bindingData))) {
                                 throw new SaslException("Channel binding data mismatch for mechanism " + getMechanismName());
                             }
-                            if (bindingIterator.next() != ',' || bindingIterator.hasNext()) { // require end
+                            if (bindingIterator.hasNext()) { // require end
                                 throw invalidClientMessage();
                             }
                             break;
@@ -553,6 +512,32 @@ final class ScramSaslServer extends AbstractSaslServer {
             if (! ok) {
                 setNegotiationState(FAILED_STATE);
             }
+        }
+    }
+
+    private void parseAuthorizationId(ByteIterator bindingIterator) throws SaslException {
+        if (bindingIterator.next() != ',') {
+            throw invalidClientMessage();
+        }
+        switch (bindingIterator.next()) {
+            case ',':
+                if (authorizationID != null) {
+                    throw invalidClientMessage();
+                }
+                break;
+            case 'a': {
+                if (bindingIterator.next() != '=') {
+                    throw invalidClientMessage();
+                }
+                if (! bindingIterator.delimitedBy(',').asUtf8String().drainToString().equals(authorizationID)) {
+                    throw invalidClientMessage();
+                }
+                if (bindingIterator.next() != ',') {
+                    throw invalidClientMessage();
+                }
+                break;
+            }
+            default: throw invalidClientMessage();
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
+++ b/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
@@ -21,6 +21,7 @@ package org.wildfly.security.sasl.util;
 import java.text.Normalizer;
 
 import org.wildfly.security.util.ByteStringBuilder;
+import org.wildfly.security.util.CodePointIterator;
 
 /**
  * Preparation of Internationalized Strings ("stringprep") by RFC 3454
@@ -79,7 +80,7 @@ public final class StringPrep {
 
     // StringPrep section 3 - Mapping
 
-    public static boolean mapCodePointToNothing(int input) {
+    private static boolean mapCodePointToNothing(int input) {
         return input == 0xAD
             || input == 0x034F
             || input == 0x1806
@@ -90,7 +91,7 @@ public final class StringPrep {
             || input == 0xFEFF;
     }
 
-    public static boolean mapCodePointToSpace(int input) {
+    private static boolean mapCodePointToSpace(int input) {
         return input == 0xA0
             || input == 0x1680
             || input >= 0x2000 && input <= 0x200B
@@ -101,19 +102,19 @@ public final class StringPrep {
 
     // StringPrep section 5 - Prohibited I/O
 
-    public static void forbidNonAsciiSpaces(int input) {
+    private static void forbidNonAsciiSpaces(int input) {
         if (mapCodePointToSpace(input)) {
             throw new IllegalArgumentException("Invalid non-ASCII space");
         }
     }
 
-    public static void forbidAsciiControl(int input) {
+    private static void forbidAsciiControl(int input) {
         if (input < 0x20 || input == 0x7F) {
             throw new IllegalArgumentException("Invalid ASCII control");
         }
     }
 
-    public static void forbidNonAsciiControl(int input) {
+    private static void forbidNonAsciiControl(int input) {
         if (input >= 0x80 && input <= 0x9F
             || input == 0x06DD
             || input == 0x070F
@@ -130,37 +131,37 @@ public final class StringPrep {
         }
     }
 
-    public static void forbidPrivateUse(int input) {
+    private static void forbidPrivateUse(int input) {
         if (input >= 0xE000 && input <= 0xF8FF || input >= 0xF0000 && input <= 0xFFFFD || input >= 0x100000 && input <= 0x10FFFD) {
             throw new IllegalArgumentException("Invalid private use character");
         }
     }
 
-    public static void forbidNonCharacter(int input) {
+    private static void forbidNonCharacter(int input) {
         if ((input & 0xFFFE) == 0xFFFE || input >= 0xFDD0 && input <= 0xFDEF) {
             throw new IllegalArgumentException("Invalid non-character code point");
         }
     }
 
-    public static void forbidSurrogate(int input) {
+    private static void forbidSurrogate(int input) {
         if (input >= 0xD800 && input <= 0xDFFF) {
             throw new IllegalArgumentException("Invalid surrogate code point");
         }
     }
 
-    public static void forbidInappropriateForPlainText(int input) {
+    private static void forbidInappropriateForPlainText(int input) {
         if (input >= 0xFFF9 && input <= 0xFFFD) {
             throw new IllegalArgumentException("Invalid plain text code point");
         }
     }
 
-    public static void forbidInappropriateForCanonicalRepresentation(int input) {
+    private static void forbidInappropriateForCanonicalRepresentation(int input) {
         if (input >= 0x2FF0 && input <= 0x2FFB) {
             throw new IllegalArgumentException("Invalid non-canonical code point");
         }
     }
 
-    public static void forbidChangeDisplayPropertiesOrDeprecated(int input) {
+    private static void forbidChangeDisplayPropertiesOrDeprecated(int input) {
         if (input >= 0x0340 && input <= 0x0341
             || input >= 0x200E && input <= 0x200F
             || input >= 0x202A && input <= 0x202E
@@ -169,13 +170,13 @@ public final class StringPrep {
         }
     }
 
-    public static void forbidTagging(int input) {
+    private static void forbidTagging(int input) {
         if (input == 0x0E0001 || input >= 0x0E0020 && input <= 0x0E007F) {
             throw new IllegalArgumentException("Invalid tagging character");
         }
     }
 
-    public static void forbidUnassigned(int input) {
+    private static void forbidUnassigned(int input) {
         if (Character.getType(input) == Character.UNASSIGNED) {
             throw new IllegalArgumentException("Unassigned code point");
         }
@@ -252,6 +253,7 @@ public final class StringPrep {
                 target.append(' ');
                 continue;
             }
+            // Escaping used in GS2 and SCRAM (RFC 5801,5802)
             if (isSet(profile, MAP_SCRAM_LOGIN_CHARS) || isSet(profile, MAP_GS2_LOGIN_CHARS)) {
                 if (cp == '=') {
                     target.append('=').append('3').append('D');
@@ -278,5 +280,31 @@ public final class StringPrep {
             // Now, encode that one
             target.appendUtf8Raw(cp);
         }
+    }
+
+    /**
+     * Decode escaping used in GS2 and SCRAM (RFC 5801,5802)
+     *
+     * @param input
+     * @param output
+     */
+    public static StringBuilder decode(CodePointIterator input, StringBuilder output) {
+        while(input.hasNext()){
+            int ch = input.next();
+            if(ch != '='){
+                output.appendCodePoint(ch);
+            }else{
+                int ch1 = input.next();
+                int ch2 = input.next();
+                if(ch1 == '2' && ch2 == 'C'){
+                    output.appendCodePoint(',');
+                }else if(ch1 == '3' && ch2 == 'D'){
+                    output.appendCodePoint('=');
+                }else{
+                    throw new IllegalArgumentException("Invalid escape sequence"); // server MUST fail
+                }
+            }
+        }
+        return output;
     }
 }

--- a/src/main/java/org/wildfly/security/util/ByteIterator.java
+++ b/src/main/java/org/wildfly/security/util/ByteIterator.java
@@ -218,12 +218,12 @@ public abstract class ByteIterator extends NumericIterator {
 
                 int calc1(final int b0, final int b1) {
                     // d1 = r1[3..0] + r0[7..6]
-                    return alphabet.encode((b1 << 2 | b0 >> 6) & 0x3f);
+                    return alphabet.encode(((b1 << 2) & 0x3f) | ((b0 >> 6) & 0x3));
                 }
 
                 int calc2(final int b1, final int b2) {
                     // d2 = r2[1..0] + r1[7..4]
-                    return alphabet.encode((b2 << 4 | b1 >> 4) & 0x3f);
+                    return alphabet.encode(((b2 << 4) & 0x3f) | ((b1 >> 4) & 0xF));
                 }
 
                 int calc3(final int b2) {
@@ -240,12 +240,12 @@ public abstract class ByteIterator extends NumericIterator {
 
                 int calc1(final int b0, final int b1) {
                     // d1 = r0[1..0] + r1[7..4]
-                    return alphabet.encode((b0 << 4 | b1 >> 4) & 0x3f);
+                    return alphabet.encode(((b0 << 4) & 0x3f) | ((b1 >> 4) & 0xF));
                 }
 
                 int calc2(final int b1, final int b2) {
                     // d2 = r1[3..0] + r2[7..6]
-                    return alphabet.encode((b1 << 2 | b2 >> 6) & 0x3f);
+                    return alphabet.encode(((b1 << 2) & 0x3f) | ((b2 >> 6) & 0x3));
                 }
 
                 int calc3(final int b2) {

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -27,6 +27,7 @@ import java.util.Random;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -84,5 +85,63 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
 
         assertTrue(saslClient.isComplete());
     }
+
+    /**
+     * Test sending authorization id by client
+     */
+    @Test
+    public void testAuthorizationId() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=JFcfWujky5ZULVQwDmB5aHMkoME=", new String(message));
+
+        message = "v=EFUP6P+SBB3T4rZgjRz28Z1FqCg=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Test rejecting bad server nonce (not based on client nonce)
+     */
+    @Test
+    public void testBadNonce() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=XXko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        try{
+            message = saslClient.evaluateChallenge(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslClient.isComplete());
+    }
+
 
 }

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -134,7 +134,7 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
         message = saslClient.evaluateChallenge(message);
         assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
 
-        message = "r=XXko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = "r=BADo+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
         try{
             message = saslClient.evaluateChallenge(message);
             fail("SaslException not throwed");
@@ -143,5 +143,65 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
         assertFalse(saslClient.isComplete());
     }
 
+    /**
+     * Test rejecting bad verifier
+     */
+    @Test
+    public void testBadVerifier() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=JFcfWujky5ZULVQwDmB5aHMkoME=", new String(message));
+
+        message = "v=badP6P+SBB3T4rZgjRz28Z1FqCg=".getBytes(StandardCharsets.UTF_8);
+        try{
+            message = saslClient.evaluateChallenge(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslClient.isComplete());
+    }
+
+    /**
+     * Test authentication with unusual characters in credentials (quoting of ',' and '=')
+     */
+    @Test
+    public void testStrangeCredentials() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("strange=user, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4", "strange=password, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "strange=admin, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=5Drqrw2srEQfQ84h8Okz6eV091w=", new String(message));
+
+        message = "v=7xo0Rb9jQts952duIEz4oaIfD/c=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
 
 }

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -192,11 +192,11 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
 
         byte[] message = AbstractSaslParticipant.NO_BYTES;
         message = saslClient.evaluateChallenge(message);
-        assertEquals("n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+        assertEquals("n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,r=fyko+d2lbbFgONRv9qkxdawL", new String(message, StandardCharsets.UTF_8));
 
         message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
         message = saslClient.evaluateChallenge(message);
-        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=5Drqrw2srEQfQ84h8Okz6eV091w=", new String(message));
+        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=5Drqrw2srEQfQ84h8Okz6eV091w=", new String(message, StandardCharsets.UTF_8));
 
         message = "v=7xo0Rb9jQts952duIEz4oaIfD/c=".getBytes(StandardCharsets.UTF_8);
         message = saslClient.evaluateChallenge(message);

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -87,6 +87,7 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         assertEquals("v=rmF9pqV8S7suAoZWja4dJRkFsKQ=", new String(message));
 
         assertTrue(saslServer.isComplete());
+        assertEquals("user", saslServer.getAuthorizationID());
     }
 
     /**
@@ -152,23 +153,22 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
         assertNotNull(serverFactory);
 
-        CallbackHandler cbh = new ServerCallbackHandler("user", "clear", new ClearPasswordSpec("pencil".toCharArray()));
-        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost",
-                Collections.emptyMap(), cbh);
+        CallbackHandler cbh = new ServerCallbackHandler("admin", "clear", new ClearPasswordSpec("pencil".toCharArray()), "user");
+        final SaslServer saslServer = serverFactory.createSaslServer(Scram.SCRAM_SHA_1, "test", "localhost", Collections.emptyMap(), cbh);
         assertNotNull(saslServer);
         assertTrue(saslServer instanceof ScramSaslServer);
 
-        byte[] message = "n,a=user,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        byte[] message = "n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
         assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
 
         //         c="n,a=user,"
-        message = "c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ="
-                .getBytes(StandardCharsets.UTF_8);
+        message = "c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=sSem09WkghLJOV/Ma5LjIqUtoo8=".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
-        assertEquals("v=n1qgUn3vi9dh7nG1+Giie5qsaVQ=", new String(message));
+        assertEquals("v=xzTfS758LckdRoQKN/ZFY/Bauxo=", new String(message));
 
         assertTrue(saslServer.isComplete());
+        assertEquals(saslServer.getAuthorizationID(),"user");
     }
 
     /**
@@ -188,6 +188,10 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
         assertTrue(saslServer instanceof ScramSaslServer);
 
         byte[] message = "n,a=admin,n=user,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        message = saslServer.evaluateResponse(message);
+        assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message));
+
+        message = "c=bixhPWFkbWluLA==,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=NdEpo1qMJaCn9xyrYplfuEKubqQ=".getBytes(StandardCharsets.UTF_8);
         try {
             saslServer.evaluateResponse(message);
             fail("SaslException not throwed");
@@ -258,7 +262,7 @@ public class ScramServerCompatibilityTest extends BaseTestCase {
     }
 
     /**
-     * Test authentication with unusual characters in credentials (quoting of "n" and "a")
+     * Test authentication with unusual characters in credentials (quoting of ',' and '=')
      */
     @Test
     public void testStrangeCredentials() throws Exception {

--- a/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
@@ -30,6 +30,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 
+import org.wildfly.security.auth.callback.ChannelBindingCallback;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
@@ -46,6 +47,8 @@ public class ClientCallbackHandler implements CallbackHandler {
     private final KeySpec keySpec;
     private final String realm;
     private final String algorithm;
+    private String bindingType = null;
+    private byte[] bindingData = null;
 
     public ClientCallbackHandler(final String username, final char[] password) {
         this(username, password, null);
@@ -65,6 +68,11 @@ public class ClientCallbackHandler implements CallbackHandler {
         this.password = null;
         this.algorithm = algorithm;
         this.keySpec = keySpec;
+    }
+
+    public void setBinding(String bindingType, byte[] bindingData){
+        this.bindingType = bindingType;
+        this.bindingData = bindingData;
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -108,6 +116,10 @@ public class ClientCallbackHandler implements CallbackHandler {
                 } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                     throw new IOException("Password object generation failed", e);
                 }
+            } else if (current instanceof ChannelBindingCallback && bindingType != null) {
+                ChannelBindingCallback cbc = (ChannelBindingCallback) current;
+                cbc.setBindingType(bindingType);
+                cbc.setBindingData(bindingData);
             } else {
                 throw new UnsupportedCallbackException(current, current.getClass().getSimpleName() + " not supported.");
             }

--- a/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
@@ -33,6 +33,7 @@ import javax.security.sasl.SaslException;
 
 import org.junit.Assert;
 import org.wildfly.security.auth.callback.AnonymousAuthorizationCallback;
+import org.wildfly.security.auth.callback.ChannelBindingCallback;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
@@ -51,6 +52,8 @@ public class ServerCallbackHandler implements CallbackHandler {
     private final String expectedAuthzid;
     private final KeySpec keySpec;
     private final String algorithm;
+    private String bindingType = null;
+    private byte[] bindingData = null;
 
     public ServerCallbackHandler(final String expectedUsername, final char[] expectedPassword) {
         this.expectedUsername = expectedUsername;
@@ -74,6 +77,11 @@ public class ServerCallbackHandler implements CallbackHandler {
         this.keySpec = keyspec;
         expectedAuthzid = authzid;
         expectedPassword = null;
+    }
+
+    public void setBinding(String bindingType, byte[] bindingData){
+        this.bindingType = bindingType;
+        this.bindingData = bindingData;
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -111,6 +119,10 @@ public class ServerCallbackHandler implements CallbackHandler {
                 } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                     throw new IOException("Password object generation failed", e);
                 }
+            } else if (current instanceof ChannelBindingCallback && bindingType != null) {
+                ChannelBindingCallback cbc = (ChannelBindingCallback) current;
+                cbc.setBindingType(bindingType);
+                cbc.setBindingData(bindingData);
             } else {
                 throw new UnsupportedCallbackException(current, current.getClass().getSimpleName() + " not supported.");
             }

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -218,6 +218,16 @@ public class StringPrepTest {
     }
 
     /**
+     * RFC 5802 5.1. SCRAM Attributes - characters ',' or '=' in usernames
+     */
+    @Test
+    public void testUnMappingScramLoginChars() {
+        ByteStringBuilder b = new ByteStringBuilder();
+        StringPrep.encode("a=2Cb=3Dc=2C", b, StringPrep.UNMAP_SCRAM_LOGIN_CHARS);
+        Assert.assertArrayEquals(new byte[]{'a', ',', 'b', '=', 'c', ','}, b.toArray());
+    }
+
+    /**
      * RFC 3454 4. Normalization (sanity check)
      */
     @Test

--- a/src/test/java/org/wildfly/security/util/Base64Test.java
+++ b/src/test/java/org/wildfly/security/util/Base64Test.java
@@ -111,6 +111,54 @@ public class Base64Test {
         Assert.assertArrayEquals(input, CodePointIterator.ofString(output).base64Decode().drain());
     }
 
+    @Test
+    public void testEncodeBytes1() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0x00);
+        bsb.append((byte)0xB8);
+        assertEquals("ALg=", bsb.iterate().base64Encode().drainToString());
+    }
+
+    @Test
+    public void testEncodeBytes2() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0x01);
+        bsb.append((byte)0xB8);
+        assertEquals("Abg=", bsb.iterate().base64Encode().drainToString());
+    }
+
+    @Test
+    public void testEncodeBytes3() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0xF0);
+        bsb.append((byte)0xF0);
+        bsb.append((byte)0xF0);
+        assertEquals("8PDw", bsb.iterate().base64Encode().drainToString());
+    }
+
+    @Test
+    public void testEncodeBytes4() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0xD0);
+        bsb.append((byte)0xB8);
+        bsb.append((byte)0xE4);
+        bsb.append((byte)0xBD);
+        bsb.append((byte)0xA0);
+        bsb.append((byte)0xF0);
+        bsb.append((byte)0x9F);
+        bsb.append((byte)0x82);
+        bsb.append((byte)0xA1);
+        bsb.append((byte)0x31);
+        bsb.append((byte)0xE2);
+        bsb.append((byte)0x81);
+        bsb.append((byte)0x84);
+        bsb.append((byte)0x32);
+        bsb.append((byte)0x20);
+        bsb.append((byte)0xCC);
+        bsb.append((byte)0x81);
+        assertEquals("0LjkvaDwn4KhMeKBhDIgzIE=", bsb.iterate().base64Encode().drainToString());
+    }
+
 
     /*
      * Standard Base64 alphabet decoding


### PR DESCRIPTION
* Added quoting/unquoting of username and authzid into Scram server and client
* Added unquoting into Stringprep (+ internal methods set as private)
* Fixed/cleared parsing/checking of gs-header in Scram server
* Fixed discovered bug in Base64 encoding
* (+ tests of it)