### PR TITLE
Scram - quoting, channel binding, gs-header checking fix

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClient.java
@@ -181,7 +181,8 @@ class ScramSaslClient extends AbstractSaslClient {
                                     }
                                     b2.append(',');
                                     if (getAuthorizationId() != null) {
-                                        b2.append("a=").append(getAuthorizationId());
+                                        b2.append("a=");
+                                        StringPrep.encode(getAuthorizationId(), b2, StringPrep.PROFILE_SASL_STORED | StringPrep.MAP_SCRAM_LOGIN_CHARS);
                                     }
                                     b2.append(',');
                                     if (plus) {
@@ -192,7 +193,8 @@ class ScramSaslClient extends AbstractSaslClient {
                                     b2.append('n');
                                     b2.append(',');
                                     if (getAuthorizationId() != null) {
-                                        b2.append("a=").append(getAuthorizationId());
+                                        b2.append("a=");
+                                        StringPrep.encode(getAuthorizationId(), b2, StringPrep.PROFILE_SASL_STORED | StringPrep.MAP_SCRAM_LOGIN_CHARS);
                                     }
                                     b2.append(',');
                                     assert !plus;

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServer.java
@@ -173,7 +173,9 @@ final class ScramSaslServer extends AbstractSaslServer {
                         if (bi.next() != '=') {
                             throw invalidClientMessage();
                         }
-                        loginName = cpi.drainToString();
+                        ByteStringBuilder bsb = new ByteStringBuilder();
+                        StringPrep.encode(cpi.drainToString(), bsb, StringPrep.PROFILE_SASL_QUERY | StringPrep.UNMAP_SCRAM_LOGIN_CHARS);
+                        loginName = new String(bsb.toArray(), StandardCharsets.UTF_8);
                         bi.next(); // skip delimiter
                     } else {
                         throw invalidClientMessage();
@@ -284,9 +286,10 @@ final class ScramSaslServer extends AbstractSaslServer {
                             throw new SaslException("Unsupported password algorithm type");
                         }
                         // get the clear password
-                        StringPrep.encode(passwordChars, b, StringPrep.NORMALIZE_KC);
+                        StringPrep.encode(passwordChars, b, StringPrep.PROFILE_SASL_STORED);
                         passwordChars = new String(b.toArray(), StandardCharsets.UTF_8).toCharArray();
                         b.setLength(0);
+
                         iterationCount = algorithmSpec.getIterationCount();
                         salt = algorithmSpec.getSalt();
                         if (iterationCount < minimumIterationCount) {

--- a/src/main/java/org/wildfly/security/util/ByteStringBuilder.java
+++ b/src/main/java/org/wildfly/security/util/ByteStringBuilder.java
@@ -376,22 +376,22 @@ public final class ByteStringBuilder {
 
             public int next() throws NoSuchElementException {
                 if (! hasNext()) throw new NoSuchElementException();
-                return content[idx ++];
+                return content[idx ++] & 0xff;
             }
 
             public int peekNext() throws NoSuchElementException {
                 if (! hasNext()) throw new NoSuchElementException();
-                return content[idx];
+                return content[idx] & 0xff;
             }
 
             public int prev() throws NoSuchElementException {
                 if (! hasPrev()) throw new NoSuchElementException();
-                return content[--idx];
+                return content[--idx] & 0xff;
             }
 
             public int peekPrev() throws NoSuchElementException {
                 if (! hasPrev()) throw new NoSuchElementException();
-                return content[idx - 1];
+                return content[idx - 1] & 0xff;
             }
 
             public int offset() {

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -18,15 +18,22 @@
 
 package org.wildfly.security.sasl.scram;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -34,6 +41,7 @@ import mockit.integration.junit4.JMockit;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.ClientCallbackHandler;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
@@ -83,6 +91,219 @@ public class ScramClientCompatibilityTest extends BaseTestCase {
         message = saslClient.evaluateChallenge(message);
 
         assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Test sending authorization id by client
+     */
+    @Test
+    public void testAuthorizationId() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=JFcfWujky5ZULVQwDmB5aHMkoME=", new String(message));
+
+        message = "v=EFUP6P+SBB3T4rZgjRz28Z1FqCg=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Test rejecting bad server nonce (not based on client nonce)
+     */
+    @Test
+    public void testBadNonce() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=BADo+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        try{
+            message = saslClient.evaluateChallenge(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslClient.isComplete());
+    }
+
+    /**
+     * Test rejecting bad verifier
+     */
+    @Test
+    public void testBadVerifier() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=JFcfWujky5ZULVQwDmB5aHMkoME=", new String(message));
+
+        message = "v=badP6P+SBB3T4rZgjRz28Z1FqCg=".getBytes(StandardCharsets.UTF_8);
+        try{
+            message = saslClient.evaluateChallenge(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+        }
+        assertFalse(saslClient.isComplete());
+    }
+
+    /**
+     * Test authentication with unusual characters in credentials (quoting of ',' and '=' + normalization)
+     */
+    @Test
+    public void testStrangeCredentials() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("strange=user, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4", "strange=password, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "strange=admin, \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,r=fyko+d2lbbFgONRv9qkxdawL", new String(message, StandardCharsets.UTF_8));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=5Drqrw2srEQfQ84h8Okz6eV091w=", new String(message, StandardCharsets.UTF_8));
+
+        message = "v=7xo0Rb9jQts952duIEz4oaIfD/c=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Client does support channel binding and thinks the server does not
+     */
+    @Test
+    public void testBindingCorrectY() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        ClientCallbackHandler cbh = new ClientCallbackHandler("user", "pencil".toCharArray());
+        cbh.setBinding("same-type", new byte[]{0x12,',',0x00});
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, null, "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("y,,n=user,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=eSws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=BjZF5dV+EkD3YCb3pH3IP8riMGw=", new String(message));
+
+        message = "v=dsprQ5R2AGYt1kn4bQRwTAE0PTU=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Client does support channel binding and server too
+     */
+    @Test
+    public void testBindingCorrectP() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        ClientCallbackHandler cbh = new ClientCallbackHandler("user", "pencil".toCharArray());
+        cbh.setBinding("same-type", new byte[]{0x12,',',0x00});
+        Map<String, String> props = new HashMap<String, String>();
+        props.put(WildFlySasl.CHANNEL_BINDING_REQUIRED, "true");
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1_PLUS }, null, "protocol", "localhost", props, cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("p=same-type,,n=user,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=cD1zYW1lLXR5cGUsLBIsAA==,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=0xrnDt+5S5sPyZE7IiTMKHbuZGQ=", new String(message));
+
+        message = "v=ooHARfuURZosAZ4dAMTwrFBGBFc=".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+
+        assertTrue(saslClient.isComplete());
+    }
+
+    /**
+     * Test receiving server-error
+     */
+    @Test
+    public void testServerError() throws Exception {
+        mockNonce("fyko+d2lbbFgONRv9qkxdawL");
+
+        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        assertNotNull(clientFactory);
+
+        CallbackHandler cbh = new ClientCallbackHandler("admin", "secret".toCharArray());
+        final SaslClient saslClient = clientFactory.createSaslClient(new String[] { Scram.SCRAM_SHA_1 }, "user", "protocol", "localhost", Collections.emptyMap(), cbh);
+        assertNotNull(saslClient);
+        assertTrue(saslClient instanceof ScramSaslClient);
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("n,a=user,n=admin,r=fyko+d2lbbFgONRv9qkxdawL", new String(message));
+
+        message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
+        message = saslClient.evaluateChallenge(message);
+        assertEquals("c=bixhPXVzZXIs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=JFcfWujky5ZULVQwDmB5aHMkoME=", new String(message));
+
+        message = "e=abcd".getBytes(StandardCharsets.UTF_8);
+        try{
+            message = saslClient.evaluateChallenge(message);
+            fail("SaslException not throwed");
+        } catch (SaslException e) {
+            if(! e.getMessage().contains("abcd")) fail("SaslException not contain error message");
+        }
+        assertFalse(saslClient.isComplete());
     }
 
 }

--- a/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
@@ -30,6 +30,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 
+import org.wildfly.security.auth.callback.ChannelBindingCallback;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
@@ -46,6 +47,8 @@ public class ClientCallbackHandler implements CallbackHandler {
     private final KeySpec keySpec;
     private final String realm;
     private final String algorithm;
+    private String bindingType = null;
+    private byte[] bindingData = null;
 
     public ClientCallbackHandler(final String username, final char[] password) {
         this(username, password, null);
@@ -65,6 +68,11 @@ public class ClientCallbackHandler implements CallbackHandler {
         this.password = null;
         this.algorithm = algorithm;
         this.keySpec = keySpec;
+    }
+
+    public void setBinding(String bindingType, byte[] bindingData){
+        this.bindingType = bindingType;
+        this.bindingData = bindingData;
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -108,6 +116,10 @@ public class ClientCallbackHandler implements CallbackHandler {
                 } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                     throw new IOException("Password object generation failed", e);
                 }
+            } else if (current instanceof ChannelBindingCallback && bindingType != null) {
+                ChannelBindingCallback cbc = (ChannelBindingCallback) current;
+                cbc.setBindingType(bindingType);
+                cbc.setBindingData(bindingData);
             } else {
                 throw new UnsupportedCallbackException(current, current.getClass().getSimpleName() + " not supported.");
             }

--- a/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
@@ -31,7 +31,9 @@ import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
 
+import org.junit.Assert;
 import org.wildfly.security.auth.callback.AnonymousAuthorizationCallback;
+import org.wildfly.security.auth.callback.ChannelBindingCallback;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
@@ -47,12 +49,16 @@ public class ServerCallbackHandler implements CallbackHandler {
 
     private final String expectedUsername;
     private final char[] expectedPassword;
+    private final String expectedAuthzid;
     private final KeySpec keySpec;
     private final String algorithm;
+    private String bindingType = null;
+    private byte[] bindingData = null;
 
     public ServerCallbackHandler(final String expectedUsername, final char[] expectedPassword) {
         this.expectedUsername = expectedUsername;
         this.expectedPassword = expectedPassword;
+        expectedAuthzid = null;
         keySpec = null;
         algorithm = null;
     }
@@ -61,7 +67,21 @@ public class ServerCallbackHandler implements CallbackHandler {
         this.expectedUsername = expectedUsername;
         this.algorithm = algorithm;
         this.keySpec = keyspec;
+        expectedAuthzid = null;
         expectedPassword = null;
+    }
+
+    public ServerCallbackHandler(final String expectedUsername, final String algorithm, KeySpec keyspec, String authzid) {
+        this.expectedUsername = expectedUsername;
+        this.algorithm = algorithm;
+        this.keySpec = keyspec;
+        expectedAuthzid = authzid;
+        expectedPassword = null;
+    }
+
+    public void setBinding(String bindingType, byte[] bindingData){
+        this.bindingType = bindingType;
+        this.bindingData = bindingData;
     }
 
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
@@ -81,7 +101,12 @@ public class ServerCallbackHandler implements CallbackHandler {
                 ((AnonymousAuthorizationCallback) current).setAuthorized(true);
             } else if (current instanceof AuthorizeCallback) {
                 AuthorizeCallback acb = (AuthorizeCallback) current;
-                acb.setAuthorized(acb.getAuthenticationID().equals(acb.getAuthorizationID()));
+                Assert.assertEquals(expectedUsername, acb.getAuthenticationID());
+                if(expectedAuthzid != null){
+                    acb.setAuthorized(expectedAuthzid.equals(acb.getAuthorizationID()));
+                }else{
+                    acb.setAuthorized(expectedUsername.equals(acb.getAuthorizationID()));
+                }
             } else if (current instanceof RealmCallback) {
             } else if (current instanceof CredentialCallback && algorithm != null && keySpec != null) {
                 CredentialCallback ccb = (CredentialCallback) current;
@@ -94,6 +119,10 @@ public class ServerCallbackHandler implements CallbackHandler {
                 } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                     throw new IOException("Password object generation failed", e);
                 }
+            } else if (current instanceof ChannelBindingCallback && bindingType != null) {
+                ChannelBindingCallback cbc = (ChannelBindingCallback) current;
+                cbc.setBindingType(bindingType);
+                cbc.setBindingData(bindingData);
             } else {
                 throw new UnsupportedCallbackException(current, current.getClass().getSimpleName() + " not supported.");
             }

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -218,6 +218,16 @@ public class StringPrepTest {
     }
 
     /**
+     * RFC 5802 5.1. SCRAM Attributes - characters ',' or '=' in usernames
+     */
+    @Test
+    public void testUnMappingScramLoginChars() {
+        ByteStringBuilder b = new ByteStringBuilder();
+        StringPrep.encode("a=2Cb=3Dc=2C", b, StringPrep.UNMAP_SCRAM_LOGIN_CHARS);
+        Assert.assertArrayEquals(new byte[]{'a', ',', 'b', '=', 'c', ','}, b.toArray());
+    }
+
+    /**
      * RFC 3454 4. Normalization (sanity check)
      */
     @Test

--- a/src/test/java/org/wildfly/security/util/Base64Test.java
+++ b/src/test/java/org/wildfly/security/util/Base64Test.java
@@ -111,6 +111,37 @@ public class Base64Test {
         Assert.assertArrayEquals(input, CodePointIterator.ofString(output).base64Decode().drain());
     }
 
+    @Test
+    public void testEncodeByteStartingWithOne() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0x00);
+        bsb.append((byte)0xB8);
+        assertEquals("ALg=", bsb.iterate().base64Encode().drainToString());
+    }
+
+    @Test
+    public void testEncodeMoreBinaryBytes() {
+        ByteStringBuilder bsb = new ByteStringBuilder();
+        bsb.append((byte)0xD0);
+        bsb.append((byte)0xB8);
+        bsb.append((byte)0xE4);
+        bsb.append((byte)0xBD);
+        bsb.append((byte)0xA0);
+        bsb.append((byte)0xF0);
+        bsb.append((byte)0x9F);
+        bsb.append((byte)0x82);
+        bsb.append((byte)0xA1);
+        bsb.append((byte)0x31);
+        bsb.append((byte)0xE2);
+        bsb.append((byte)0x81);
+        bsb.append((byte)0x84);
+        bsb.append((byte)0x32);
+        bsb.append((byte)0x20);
+        bsb.append((byte)0xCC);
+        bsb.append((byte)0x81);
+        assertEquals("0LjkvaDwn4KhMeKBhDIgzIE=", bsb.iterate().base64Encode().drainToString());
+    }
+
 
     /*
      * Standard Base64 alphabet decoding


### PR DESCRIPTION
Fixed version of #161 

* Added quoting/unquoting of username and authzid into Scram server and client
* Added unquoting into Stringprep
* Fixed missing `&0xFF` in ByteStringBuilder (discovered in Base64 tests)
* Scram server refactoring:
 * loginName renamed to userName (could be confusing because in all other SASL mechanisms and RFC is username/userName)
 * authorization check moved after checking equality of gs-header in client messages
 * parsing of `y` and `n` is identical in final message, so I merged it into one part of switch
 * added  checking of equality of parts gs-header (removed checking as one string from base64, because I I overlooked before, channel binding data are only in final client messages)
 * More meaningful name of `s`/`proofOffset` variable