### PR TITLE
i18n - sasl  internationalization + refactoring

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -47,6 +47,7 @@ import org.jboss.logging.annotations.Param;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.wildfly.client.config.ConfigXMLParseException;
+import org.wildfly.security.asn1.ASN1Exception;
 import org.wildfly.security.auth.callback.FastUnsupportedCallbackException;
 import org.wildfly.security.auth.spi.RealmUnavailableException;
 import org.wildfly.security.util.DecodeException;
@@ -67,37 +68,35 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1, value = "WildFly Elytron version %s")
     void logVersion(String versionString);
 
-    @Message(value = "Parse error")
+    @Message(id = 2, value = "Parse error")
     String parseError();
 
-    @Message(id = 2, value = "No algorithm found matching TLS/SSL protocol selection criteria")
+    @Message(id = 3, value = "No algorithm found matching TLS/SSL protocol selection criteria")
     NoSuchAlgorithmException noAlgorithmForSslProtocol();
 
-    @Message(id = 3, value = "Empty certificate chain is not trusted")
+    @Message(id = 4, value = "Empty certificate chain is not trusted")
     CertificateException emptyChainNotTrusted();
 
-    @Message(id = 4, value = "Certificate not trusted due to realm failure for principal %s")
+    @Message(id = 5, value = "Certificate not trusted due to realm failure for principal %s")
     CertificateException notTrustedRealmProblem(@Cause RealmUnavailableException e, Principal principal);
 
-    @Message(id = 5, value = "Credential validation failed; certificate is not trusted for principal %s")
+    @Message(id = 6, value = "Credential validation failed; certificate is not trusted for principal %s")
     CertificateException notTrusted(Principal principal);
 
-    @Message(id = 6, value = "No module found for identifier \"%s\"")
+    @Message(id = 7, value = "No module found for identifier \"%s\"")
     ConfigXMLParseException noModuleFound(@Param XMLStreamReader reader, @Cause ModuleLoadException e, ModuleIdentifier id);
 
-    @Message(id = 7, value = "Invalid port number \"%s\" specified for attribute \"%s\" of element \"%s\"; expected a numerical value between 1 and 65535 (inclusive)")
+    @Message(id = 8, value = "Invalid port number \"%s\" specified for attribute \"%s\" of element \"%s\"; expected a numerical value between 1 and 65535 (inclusive)")
     ConfigXMLParseException xmlInvalidPortNumber(@Param XMLStreamReader reader, String attributeValue, String attributeName, QName elementName);
 
-    @Message(id = 8, value = "No authentication is in progress")
+    @Message(id = 9, value = "No authentication is in progress")
     IllegalStateException noAuthenticationInProgress();
 
-    @Message(id = 9, value = "No successful authentication on this context")
+    @Message(id = 10, value = "No successful authentication on this context")
     IllegalStateException noSuccessfulAuthentication();
 
-    @Message(id = 10, value = "Authentication already initiated on this context")
+    @Message(id = 11, value = "Authentication already initiated on this context")
     IllegalStateException alreadyInitiated();
-
-    // id = 11
 
     @Message(id = 12, value = "Realm map does not contain mapping for default realm '%s'")
     IllegalArgumentException realmMapDoesntContainDefault(String defaultRealm);
@@ -126,187 +125,186 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 20, value = "Unexpected end of file")
     EOFException unexpectedEof();
 
-    @Message(id = 21, value = "SASL exchange received a message after authentication was already complete")
-    SaslException saslMessageAfterComplete();
+    @Message(id = 21, value = "[%s] SASL exchange received a message after authentication was already complete")
+    SaslException saslMessageAfterComplete(String mechName);
 
-    @Message(id = 22, value = "SASL user name contains an invalid or disallowed character")
-    SaslException saslUserNameContainsInvalidCharacter();
+    @Message(id = 22, value = "[%s] SASL user name contains an invalid or disallowed character")
+    SaslException saslUserNameContainsInvalidCharacter(String mechName);
 
-    @Message(id = 23, value = "SASL user name could not be decoded from encoding \"%s\"")
-    SaslException saslUserNameDecodeFailed(String encodingName);
+    @Message(id = 23, value = "[%s] SASL user name could not be decoded from encoding \"%s\"")
+    SaslException saslUserNameDecodeFailed(String mechName, String encodingName);
 
-    @Message(id = 24, value = "SASL authorization failed")
-    SaslException saslAuthorizationFailed(@Cause Throwable cause);
+    @Message(id = 24, value = "[%s] SASL authorization failed")
+    SaslException saslAuthorizationFailed(String mechName, @Cause Throwable cause);
 
-    @Message(id = 25, value = "SASL authentication is not yet complete")
-    IllegalStateException saslAuthenticationNotComplete();
+    @Message(id = 25, value = "[%s] SASL authentication is not yet complete")
+    IllegalStateException saslAuthenticationNotComplete(String mechName);
 
-    @Message(id = 26, value = "No SASL security layer is currently in force")
-    SaslException saslNoSecurityLayer();
+    @Message(id = 26, value = "[%s] SASL mechanism not support security layer (wrapping/unwrapping)")
+    SaslException saslNoSecurityLayer(String mechName);
 
-    @Message(id = 27, value = "Invalid SASL negotiation message received")
-    SaslException saslInvalidMessageReceived();
+    @Message(id = 27, value = "[%s] Invalid SASL negotiation message received")
+    SaslException saslInvalidMessageReceived(String mechName);
 
-    @Message(id = 28, value = "SASL client-side authentication failed")
-    SaslException saslClientSideAuthenticationFailed(@Cause Exception e);
+    @Message(id = 28, value = "[%s] No SASL login name was given")
+    SaslException saslNoLoginNameGiven(String mechName);
 
-    @Message(id = 29, value = "No SASL login name was given")
-    SaslException saslNoLoginNameGiven();
+    @Message(id = 29, value = "[%s] No SASL password was given")
+    SaslException saslNoPasswordGiven(String mechName);
 
-    @Message(id = 30, value = "No SASL password was given")
-    SaslException saslNoPasswordGiven();
+    @Message(id = 30, value = "[%s] SASL authentication failed due to one or more malformed fields")
+    SaslException saslMalformedFields(String mechName, @Cause IllegalArgumentException ex);
 
-    @Message(id = 31, value = "SASL authentication failed due to one or more malformed fields")
-    SaslException saslMalformedFields(@Cause IllegalArgumentException ex);
+    @Message(id = 31, value = "[%s] SASL message is too long")
+    SaslException saslMessageTooLong(String mechName);
 
-    @Message(id = 32, value = "SASL message is too long")
-    SaslException saslMessageTooLong();
+    @Message(id = 32, value = "[%s] SASL server-side authentication failed")
+    SaslException saslServerSideAuthenticationFailed(String mechName, @Cause Exception e);
 
-    @Message(id = 33, value = "SASL server-side authentication failed")
-    SaslException saslServerSideAuthenticationFailed(@Cause Exception e);
+    @Message(id = 33, value = "[%s] SASL password not verified")
+    SaslException saslPasswordNotVerified(String mechName);
 
-    @Message(id = 34, value = "SASL password not verified")
-    SaslException saslPasswordNotVerified();
+    @Message(id = 34, value = "[%s] SASL authorization failed: \"%s\" is not authorized to act on behalf of \"%s\"")
+    SaslException saslAuthorizationFailed(String mechName, String userName, String authorizationId);
 
-    @Message(id = 35, value = "SASL authorization failed: \"%s\" is not authorized to act on behalf of \"%s\"")
-    SaslException saslAuthorizationFailed(String loginName, String authorizationId);
-
-    @Message(id = 36, value = "Unexpected character U+%04x at offset %d of mechanism selection string \"%s\"")
+    @Message(id = 35, value = "Unexpected character U+%04x at offset %d of mechanism selection string \"%s\"")
     IllegalArgumentException mechSelectorUnexpectedChar(int codePoint, int offset, String string);
 
-    @Message(id = 37, value = "Unrecognized token \"%s\" in mechanism selection string \"%s\"")
+    @Message(id = 36, value = "Unrecognized token \"%s\" in mechanism selection string \"%s\"")
     IllegalArgumentException mechSelectorUnknownToken(String word, String string);
 
-    @Message(id = 38, value = "Token \"%s\" not allowed at offset %d of mechanism selection string \"%s\"")
+    @Message(id = 37, value = "Token \"%s\" not allowed at offset %d of mechanism selection string \"%s\"")
     IllegalArgumentException mechSelectorTokenNotAllowed(String token, int offset, String string);
 
-    @Message(id = 39, value = "Expected token \"%s\" at offset %d of mechanism selection string \"%s\"")
+    @Message(id = 38, value = "Expected token \"%s\" at offset %d of mechanism selection string \"%s\"")
     IllegalArgumentException mechSelectorTokenExpected(String token, int offset, String string);
 
-    @Message(id = 40, value = "Proxied SASL authentication failed")
-    SaslException saslProxyAuthenticationFailed();
+    @Message(id = 39, value = "[%s] Proxied SASL authentication failed")
+    SaslException saslProxyAuthenticationFailed(String mechName);
 
-    @Message(id = 41, value = "No SASL client mechanism \"%s\" is available with the current configuration from %s")
+    @Message(id = 40, value = "No SASL client mechanism \"%s\" is available with the current configuration from %s")
     SaslException saslNoClientMechanism(String mechName, SaslClientFactory clientFactory);
 
-    @Message(id = 42, value = "No SASL server mechanism \"%s\" is available with the current configuration from %s")
+    @Message(id = 41, value = "No SASL server mechanism \"%s\" is available with the current configuration from %s")
     SaslException saslNoServerMechanism(String mechName, SaslServerFactory serverFactory);
 
-    @Message(id = 43, value = "A revertible load is not possible until the KeyStore has first been initialised")
+    @Message(id = 42, value = "A revertible load is not possible until the KeyStore has first been initialised")
     IllegalStateException revertibleLoadNotPossible();
 
-    @Message(id = 44, value = "Unable to create a new KeyStore instance")
+    @Message(id = 43, value = "Unable to create a new KeyStore instance")
     IOException unableToCreateKeyStore(@Cause Exception cause);
 
-    @Message(id = 45, value = "Invalid password type for alias %s (expected %s, got %s)")
+    @Message(id = 44, value = "Invalid password type for alias %s (expected %s, got %s)")
     KeyStoreException invalidPasswordType(String alias, Class<?> expectedClass, Class<?> actualClass);
 
-    @Message(id = 46, value = "The password entry must contain a non null realm name")
+    @Message(id = 45, value = "The password entry must contain a non null realm name")
     KeyStoreException invalidNullRealmInPasswordEntry();
 
-    @Message(id = 47, value = "The password entry realm for alias %s must match the properties-based keystore realm. (expected %s, got %s)")
+    @Message(id = 46, value = "The password entry realm for alias %s must match the properties-based keystore realm. (expected %s, got %s)")
     KeyStoreException invalidRealmNameInPasswordEntry(String alias, String keyStoreRealm, String actualRealm);
 
-    @Message(id = 48, value = "Invalid algorithm found in password entry for alias %s (expected %s, got %s)")
+    @Message(id = 47, value = "Invalid algorithm found in password entry for alias %s (expected %s, got %s)")
     KeyStoreException invalidAlgorithmInPasswordEntry(String alias, String expectedAlgorithm, String actualAlgorithm);
 
-    @Message(id = 49, value = "No realm name found in properties file")
+    @Message(id = 48, value = "No realm name found in properties file")
     IOException noRealmFoundInProperties();
 
-    @Message(id = 50, value = "Unexpected padding")
+    @Message(id = 49, value = "Unexpected padding")
     DecodeException unexpectedPadding();
 
-    @Message(id = 51, value = "Expected padding")
+    @Message(id = 50, value = "Expected padding")
     DecodeException expectedPadding();
 
-    @Message(id = 52, value = "Incomplete decode")
+    @Message(id = 51, value = "Incomplete decode")
     DecodeException incompleteDecode();
 
-    @Message(id = 53, value = "Expected %d padding characters")
+    @Message(id = 52, value = "Expected %d padding characters")
     DecodeException expectedPaddingCharacters(int numExpected);
 
-    @Message(id = 54, value = "Invalid base 32 character")
+    @Message(id = 53, value = "Invalid base 32 character")
     DecodeException invalidBase32Character();
 
-    @Message(id = 55, value = "Expected an even number of hex characters")
+    @Message(id = 54, value = "Expected an even number of hex characters")
     DecodeException expectedEvenNumberOfHexCharacters();
 
-    @Message(id = 56, value = "Invalid hex character")
+    @Message(id = 55, value = "Invalid hex character")
     DecodeException invalidHexCharacter();
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 57, value = "JAAS authentication failed for principal %s")
+    @Message(id = 56, value = "JAAS authentication failed for principal %s")
     void debugJAASAuthenticationFailure(Principal principal, @Cause Throwable cause);
 
-    @Message(id = 58, value = "Invalid principal type (expected %s, got %s)")
+    @Message(id = 57, value = "Invalid principal type (expected %s, got %s)")
     IllegalArgumentException invalidPrincipalType(Class<?> expectedType, Class<?> actualType);
 
-    @Message(id = 59, value = "Failed to create login context")
+    @Message(id = 58, value = "Failed to create login context")
     RealmUnavailableException failedToCreateLoginContext(@Cause Throwable cause);
 
-    @Message(id = 60, value = "Failed to instantiate custom CallbackHandler")
+    @Message(id = 59, value = "Failed to instantiate custom CallbackHandler")
     RealmUnavailableException failedToInstantiateCustomHandler(@Cause Throwable cause);
 
-    @Message(id = 61, value = "The Callback array cannot be null")
+    @Message(id = 60, value = "The Callback array cannot be null")
     IllegalArgumentException invalidNullCallbackArray();
 
-    @Message(id = 62, value = "Credential cannot be converted to a password")
+    @Message(id = 61, value = "Credential cannot be converted to a password")
     FastUnsupportedCallbackException failedToConvertCredentialToPassword(@Param Callback callback);
 
-    @Message(id = 63, value = "Initial challenge must be empty")
-    SaslException saslInitialChallengeMustBeEmpty();
+    @Message(id = 62, value = "[%s] Initial challenge must be empty")
+    SaslException saslInitialChallengeMustBeEmpty(String mechName);
 
-    @Message(id = 64, value = "Unable to create response token")
-    SaslException saslUnableToCreateResponseToken(@Cause Exception e);
+    @Message(id = 63, value = "[%s] Unable to set channel binding")
+    SaslException saslUnableToSetChannelBinding(String mechName, @Cause Exception e);
 
-    @Message(id = 65, value = "Unable to set channel binding")
-    SaslException saslUnableToSetChannelBinding(@Cause Exception e);
-
-    @Message(id = 66, value = "Failed to determine channel binding status")
+    @Message(id = 64, value = "Failed to determine channel binding status")
     SaslException saslFailedToDetermineChannelBindingStatus(@Cause Exception e);
 
-    @Message(id = 67, value = "Mutual authentication not enabled")
-    SaslException saslMutualAuthenticationNotEnabled();
+    @Message(id = 65, value = "[%s] Mutual authentication not enabled")
+    SaslException saslMutualAuthenticationNotEnabled(String mechName);
 
-    @Message(id = 68, value = "Unable to map SASL mechanism name to a GSS-API OID")
-    SaslException saslMechanismToOidMappingFailed(@Cause Exception e);
+    @Message(id = 66, value = "[%s] Unable to map SASL mechanism name to a GSS-API OID")
+    SaslException saslMechanismToOidMappingFailed(String mechName, @Cause Exception e);
 
-    @Message(id = 69, value = "Unable to dispose of GSSContext")
-    SaslException saslUnableToDisposeGssContext(@Cause Exception e);
+    @Message(id = 67, value = "[%s] Unable to dispose of GSSContext")
+    SaslException saslUnableToDisposeGssContext(String mechName, @Cause Exception e);
 
-    @Message(id = 70, value = "Unable to create name for acceptor")
-    SaslException saslUnableToCreateNameForAcceptor(@Cause Exception e);
+    @Message(id = 68, value = "[%s] Unable to create name for acceptor")
+    SaslException saslUnableToCreateNameForAcceptor(String mechName, @Cause Exception e);
 
-    @Message(id = 71, value = "Unable to create GSSContext")
-    SaslException saslUnableToCreateGssContext(@Cause Exception e);
+    @Message(id = 69, value = "[%s] Unable to create GSSContext")
+    SaslException saslUnableToCreateGssContext(String mechName, @Cause Exception e);
 
-    @Message(id = 72, value = "Unable to set GSSContext request flags")
-    SaslException saslUnableToSetGssContextRequestFlags(@Cause Exception e);
+    @Message(id = 70, value = "[%s] Unable to set GSSContext request flags")
+    SaslException saslUnableToSetGssContextRequestFlags(String mechName, @Cause Exception e);
 
-    @Message(id = 73, value = "Unable to accept SASL client message")
-    SaslException saslUnableToAcceptClientMessage(@Cause Exception e);
+    @Message(id = 71, value = "[%s] Unable to accept SASL client message")
+    SaslException saslUnableToAcceptClientMessage(String mechName, @Cause Exception e);
 
-    @Message(id = 74, value = "GSS-API mechanism mismatch between SASL client and server")
-    SaslException saslGssApiMechanismMismatch();
+    @Message(id = 72, value = "[%s] GSS-API mechanism mismatch between SASL client and server")
+    SaslException saslGssApiMechanismMismatch(String mechName);
 
-    @Message(id = 75, value = "Channel binding not supported for SASL mechanism \"%s\"")
+    @Message(id = 73, value = "[%s] Channel binding not supported for this SASL mechanism")
     SaslException saslChannelBindingNotSupported(String mechName);
 
-    @Message(id = 76, value = "Channel binding type mismatch between SASL client and server")
-    SaslException saslChannelBindingTypeMismatch();
+    @Message(id = 74, value = "[%s] Channel binding type mismatch between SASL client and server")
+    SaslException saslChannelBindingTypeMismatch(String mechName);
 
-    @Message(id = 77, value = "Channel binding not provided by client for SASL mechanism \"%s\"")
+    @Message(id = 75, value = "[%s] Channel binding not provided by client")
     SaslException saslChannelBindingNotProvided(String mechName);
 
-    @Message(id = 78, value = "Unable to determine peer name")
-    SaslException saslUnableToDeterminePeerName(@Cause Exception e);
+    @Message(id = 76, value = "[%s] Unable to determine peer name")
+    SaslException saslUnableToDeterminePeerName(String mechName, @Cause Exception e);
 
-    @Message(id = 79, value = "SASL client refuses to initiate authentication")
-    SaslException saslClientRefusesToInitiateAuthentication();
+    @Message(id = 77, value = "[%s] SASL client refuses to initiate authentication")
+    SaslException saslClientRefusesToInitiateAuthentication(String mechName);
+
+    @Message(id = 78, value = "Parameter %s is null")
+    IllegalArgumentException nullParameter(String parameter);
+
+    // 79
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 80, value = "JAAS logout failed for principal %s")
-    void debugJAASLogoutFailure(Principal principal, @Cause Throwable cause);
+    @Message(id = 80, value = "[%s] JAAS logout failed for principal %s")
+    void debugJAASLogoutFailure(String mechName, Principal principal, @Cause Throwable cause);
 
     @Message(id = 81, value = "No default trust manager available")
     NoSuchAlgorithmException noDefaultTrustManager();
@@ -388,4 +386,361 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 107, value = "Filesystem-backed realm encountered invalid key algorithm for format \"%s\" in path \"%s\" line %d for identity name \"%s\"")
     RealmUnavailableException fileSystemRealmUnsupportedKeyAlgorithm(String format, Path path, int lineNumber, String name);
+
+    @Message(id = 108, value = "[%s] Nonces do not match")
+    SaslException saslNoncesDoNotMatch(String mechName);
+
+    @Message(id = 109, value = "[%s] Server nonce is too short")
+    SaslException saslServerNonceIsTooShort(String mechName);
+
+    @Message(id = 110, value = "[%s] Iteration count %d is below the minimum of %d")
+    SaslException saslIterationCountIsTooLow(String mechName, int iterationCount, int minimumIterationCount);
+
+    @Message(id = 111, value = "[%s] Iteration count %d is above the maximum of %d")
+    SaslException saslIterationCountIsTooHigh(String mechName, int iterationCount, int maximumIterationCount);
+
+    @Message(id = 112, value = "[%s] Extensions unsupported")
+    SaslException saslExtensionsUnsupported(String mechName);
+
+    @Message(id = 113, value = "[%s] Invalid server message")
+    SaslException saslInvalidServerMessage(String mechName);
+
+    @Message(id = 114, value = "[%s] Invalid server message")
+    SaslException saslInvalidServerMessageWithCause(String mechName, @Cause Throwable cause);
+
+    @Message(id = 115, value = "[%s] Invalid client message")
+    SaslException saslInvalidClientMessage(String mechName);
+
+    @Message(id = 116, value = "[%s] Invalid client message")
+    SaslException saslInvalidClientMessageWithCause(String mechName, @Cause Throwable cause);
+
+    @Message(id = 117, value = "[%s] Server rejected authentication: %s")
+    SaslException saslServerRejectedAuthentication(String mechName, String message);
+
+    @Message(id = 118, value = "[%s] Server rejected authentication")
+    SaslException saslServerRejectedAuthentication(String mechName);
+
+    @Message(id = 119, value = "[%s] Server authenticity cannot be verified")
+    SaslException saslServerAuthenticityCannotBeVerified(String mechName);
+
+    @Message(id = 120, value = "[%s] Callback handler does not support user name")
+    SaslException saslCallbackHandlerDoesNotSupportUserName(String mechName, @Cause Throwable cause);
+
+    @Message(id = 121, value = "[%s] Callback handler does not support credential acquisition")
+    SaslException saslCallbackHandlerDoesNotSupportCredentialAcquisition(String mechName, @Cause Throwable cause);
+
+    @Message(id = 122, value = "[%s] Callback handler does not support authorization")
+    SaslException saslAuthorizationUnsupported(String mechName, @Cause Throwable cause);
+
+    @Message(id = 123, value = "[%s] Callback handler failed for unknown reason")
+    SaslException saslCallbackHandlerFailedForUnknownReason(String mechName, @Cause Throwable cause);
+
+    @Message(id = 124, value = "[%s] Salt must be specified")
+    SaslException saslSaltMustBeSpecified(String mechName);
+
+    @Message(id = 125, value = "[%s] Authentication rejected (invalid proof)")
+    SaslException saslAuthenticationRejectedInvalidProof(String mechName);
+
+    @Message(id = 126, value = "[%s] Client sent extra message")
+    SaslException saslClientSentExtraMessage(String mechName);
+
+    @Message(id = 127, value = "[%s] Server sent extra message")
+    SaslException saslServerSentExtraMessage(String mechName);
+
+    @Message(id = 128, value = "[%s] Authentication failed")
+    SaslException saslAuthenticationFailed(String mechName);
+
+    @Message(id = 129, value = "[%s] Invalid MAC initialization key")
+    SaslException saslInvalidMacInitializationKey(String mechName);
+
+    @Message(id = 130, value = "Empty number")
+    NumberFormatException emptyNumber();
+
+    @Message(id = 131, value = "Invalid numeric character")
+    NumberFormatException invalidNumericCharacter();
+
+    @Message(id = 132, value = "Too big number")
+    NumberFormatException tooBigNumber();
+
+    @Message(id = 133, value = "[%s] Cannot get clear password from two way password")
+    SaslException saslCannotGetTwoWayPasswordChars(String mechName, @Cause Throwable cause);
+
+    @Message(id = 134, value = "[%s] Hashing algorithm not supported")
+    SaslException saslMacAlgorithmNotSupported(String mechName, @Cause Throwable cause);
+
+    @Message(id = 135, value = "[%s] keyword cannot be empty")
+    SaslException saslKeywordCannotBeEmpty(String mechName);
+
+    @Message(id = 136, value = "[%s] No value found for keyword: %s")
+    SaslException saslNoValueFoundForKeyword(String mechName, String keyword);
+
+    @Message(id = 137, value = "[%s] '=' expected after keyword: %s")
+    SaslException saslKeywordNotFolowedByEqual(String mechName, String keyword);
+
+    @Message(id = 138, value = "[%s] Unmatched quote found for value: %s")
+    SaslException saslUnmatchedQuoteFoundForValue(String mechName, String value);
+
+    @Message(id = 139, value = "[%s] Expecting comma or linear whitespace after quoted string: %s")
+    SaslException saslExpectingCommaOrLinearWhitespaceAfterQuoted(String mechName, String value);
+
+    @Message(id = 140, value = "[%s] MessageType must equal to %d, but it is %d")
+    SaslException saslMessageTypeMustEqual(String mechName, int expected, int actual);
+
+    @Message(id = 141, value = "[%s] Bad sequence number while unwrapping: expected %d, but %d received")
+    SaslException saslBadSequenceNumberWhileUnwrapping(String mechName, int expected, int actual);
+
+    @Message(id = 142, value = "[%s] Problem during crypt")
+    SaslException saslProblemDuringCrypt(String mechName, @Cause Throwable cause);
+
+    @Message(id = 143, value = "[%s] Problem during decrypt")
+    SaslException saslProblemDuringDecrypt(String mechName, @Cause Throwable cause);
+
+    @Message(id = 144, value = "[%s] Unknown cipher \"%s\"")
+    SaslException saslUnknownCipher(String mechName, String cipher);
+
+    @Message(id = 145, value = "[%s] Cipher \"%s\" unsupported by ")
+    SaslException saslUnsupportedCipher(String mechName, String cipher);
+
+    @Message(id = 146, value = "[%s] Problem getting required cipher. Check your transformation mapper settings.")
+    SaslException saslProblemGettingRequiredCipher(String mechName, @Cause Throwable cause);
+
+    @Message(id = 147, value = "[%s] No common protection layer between client and server")
+    SaslException saslNoCommonProtectionLayer(String mechName);
+
+    @Message(id = 148, value = "[%s] No common cipher between client and server")
+    SaslException saslNoCommonCipher(String mechName);
+
+    @Message(id = 149, value = "[%s] No ciphers offered by server")
+    SaslException saslNoCiphersOfferedByServer(String mechName);
+
+    @Message(id = 150, value = "[%s] Callback handler not provided user name")
+    SaslException saslNotProvidedUserName(String mechName);
+
+    @Message(id = 151, value = "[%s] Callback handler not provided pre-digested password")
+    SaslException saslNotProvidedPreDigested(String mechName);
+
+    @Message(id = 152, value = "[%s] Callback handler not provided clear password")
+    SaslException saslNotProvidedClearPassword(String mechName);
+
+    @Message(id = 153, value = "[%s] Missing \"%s\" directive")
+    SaslException saslMissingDirective(String mechName, String directive);
+
+    @Message(id = 154, value = "[%s] nonce-count must equal to %d, but it is %d")
+    SaslException saslNonceCountMustEqual(String mechName, int expected, int actual);
+
+    @Message(id = 155, value = "[%s] Server is set to not support %s charset")
+    SaslException saslUnsupportedCharset(String mechName, String charset);
+
+    @Message(id = 156, value = "[%s] Charset can be only \"utf-8\" or unspecified (to use ISO 8859-1)")
+    SaslException saslUnknownCharset(String mechName);
+
+    @Message(id = 157, value = "[%s] Client selected realm not offered by server (%s)")
+    SaslException saslUnallowedClientRealm(String mechName, String clientRealm);
+
+    @Message(id = 158, value = "[%s] Mismatched digest-uri \"%s\" Expected: \"%s\"")
+    SaslException saslMismatchedWrongDigestUri(String mechName, String actual, String expected);
+
+    @Message(id = 159, value = "[%s] Unexpected qop value: \"%s\"")
+    SaslException saslUnexpectedQop(String mechName, String qop);
+
+    @Message(id = 160, value = "[%s] Wrapping is not configured")
+    IllegalStateException wrappingNotConfigured(String mechName);
+
+    @Message(id = 161, value = "[%s] Authentication name string is too long")
+    SaslException saslAuthenticationNameTooLong(String mechName);
+
+    @Message(id = 162, value = "[%s] Authentication name is empty")
+    SaslException saslAuthenticationNameIsEmpty(String mechName);
+
+    @Message(id = 163, value = "[%s] Authorization for anonymous access is denied")
+    SaslException saslAnonymousAuthorizationDenied(String mechName);
+
+    @Message(id = 164, value = "Required padded length (%d) is less than length of conversion result (%d)")
+    IllegalArgumentException requiredNegativePadding(int totalLength, int hexLength);
+
+    @Message(id = 165, value = "Invalid key provided for Digest HMAC computing")
+    SaslException saslInvalidKeyForDigestHMAC();
+
+    @Message(id = 166, value = "Unrecognised encoding algorithm")
+    ASN1Exception asnUnrecognisedAlgorithm();
+
+    @Message(id = 167, value = "Invalid general name type")
+    ASN1Exception asnInvalidGeneralNameType();
+
+    @Message(id = 168, value = "Invalid trusted authority type")
+    ASN1Exception asnInvalidTrustedAuthorityType();
+
+    @Message(id = 169, value = "Unexpected ASN.1 tag encountered")
+    ASN1Exception asnUnexpectedTag();
+
+    @Message(id = 170, value = "Unable to read X.509 certificate data")
+    ASN1Exception asnUnableToReadCertificateData(@Cause Throwable cause);
+
+    @Message(id = 171, value = "Unable to read certificate from URL \"%s\"")
+    IOException asnUnableToReadCertificateFromUrl(String url, @Cause Throwable cause);
+
+    @Message(id = 172, value = "Unable to determine subject name from X.509 certificate")
+    IllegalStateException unableToDetermineSubjectName(@Cause Throwable cause);
+
+    @Message(id = 173, value = "[%s] Unable to verify client signature")
+    SaslException saslUnableToVerifyClientSignature(String mechName, @Cause Throwable cause);
+
+    @Message(id = 174, value = "[%s] Unable to verify server signature")
+    SaslException saslUnableToVerifyServerSignature(String mechName, @Cause Throwable cause);
+
+    @Message(id = 175, value = "[%s] Unable to obtain other side certificate from URL \"%s\"")
+    SaslException saslUnableToObtainServerCertificate(String mechName, String url, @Cause Throwable cause);
+
+    @Message(id = 176, value = "[%s] Callback handler not provided URL of server certificate")
+    SaslException saslCallbackHandlerNotProvidedServerCertificate(String mechName);
+
+    @Message(id = 177, value = "[%s] Callback handler not provided URL of client certificate")
+    SaslException saslCallbackHandlerNotProvidedClientCertificate(String mechName);
+
+    @Message(id = 178, value = "[%s] Server identifier mismatch")
+    SaslException saslServerIdentifierMismatch(String mechName);
+
+    @Message(id = 179, value = "[%s] Client identifier mismatch")
+    SaslException saslClientIdentifierMismatch(String mechName);
+
+    @Message(id = 180, value = "[%s] Unable to determine client name")
+    SaslException saslUnableToDetermineClientName(String mechName, @Cause Throwable cause);
+
+    @Message(id = 181, value = "[%s] Callback handler not provided private key")
+    SaslException saslCallbackHandlerNotProvidedPrivateKey(String mechName);
+
+    @Message(id = 182, value = "[%s] Unable to create signature")
+    SaslException saslUnableToCreateSignature(String mechName, @Cause Throwable cause);
+
+    @Message(id = 183, value = "[%s] Unable to create response token")
+    SaslException saslUnableToCreateResponseToken(String mechName, @Cause Throwable cause);
+
+    @Message(id = 184, value = "[%s] Unable to create response token")
+    SaslException saslUnableToCreateResponseTokenWithCause(String mechName, @Cause Throwable cause);
+
+    @Message(id = 185, value = "Invalid value for trusted authority type; expected a value between 0 and 4 (inclusive)")
+    IllegalArgumentException invalidValueForTrustedAuthorityType();
+
+    @Message(id = 186, value = "Invalid value for a general name type; expected a value between 0 and 8 (inclusive)")
+    IllegalArgumentException invalidValueForGeneralNameType();
+
+    @Message(id = 187, value = "Invalid general name for URI type")
+    ASN1Exception asnInvalidGeneralNameForUriType(@Cause Throwable cause);
+
+    @Message(id = 188, value = "Invalid general name for IP address type")
+    ASN1Exception asnInvalidGeneralNameForIpAddressType();
+
+    @Message(id = 189, value = "IP address general name cannot be resolved")
+    ASN1Exception asnIpAddressGeneralNameCannotBeResolved(@Cause Throwable cause);
+
+    @Message(id = 190, value = "Getting SASL mechanisms supported by GSS-API failed")
+    SaslException saslGettingSupportedMechanismsFailed(@Cause Throwable cause);
+
+    @Message(id = 191, value = "Unable to initialise Oid of Kerberos V5")
+    RuntimeException unableToInitialiseOid(@Cause Throwable cause);
+
+    @Message(id = 192, value = "[%s] Receive buffer requested '%d' is greater than supported maximum '%d'")
+    SaslException saslReceiveBufferIsGreaterThanMaximum(String mechName, int requested, int maximum);
+
+    @Message(id = 193, value = "[%s] Unable to wrap message")
+    SaslException saslUnableToWrapMessage(String mechName, @Cause Throwable cause);
+
+    @Message(id = 194, value = "[%s] Unable to unwrap message")
+    SaslException saslUnableToUnwrapMessage(String mechName, @Cause Throwable cause);
+
+    @Message(id = 195, value = "[%s] Unable to unwrap security layer negotiation message")
+    SaslException saslUnableToUnwrapSecurityLayerNegotiationMessage(String mechName, @Cause Throwable cause);
+
+    @Message(id = 196, value = "[%s] Invalid message of length %d on unwrapping")
+    SaslException saslInvalidMessageOnUnwrapping(String mechName, int length);
+
+    @Message(id = 197, value = "[%s] Negotiated mechanism was not Kerberos V5")
+    SaslException saslNegotiatedMechanismWasNotKerberosV5(String mechName);
+
+    @Message(id = 198, value = "[%s] Insufficient levels of protection available for supported security layers")
+    SaslException saslInsufficientQopsAvailable(String mechName);
+
+    @Message(id = 199, value = "[%s] Unable to generate security layer challenge")
+    SaslException saslUnableToGenerateChallenge(String mechName, @Cause Throwable cause);
+
+    @Message(id = 200, value = "[%s] Client selected a security layer that was not offered by server")
+    SaslException saslSelectedUnofferedQop(String mechName);
+
+    @Message(id = 201, value = "[%s] No security layer selected but message length received")
+    SaslException saslNoSecurityLayerButLengthReceived(String mechName);
+
+    @Message(id = 202, value = "[%s] Unable to get maximum size of message before wrap")
+    SaslException saslUnableToGetMaximumSizeOfMessage(String mechName, @Cause Throwable cause);
+
+    @Message(id = 203, value = "[%s] Unable to handle response from server")
+    SaslException saslUnableToHandleResponseFromServer(String mechName, @Cause Throwable cause);
+
+    @Message(id = 204, value = "[%s] Bad length of message for negotiating security layer")
+    SaslException saslBadLengthOfMessageForNegotiatingSecurityLayer(String mechName);
+
+    @Message(id = 205, value = "[%s] No security layer supported by server but maximum message size received: \"%d\"")
+    SaslException saslReceivedMaxMessageSizeWhenNoSecurityLayer(String mechName, int length);
+
+    @Message(id = 206, value = "[%s] Failed to read challenge file")
+    SaslException saslFailedToReadChallengeFile(String mechName, @Cause Throwable cause);
+
+    @Message(id = 207, value = "[%s] Failed to create challenge file")
+    SaslException saslFailedToCreateChallengeFile(String mechName, @Cause Throwable cause);
+
+    @Message(id = 208, value = "Invalid non-ASCII space \"0x%X\"")
+    IllegalArgumentException invalidNonAsciiSpace(int input);
+
+    @Message(id = 209, value = "Invalid ASCII control \"0x%X\"")
+    IllegalArgumentException invalidAsciiControl(int input);
+
+    @Message(id = 210, value = "Invalid non-ASCII control \"0x%X\"")
+    IllegalArgumentException invalidNonAsciiControl(int input);
+
+    @Message(id = 211, value = "Invalid private use character \"0x%X\"")
+    IllegalArgumentException invalidPrivateUseCharacter(int input);
+
+    @Message(id = 212, value = "Invalid non-character code point \"0x%X\"")
+    IllegalArgumentException invalidNonCharacterCodePoint(int input);
+
+    @Message(id = 213, value = "Invalid surrogate code point \"0x%X\"")
+    IllegalArgumentException invalidSurrogateCodePoint(int input);
+
+    @Message(id = 214, value = "Invalid plain text code point \"0x%X\"")
+    IllegalArgumentException invalidPlainTextCodePoint(int input);
+
+    @Message(id = 215, value = "Invalid non-canonical code point \"0x%X\"")
+    IllegalArgumentException invalidNonCanonicalCodePoint(int input);
+
+    @Message(id = 216, value = "Invalid control character \"0x%X\"")
+    IllegalArgumentException invalidControlCharacter(int input);
+
+    @Message(id = 217, value = "Invalid tagging character \"0x%X\"")
+    IllegalArgumentException invalidTaggingCharacter(int input);
+
+    @Message(id = 218, value = "Unassigned code point \"0x%X\"")
+    IllegalArgumentException unassignedCodePoint(int input);
+
+    @Message(id = 219, value = "Invalid surrogate pair (high at end of string) \"0x%X\"")
+    IllegalArgumentException invalidSurrogatePairHightAtEnd(char input);
+
+    @Message(id = 220, value = "Invalid surrogate pair (second is not low) \"0x%X 0x%X\"")
+    IllegalArgumentException invalidSurrogatePairSecondIsNotLow(char high, char low);
+
+    @Message(id = 221, value = "Invalid surrogate pair (low without high) \"0x%X\"")
+    IllegalArgumentException invalidSurrogatePairLowWithoutHigh(char low);
+
+    @Message(id = 222, value = "Invalid code point \"0x%X\"")
+    IllegalArgumentException invalidCodePoint(int input);
+
+    @Message(id = 223, value = "Disallowed R/AL directionality character in L string")
+    IllegalArgumentException disallowedRalDirectionalityInL();
+
+    @Message(id = 224, value = "Disallowed L directionality character in R/AL string")
+    IllegalArgumentException disallowedLDirectionalityInRal();
+
+    @Message(id = 225, value = "Missing trailing R/AL directionality character")
+    IllegalArgumentException missingTrailingRal();
+
+    @Message(id = 226, value = "Invalid escape sequence")
+    IllegalArgumentException invalidEscapeSequence();
 }

--- a/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslClient.java
@@ -18,12 +18,14 @@
 
 package org.wildfly.security.sasl.anonymous;
 
+import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.sasl.anonymous.AbstractAnonymousFactory.ANONYMOUS;
 
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.sasl.SaslException;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.sasl.util.AbstractSaslClient;
 import org.wildfly.security.sasl.util.StringPrep;
 import org.wildfly.security.util.ByteStringBuilder;
@@ -55,19 +57,19 @@ public final class AnonymousSaslClient extends AbstractSaslClient {
         switch (state) {
             case INITIAL_STATE:
                 if (message != null && message.length > 0) {
-                    throw new SaslException("Invalid challenge received from server");
+                    throw log.saslInvalidServerMessage(getMechanismName());
                 }
                 NameCallback nameCallback = new NameCallback("Authentication name");
                 handleCallbacks(nameCallback);
                 String name = nameCallback.getName();
                 if (name == null) {
-                    throw new SaslException("Authentication name is missing");
+                    throw log.saslNotProvidedUserName(getMechanismName());
                 }
                 if (name.length() > 255) {
-                    throw new SaslException("Authentication name string is too long");
+                    throw log.saslAuthenticationNameTooLong(getMechanismName());
                 }
                 if (name.isEmpty()) {
-                    throw new SaslException("Authentication name is empty");
+                    throw log.saslAuthenticationNameIsEmpty(getMechanismName());
                 }
                 ByteStringBuilder b = new ByteStringBuilder();
                 StringPrep.encode(name, b, 0
@@ -86,6 +88,6 @@ public final class AnonymousSaslClient extends AbstractSaslClient {
                 negotiationComplete();
                 return b.toArray();
         }
-        throw new SaslException("Invalid state");
+        throw Assert.impossibleSwitchCase(state);
     }
 }

--- a/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslServer.java
@@ -18,10 +18,12 @@
 
 package org.wildfly.security.sasl.anonymous;
 
+import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.sasl.anonymous.AbstractAnonymousFactory.ANONYMOUS;
 
 import java.nio.charset.StandardCharsets;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.auth.callback.AnonymousAuthorizationCallback;
 import org.wildfly.security.sasl.util.AbstractSaslServer;
 
@@ -65,21 +67,21 @@ public final class AnonymousSaslServer extends AbstractSaslServer {
                 } else {
                     // sanity check
                     if (length > 1020) {
-                        throw new SaslException("Authentication name string is too long");
+                        throw log.saslAuthenticationNameTooLong(getMechanismName());
                     }
                     String name = new String(message, StandardCharsets.UTF_8);
                     if (name.length() > 255) {
-                        throw new SaslException("Authentication name string is too long");
+                        throw log.saslAuthenticationNameTooLong(getMechanismName());
                     }
                     final AnonymousAuthorizationCallback callback = new AnonymousAuthorizationCallback(name);
                     handleCallbacks(callback);
                     if (! callback.isAuthorized()) {
-                        throw new SaslException("Authorization for anonymous access is denied");
+                        throw log.saslAnonymousAuthorizationDenied(getMechanismName());
                     }
                     negotiationComplete();
                     return null;
                 }
         }
-        throw new SaslException("Invalid state");
+        throw Assert.impossibleSwitchCase(state);
     }
 }

--- a/src/main/java/org/wildfly/security/sasl/entity/GeneralName.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/GeneralName.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.entity;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.net.URI;
@@ -53,7 +55,7 @@ public abstract class GeneralName {
 
     GeneralName(final int type) {
         if (type < 0 || type > 8) {
-            throw new IllegalArgumentException("Invalid value for a general name type; expected a value between 0 and 8 (inclusive)");
+            throw log.invalidValueForGeneralNameType();
         }
         this.type = type;
     }
@@ -451,7 +453,7 @@ public abstract class GeneralName {
             try {
                 return (new URI(name)).equals(new URI(other.getName()));
             } catch (URISyntaxException e) {
-                throw new ASN1Exception("Invalid general name for URI type");
+                throw log.asnInvalidGeneralNameForUriType(e);
             }
         }
 
@@ -486,7 +488,7 @@ public abstract class GeneralName {
         public IPAddress(final byte[] address) {
             super(IP_ADDRESS);
             if ((address.length != 4) && (address.length != 8) && (address.length != 16) && (address.length != 32)) {
-                throw new ASN1Exception("Invalid general name for IP address type");
+                throw log.asnInvalidGeneralNameForIpAddressType();
             }
             this.address = address;
         }
@@ -545,10 +547,10 @@ public abstract class GeneralName {
                 } else if (strAddress.indexOf(':') >= 0) {
                     addr = parseIPv6Address(strAddress);
                 } else {
-                    throw new ASN1Exception("Invalid general name for IP address type");
+                    throw log.asnInvalidGeneralNameForIpAddressType();
                 }
             } catch (UnknownHostException e) {
-                throw new ASN1Exception(e.getMessage());
+                throw log.asnIpAddressGeneralNameCannotBeResolved(e);
             }
             return addr;
         }
@@ -580,7 +582,7 @@ public abstract class GeneralName {
 
                 int prefixLength = Integer.parseInt(strAddress.substring(slashIndex + 1));
                 if (prefixLength > 128) {
-                    throw new ASN1Exception("Invalid general name for IP address type");
+                    throw log.asnInvalidGeneralNameForIpAddressType();
                 }
                 byte[] mask = new byte[16];
                 int maskIndex, bit;

--- a/src/main/java/org/wildfly/security/sasl/entity/TrustedAuthority.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/TrustedAuthority.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.sasl.entity;
 
+import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
@@ -40,7 +41,7 @@ public abstract class TrustedAuthority {
 
     TrustedAuthority(final int type) {
         if (type < 0 || type > 4) {
-            throw new IllegalArgumentException("Invalid value for trusted authority type; expected a value between 0 and 4 (inclusive)");
+            throw log.invalidValueForTrustedAuthorityType();
         }
         this.type = type;
     }

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClient.java
@@ -48,10 +48,10 @@ final class ExternalSaslClient implements SaslClient, SaslWrapper {
 
     public byte[] evaluateChallenge(final byte[] challenge) throws SaslException {
         if (challenge.length != 0) {
-            throw log.saslInvalidMessageReceived();
+            throw log.saslInvalidMessageReceived(getMechanismName());
         }
         if (complete) {
-            throw log.saslMessageAfterComplete();
+            throw log.saslMessageAfterComplete(getMechanismName());
         }
         complete = true;
         return authorizationId;
@@ -63,17 +63,17 @@ final class ExternalSaslClient implements SaslClient, SaslWrapper {
 
     public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         } else {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
     }
 
     public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         } else {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
@@ -52,7 +52,7 @@ final class ExternalSaslServer implements SaslServer {
 
     public byte[] evaluateResponse(final byte[] response) throws SaslException {
         if (complete) {
-            throw log.saslMessageAfterComplete();
+            throw log.saslMessageAfterComplete(getMechanismName());
         }
         complete = true;
         String authorizationId;
@@ -61,10 +61,10 @@ final class ExternalSaslServer implements SaslServer {
         } else try {
             authorizationId = Normalizer.normalize(new String(response, "UTF-8"), Normalizer.Form.NFKC);
             if (authorizationId.indexOf(0) != -1) {
-                throw log.saslUserNameContainsInvalidCharacter();
+                throw log.saslUserNameContainsInvalidCharacter(getMechanismName());
             }
         } catch (UnsupportedEncodingException e) {
-            throw log.saslUserNameDecodeFailed("UTF-8");
+            throw log.saslUserNameDecodeFailed(getMechanismName(), "UTF-8");
         }
         final AuthorizeCallback authorizeCallback = new AuthorizeCallback(null, authorizationId);
         try {
@@ -72,12 +72,12 @@ final class ExternalSaslServer implements SaslServer {
         } catch (SaslException e) {
             throw e;
         } catch (IOException e) {
-            throw log.saslAuthorizationFailed(e);
+            throw log.saslAuthorizationFailed(getMechanismName(), e);
         } catch (UnsupportedCallbackException e) {
-            throw log.saslAuthorizationFailed(null);
+            throw log.saslAuthorizationFailed(getMechanismName(), e);
         }
         if (!authorizeCallback.isAuthorized()) {
-            throw log.saslAuthorizationFailed(null);
+            throw log.saslAuthorizationFailed(getMechanismName(), null, authorizationId);
         }
         this.authorizationID = authorizeCallback.getAuthorizedID();
         return AbstractSaslParticipant.NO_BYTES;
@@ -89,24 +89,24 @@ final class ExternalSaslServer implements SaslServer {
 
     public String getAuthorizationID() {
         if (! complete) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
         return authorizationID;
     }
 
     public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         } else {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
     }
 
     public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         } else {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClientFactory.java
@@ -68,7 +68,7 @@ public final class Gs2SaslClientFactory implements SaslClientFactory {
         try {
             supportedMechanisms = Gs2Util.getSupportedSaslNamesForMechanisms(gssManager.getMechs());
         } catch (GSSException e) {
-            throw new SaslException(e.getMessage());
+            throw log.saslGettingSupportedMechanismsFailed(e);
         }
         final String bindingType = callback.getBindingType();
         final byte[] bindingData = callback.getBindingData();

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServerFactory.java
@@ -63,7 +63,7 @@ public final class Gs2SaslServerFactory implements SaslServerFactory {
         try {
             supportedMechs = Gs2Util.getSupportedSaslNamesForMechanisms(gssManager.getMechs());
         } catch (GSSException e) {
-            throw new SaslException(e.getMessage());
+            throw log.saslGettingSupportedMechanismsFailed(e);
         }
         if (! Gs2Util.isIncluded(mechanism, supportedMechs)) return null;
         final String bindingType = channelBindingCallback.getBindingType();

--- a/src/main/java/org/wildfly/security/sasl/gssapi/AbstractGssapiMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/gssapi/AbstractGssapiMechanism.java
@@ -28,7 +28,7 @@ import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.MessageProp;
 import org.ietf.jgss.Oid;
-import org.jboss.logging.Logger;
+import org.wildfly.security._private.ElytronMessages;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.SaslWrapper;
@@ -55,11 +55,11 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
         try {
             KERBEROS_V5 = new Oid("1.2.840.113554.1.2.2");
         } catch (GSSException e) {
-            throw new RuntimeException("Unable to initialise Oid", e);
+            throw ElytronMessages.log.unableToInitialiseOid(e);
         }
     }
 
-    private final Logger log;
+    private final ElytronMessages log;
     protected GSSContext gssContext;
     protected final int configuredMaxReceiveBuffer;
     protected int actualMaxReceiveBuffer;
@@ -69,7 +69,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
     protected QOP selectedQop;
 
     protected AbstractGssapiMechanism(String mechanismName, String protocol, String serverName, final Map<String, ?> props,
-            final CallbackHandler callbackHandler, final Logger log) throws SaslException {
+            final CallbackHandler callbackHandler, final ElytronMessages log) throws SaslException {
         super(mechanismName, protocol, serverName, callbackHandler);
 
         this.log = log;
@@ -77,8 +77,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
         if (props.containsKey(Sasl.MAX_BUFFER)) {
             configuredMaxReceiveBuffer = Integer.parseInt((String) props.get(Sasl.MAX_BUFFER));
             if (configuredMaxReceiveBuffer > DEFAULT_MAX_BUFFER_SIZE) {
-                throw new SaslException(String.format("Receive buffer requested '%d' is greater than supported maximum '%d'.",
-                        configuredMaxReceiveBuffer, DEFAULT_MAX_BUFFER_SIZE));
+                throw log.saslReceiveBufferIsGreaterThanMaximum(getMechanismName(), configuredMaxReceiveBuffer, DEFAULT_MAX_BUFFER_SIZE);
             }
         } else {
             configuredMaxReceiveBuffer = DEFAULT_MAX_BUFFER_SIZE;
@@ -143,7 +142,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
             log.trace("dispose");
             gssContext.dispose();
         } catch (GSSException e) {
-            throw new SaslException("Unable to dispose of GSSContext", e);
+            throw log.saslUnableToDisposeGssContext(getMechanismName(), e);
         } finally {
             gssContext = null;
         }
@@ -157,7 +156,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
                 for (int i = 0; i < qopNames.length; i++) {
                     QOP mapped = QOP.mapFromName(qopNames[i]);
                     if (mapped == null) {
-                        throw new SaslException(String.format("Unrecogniesed QOP value '%s'", qopNames[i]));
+                        throw log.saslUnexpectedQop(getMechanismName(), qopNames[i]);
                     }
                     preferredQop[i] = mapped;
 
@@ -256,7 +255,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
                 log.tracef("Wrapping message of length '%d' resulting message of length '%d'", len, response.length);
                 return response;
             } catch (GSSException e) {
-                throw new SaslException("Unable to wrap message.", e);
+                throw log.saslUnableToWrapMessage(getMechanismName(), e);
             }
         }
 
@@ -268,7 +267,7 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
                 log.tracef("Unwrapping message of length '%d' resulting message of length '%d'", len, response.length);
                 return response;
             } catch (GSSException e) {
-                throw new SaslException("Unable to wrap message.", e);
+                throw log.saslUnableToUnwrapMessage(getMechanismName(), e);
             }
         }
 

--- a/src/main/java/org/wildfly/security/sasl/localuser/LocalUserClient.java
+++ b/src/main/java/org/wildfly/security/sasl/localuser/LocalUserClient.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.localuser;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
@@ -25,14 +27,15 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.wildfly.security.sasl.util.AbstractSaslClient;
-import org.wildfly.security.util.ByteStringBuilder;
-import org.wildfly.security.util.CodePointIterator;
-
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.SaslException;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.sasl.util.AbstractSaslClient;
+import org.wildfly.security.util.ByteStringBuilder;
+import org.wildfly.security.util.CodePointIterator;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -89,7 +92,7 @@ public final class LocalUserClient extends AbstractSaslClient {
                         while (t < 8) {
                             int r = stream.read(challenge, t, 8-t);
                             if (r < 0) {
-                                throw new SaslException("Invalid server challenge");
+                                throw log.saslInvalidServerMessage(getMechanismName());
                             } else {
                                 t += r;
                             }
@@ -98,7 +101,7 @@ public final class LocalUserClient extends AbstractSaslClient {
                         safeClose(stream);
                     }
                 } catch (IOException e) {
-                    throw new SaslException("Failed to read server challenge", e);
+                    throw log.saslFailedToReadChallengeFile(getMechanismName(), e);
                 }
                 String authenticationId = getAuthorizationId();
                 String authenticationRealm = null;
@@ -119,7 +122,7 @@ public final class LocalUserClient extends AbstractSaslClient {
                 negotiationComplete();
                 return response;
         }
-        throw new SaslException("Invalid state");
+        throw Assert.impossibleSwitchCase(state);
     }
 
     private static void safeClose(Closeable c) {

--- a/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
@@ -60,11 +60,11 @@ class PlainSaslClient implements SaslClient, SaslWrapper {
 
     public byte[] evaluateChallenge(final byte[] challenge) throws SaslException {
         if (complete) {
-            throw log.saslMessageAfterComplete();
+            throw log.saslMessageAfterComplete(getMechanismName());
         }
         complete = true;
         if (challenge.length > 0) {
-            throw log.saslInvalidMessageReceived();
+            throw log.saslInvalidMessageReceived(getMechanismName());
         }
         final NameCallback nameCallback = new NameCallback("Login name");
         final PasswordCallback passwordCallback = new PasswordCallback("Password", false);
@@ -73,15 +73,15 @@ class PlainSaslClient implements SaslClient, SaslWrapper {
         } catch (SaslException e) {
             throw e;
         } catch (IOException | UnsupportedCallbackException e) {
-            throw log.saslClientSideAuthenticationFailed(e);
+            throw log.saslCallbackHandlerFailedForUnknownReason(getMechanismName(), e);
         }
         final String name = nameCallback.getName();
         if (name == null) {
-            throw log.saslNoLoginNameGiven();
+            throw log.saslNoLoginNameGiven(getMechanismName());
         }
         final char[] password = passwordCallback.getPassword();
         if (password == null) {
-            throw log.saslNoPasswordGiven();
+            throw log.saslNoPasswordGiven(getMechanismName());
         }
         try {
             final ByteStringBuilder b = new ByteStringBuilder();
@@ -94,7 +94,7 @@ class PlainSaslClient implements SaslClient, SaslWrapper {
             StringPrep.encode(password, b, StringPrep.PROFILE_SASL_STORED);
             return b.toArray();
         } catch (IllegalArgumentException ex) {
-            throw log.saslMalformedFields(ex);
+            throw log.saslMalformedFields(getMechanismName(), ex);
         }
     }
 
@@ -104,17 +104,17 @@ class PlainSaslClient implements SaslClient, SaslWrapper {
 
     public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         } else {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
     }
 
     public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         } else {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/plain/PlainSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/plain/PlainSaslServer.java
@@ -58,7 +58,7 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
     @Override
     public String getAuthorizationID() {
         if (! isComplete()) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
         return authorizedId;
     }
@@ -76,11 +76,11 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
     @Override
     public byte[] evaluateResponse(final byte[] response) throws SaslException {
         if (complete) {
-            throw log.saslMessageAfterComplete();
+            throw log.saslMessageAfterComplete(getMechanismName());
         }
         complete = true;
         if (response.length >= 65536) {
-            throw log.saslMessageTooLong();
+            throw log.saslMessageTooLong(getMechanismName());
         }
         CodePointIterator i = CodePointIterator.ofUtf8Bytes(response);
         String authorizationId;
@@ -97,7 +97,7 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
                 authorizationId = loginName;
             }
         } catch (NoSuchElementException ignored) {
-            throw log.saslInvalidMessageReceived();
+            throw log.saslInvalidMessageReceived(getMechanismName());
         }
 
         // The message has now been parsed, split and converted to UTF-8 Strings
@@ -113,13 +113,13 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
         } catch (SaslException e) {
             throw e;
         } catch (IOException | UnsupportedCallbackException e) {
-            throw log.saslServerSideAuthenticationFailed(e);
+            throw log.saslServerSideAuthenticationFailed(getMechanismName(), e);
         } finally {
             pvc.clearPassword();
         }
 
         if (pvc.isVerified() == false) {
-            throw log.saslPasswordNotVerified();
+            throw log.saslPasswordNotVerified(getMechanismName());
         }
 
         // Now check the authorization id
@@ -130,13 +130,13 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
         } catch (SaslException e) {
             throw e;
         } catch (IOException | UnsupportedCallbackException e) {
-            throw log.saslServerSideAuthenticationFailed(e);
+            throw log.saslServerSideAuthenticationFailed(getMechanismName(), e);
         }
 
         if (acb.isAuthorized() == true) {
             authorizedId = acb.getAuthorizedID();
         } else {
-            throw log.saslAuthorizationFailed(loginName, authorizationId);
+            throw log.saslAuthorizationFailed(getMechanismName(), loginName, authorizationId);
         }
         return null;
     }
@@ -144,18 +144,18 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
     @Override
     public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         } else {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
     }
 
     @Override
     public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
         if (complete) {
-            throw log.saslAuthenticationNotComplete();
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         } else {
-            throw log.saslNoSecurityLayer();
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/proxy/SaslProxy.java
+++ b/src/main/java/org/wildfly/security/sasl/proxy/SaslProxy.java
@@ -24,6 +24,8 @@ import javax.security.sasl.SaslClient;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
+import org.wildfly.common.Assert;
+
 /**
  * A proxy between an incoming and outgoing (upstream) SASL authentication.  Each received response from the downstream
  * client is proxied to the upstream server, and each received challenge from the upstream server is proxied to the
@@ -77,7 +79,7 @@ public final class SaslProxy {
             synchronized (lock) {
                 for (;;) switch (state) {
                     case ST_FAILED: {
-                        throw log.saslProxyAuthenticationFailed();
+                        throw log.saslProxyAuthenticationFailed(getMechanismName());
                     }
                     case ST_DONE: {
                         return null;
@@ -88,7 +90,7 @@ public final class SaslProxy {
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             state = ST_FAILED;
-                            throw log.saslProxyAuthenticationFailed();
+                            throw log.saslProxyAuthenticationFailed(getMechanismName());
                         }
                         break;
                     }
@@ -99,7 +101,7 @@ public final class SaslProxy {
                         message = challenge;
                         lock.notifyAll();
                     }
-                    default: throw new IllegalStateException();
+                    default: throw Assert.impossibleSwitchCase(state);
                 }
             }
         }
@@ -111,11 +113,11 @@ public final class SaslProxy {
         }
 
         public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
-            throw new IllegalStateException("Wrap/unwrap is unsupported");
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
 
         public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
-            throw new IllegalStateException("Wrap/unwrap is unsupported");
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
 
         public Object getNegotiatedProperty(final String propName) {
@@ -153,7 +155,7 @@ public final class SaslProxy {
             synchronized (lock) {
                 for (;;) switch (state) {
                     case ST_FAILED: {
-                        throw log.saslProxyAuthenticationFailed();
+                        throw log.saslProxyAuthenticationFailed(getMechanismName());
                     }
                     case ST_DONE: {
                         return null;
@@ -164,7 +166,7 @@ public final class SaslProxy {
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             state = ST_FAILED;
-                            throw log.saslProxyAuthenticationFailed();
+                            throw log.saslProxyAuthenticationFailed(getMechanismName());
                         }
                         break;
                     }
@@ -175,7 +177,7 @@ public final class SaslProxy {
                         message = response;
                         lock.notifyAll();
                     }
-                    default: throw new IllegalStateException();
+                    default: throw Assert.impossibleSwitchCase(state);
                 }
             }
         }
@@ -192,15 +194,15 @@ public final class SaslProxy {
                     return authorizationID;
                 }
             }
-            throw new IllegalStateException();
+            throw Assert.unreachableCode();
         }
 
         public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
-            throw new IllegalStateException("Wrap/unwrap is unsupported");
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
 
         public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
-            throw new IllegalStateException("Wrap/unwrap is unsupported");
+            throw log.saslNoSecurityLayer(getMechanismName());
         }
 
         public Object getNegotiatedProperty(final String propName) {
@@ -256,7 +258,7 @@ public final class SaslProxy {
     public void upstreamServerComplete(String authorizationID) {
         synchronized (lock) {
             if (state == ST_DONE) {
-                throw new IllegalStateException();
+                throw Assert.unreachableCode();
             }
             state = ST_DONE;
             this.authorizationID = authorizationID;

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.scram;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -55,7 +57,7 @@ public final class ScramSaslClientFactory implements SaslClientFactory {
         } catch (SaslException e) {
             throw e;
         } catch (IOException e) {
-            throw new SaslException("Failed to determine channel binding status", e);
+            throw log.saslFailedToDetermineChannelBindingStatus(e);
         } catch (UnsupportedCallbackException e) {
             // ignored
         }

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslServerFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.scram;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -50,7 +52,7 @@ public final class ScramSaslServerFactory implements SaslServerFactory {
         } catch (SaslException e) {
             throw e;
         } catch (IOException e) {
-            throw new SaslException("Failed to determine channel binding status", e);
+            throw log.saslFailedToDetermineChannelBindingStatus(e);
         } catch (UnsupportedCallbackException e) {
             // ignored
         }

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.Map;
 
 import javax.security.auth.callback.Callback;
@@ -80,7 +82,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         try {
             tryHandleCallbacks(callbacks);
         } catch (UnsupportedCallbackException e) {
-            throw new SaslException("Callback handler cannot support callback " + e.getCallback().getClass(), e);
+            throw log.saslCallbackHandlerFailedForUnknownReason(getMechanismName(), e);
         }
     }
 
@@ -97,7 +99,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         } catch (SaslException | UnsupportedCallbackException e) {
             throw e;
         } catch (Throwable t) {
-            throw new SaslException("Callback handler invocation failed", t);
+            throw log.saslCallbackHandlerFailedForUnknownReason(getMechanismName(), t);
         }
     }
 
@@ -168,9 +170,9 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
         boolean ok = false;
         try {
             if (state == COMPLETE_STATE) {
-                throw new SaslException("SASL negotiation already complete");
+                throw log.saslMessageAfterComplete(getMechanismName());
             } else if (state == FAILED_STATE) {
-                throw new SaslException("SASL negotiation failed");
+                throw log.saslAuthenticationFailed(getMechanismName());
             }
             byte[] result = evaluateMessage(state, message);
             ok = true;
@@ -206,7 +208,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
     public byte[] wrap(final byte[] outgoing, final int offset, final int len) throws SaslException {
         SaslWrapper wrapper = this.wrapper;
         if (wrapper == null) {
-            throw new IllegalStateException("Wrapping is not configured");
+            throw log.wrappingNotConfigured(getMechanismName());
         }
         if(len == 0) {
             return NO_BYTES;
@@ -227,7 +229,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
     public byte[] unwrap(final byte[] incoming, final int offset, final int len) throws SaslException {
         SaslWrapper wrapper = this.wrapper;
         if (wrapper == null) {
-            throw new IllegalStateException("Wrapping is not configured");
+            throw log.wrappingNotConfigured(getMechanismName());
         }
         if(len == 0) {
             return NO_BYTES;
@@ -251,7 +253,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
      */
     protected void assertComplete() {
         if (isComplete() == false) {
-            throw new IllegalStateException("Authentication is not yet complete.");
+            throw log.saslAuthenticationNotComplete(getMechanismName());
         }
     }
 

--- a/src/main/java/org/wildfly/security/sasl/util/AggregateSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AggregateSaslClientFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -43,7 +45,7 @@ public final class AggregateSaslClientFactory implements SaslClientFactory {
      */
     public AggregateSaslClientFactory(final SaslClientFactory... factories) {
         if (factories == null) {
-            throw new IllegalArgumentException("factories is null");
+            throw log.nullParameter("factories");
         }
         this.factories = factories.clone();
     }
@@ -55,7 +57,7 @@ public final class AggregateSaslClientFactory implements SaslClientFactory {
      */
     public AggregateSaslClientFactory(final Collection<SaslClientFactory> factories) {
         if (factories == null) {
-            throw new IllegalArgumentException("factories is null");
+            throw log.nullParameter("factories");
         }
         this.factories = factories.toArray(new SaslClientFactory[factories.size()]);
     }

--- a/src/main/java/org/wildfly/security/sasl/util/AggregateSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AggregateSaslServerFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -43,7 +45,7 @@ public final class AggregateSaslServerFactory implements SaslServerFactory {
      */
     public AggregateSaslServerFactory(final SaslServerFactory... factories) {
         if (factories == null) {
-            throw new IllegalArgumentException("factories is null");
+            throw log.nullParameter("factories");
         }
         this.factories = factories.clone();
     }
@@ -55,7 +57,7 @@ public final class AggregateSaslServerFactory implements SaslServerFactory {
      */
     public AggregateSaslServerFactory(final Collection<SaslServerFactory> factories) {
         if (factories == null) {
-            throw new IllegalArgumentException("factories is null");
+            throw log.nullParameter("factories");
         }
         this.factories = factories.toArray(new SaslServerFactory[factories.size()]);
     }

--- a/src/main/java/org/wildfly/security/sasl/util/FilterMechanismSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/FilterMechanismSaslClientFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -50,7 +52,7 @@ public final class FilterMechanismSaslClientFactory extends AbstractDelegatingSa
     public FilterMechanismSaslClientFactory(final SaslClientFactory delegate, boolean include, String... mechanisms) {
         super(delegate);
         if (mechanisms == null) {
-            throw new IllegalArgumentException("mechanisms is null");
+            throw log.nullParameter("mechanisms");
         }
         this.include = include;
         final HashSet<String> set = new HashSet<String>(mechanisms.length);
@@ -68,7 +70,7 @@ public final class FilterMechanismSaslClientFactory extends AbstractDelegatingSa
     public FilterMechanismSaslClientFactory(final SaslClientFactory delegate, boolean include, Collection<String> mechanisms) {
         super(delegate);
         if (mechanisms == null) {
-            throw new IllegalArgumentException("mechanisms is null");
+            throw log.nullParameter("mechanisms");
         }
         this.include = include;
         this.mechanisms = new HashSet<String>(mechanisms);

--- a/src/main/java/org/wildfly/security/sasl/util/FilterMechanismSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/FilterMechanismSaslServerFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,9 +28,9 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
-import javax.security.sasl.SaslException;
 
 /**
  * A {@link SaslServerFactory} which filters available mechanisms (either inclusively or exclusively) from a delegate
@@ -50,7 +52,7 @@ public final class FilterMechanismSaslServerFactory extends AbstractDelegatingSa
     public FilterMechanismSaslServerFactory(final SaslServerFactory delegate, boolean include, String... mechanisms) {
         super(delegate);
         if (mechanisms == null) {
-            throw new IllegalArgumentException("mechanisms is null");
+            throw log.nullParameter("mechanisms");
         }
         this.include = include;
         final HashSet<String> set = new HashSet<String>(mechanisms.length);
@@ -68,7 +70,7 @@ public final class FilterMechanismSaslServerFactory extends AbstractDelegatingSa
     public FilterMechanismSaslServerFactory(final SaslServerFactory delegate, boolean include, Collection<String> mechanisms) {
         super(delegate);
         if (mechanisms == null) {
-            throw new IllegalArgumentException("mechanisms is null");
+            throw log.nullParameter("mechanisms");
         }
         this.include = include;
         this.mechanisms = new HashSet<String>(mechanisms);

--- a/src/main/java/org/wildfly/security/sasl/util/PrivilegedSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/util/PrivilegedSaslClient.java
@@ -19,6 +19,7 @@
 package org.wildfly.security.sasl.util;
 
 import static java.security.AccessController.doPrivileged;
+import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.AccessControlContext;
@@ -40,10 +41,10 @@ public final class PrivilegedSaslClient extends AbstractDelegatingSaslClient imp
     PrivilegedSaslClient(final SaslClient delegate, final AccessControlContext accessControlContext) {
         super(delegate);
         if (delegate == null) {
-            throw new IllegalArgumentException("delegate is null");
+            throw log.nullParameter("delegate");
         }
         if (accessControlContext == null) {
-            throw new IllegalArgumentException("accessControlContext is null");
+            throw log.nullParameter("accessControlContext");
         }
         this.accessControlContext = accessControlContext;
     }

--- a/src/main/java/org/wildfly/security/sasl/util/PrivilegedSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/util/PrivilegedSaslServer.java
@@ -19,6 +19,7 @@
 package org.wildfly.security.sasl.util;
 
 import static java.security.AccessController.doPrivileged;
+import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.AccessControlContext;
@@ -40,10 +41,10 @@ public final class PrivilegedSaslServer extends AbstractDelegatingSaslServer imp
     PrivilegedSaslServer(final SaslServer delegate, final AccessControlContext accessControlContext) {
         super(delegate);
         if (delegate == null) {
-            throw new IllegalArgumentException("delegate is null");
+            throw log.nullParameter("delegate");
         }
         if (accessControlContext == null) {
-            throw new IllegalArgumentException("accessControlContext is null");
+            throw log.nullParameter("accessControlContext");
         }
         this.accessControlContext = accessControlContext;
     }

--- a/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
+++ b/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.text.Normalizer;
 
 import org.wildfly.security.util.ByteStringBuilder;
@@ -106,13 +108,13 @@ public final class StringPrep {
 
     public static void forbidNonAsciiSpaces(int input) {
         if (mapCodePointToSpace(input)) {
-            throw new IllegalArgumentException("Invalid non-ASCII space");
+            throw log.invalidNonAsciiSpace(input);
         }
     }
 
     public static void forbidAsciiControl(int input) {
         if (input < 0x20 || input == 0x7F) {
-            throw new IllegalArgumentException("Invalid ASCII control");
+            throw log.invalidAsciiControl(input);
         }
     }
 
@@ -129,37 +131,37 @@ public final class StringPrep {
             || input >= 0xFFF9 && input <= 0xFFFC
             || input >= 0x01D173 && input <= 0x01D17A
         ) {
-            throw new IllegalArgumentException("Invalid non-ASCII control");
+            throw log.invalidNonAsciiControl(input);
         }
     }
 
     public static void forbidPrivateUse(int input) {
         if (input >= 0xE000 && input <= 0xF8FF || input >= 0xF0000 && input <= 0xFFFFD || input >= 0x100000 && input <= 0x10FFFD) {
-            throw new IllegalArgumentException("Invalid private use character");
+            throw log.invalidPrivateUseCharacter(input);
         }
     }
 
     public static void forbidNonCharacter(int input) {
         if ((input & 0xFFFE) == 0xFFFE || input >= 0xFDD0 && input <= 0xFDEF) {
-            throw new IllegalArgumentException("Invalid non-character code point");
+            throw log.invalidNonCharacterCodePoint(input);
         }
     }
 
     public static void forbidSurrogate(int input) {
         if (input >= 0xD800 && input <= 0xDFFF) {
-            throw new IllegalArgumentException("Invalid surrogate code point");
+            throw log.invalidSurrogateCodePoint(input);
         }
     }
 
     public static void forbidInappropriateForPlainText(int input) {
         if (input >= 0xFFF9 && input <= 0xFFFD) {
-            throw new IllegalArgumentException("Invalid plain text code point");
+            throw log.invalidPlainTextCodePoint(input);
         }
     }
 
     public static void forbidInappropriateForCanonicalRepresentation(int input) {
         if (input >= 0x2FF0 && input <= 0x2FFB) {
-            throw new IllegalArgumentException("Invalid non-canonical code point");
+            throw log.invalidNonCanonicalCodePoint(input);
         }
     }
 
@@ -168,19 +170,19 @@ public final class StringPrep {
             || input >= 0x200E && input <= 0x200F
             || input >= 0x202A && input <= 0x202E
             || input >= 0x206A && input <= 0x206F) {
-            throw new IllegalArgumentException("Invalid control character");
+            throw log.invalidControlCharacter(input);
         }
     }
 
     public static void forbidTagging(int input) {
         if (input == 0x0E0001 || input >= 0x0E0020 && input <= 0x0E007F) {
-            throw new IllegalArgumentException("Invalid tagging character");
+            throw log.invalidTaggingCharacter(input);
         }
     }
 
     public static void forbidUnassigned(int input) {
         if (Character.getType(input) == Character.UNASSIGNED) {
-            throw new IllegalArgumentException("Unassigned code point");
+            throw log.unassignedCodePoint(input);
         }
     }
 
@@ -206,21 +208,21 @@ public final class StringPrep {
             int cp;
             if (Character.isHighSurrogate(ch)) {
                 if (i == len) {
-                    throw new IllegalArgumentException("Invalid surrogate pair (high at end of string)");
+                    throw log.invalidSurrogatePairHightAtEnd(ch);
                 }
                 char low = string.charAt(i++);
                 if (!Character.isLowSurrogate(low)) {
-                    throw new IllegalArgumentException("Invalid surrogate pair (second is not low)");
+                    throw log.invalidSurrogatePairSecondIsNotLow(ch, low);
                 }
                 cp = Character.toCodePoint(ch, low);
             } else if (Character.isLowSurrogate(ch)) {
-                throw new IllegalArgumentException("Invalid surrogate pair (low without high)");
+                throw log.invalidSurrogatePairLowWithoutHigh(ch);
             } else {
                 cp = ch;
             }
 
             if (! Character.isValidCodePoint(cp)) {
-                throw new IllegalArgumentException("Invalid code point");
+                throw log.invalidCodePoint(cp);
             }
 
             assert Character.MIN_CODE_POINT <= cp && cp <= Character.MAX_CODE_POINT;
@@ -232,17 +234,17 @@ public final class StringPrep {
                     if (first) {
                         isRALString = true;
                     } else if (!isRALString) {
-                        throw new IllegalArgumentException("Disallowed R/AL directionality character in L string");
+                        throw log.disallowedRalDirectionalityInL();
                     }
                     break;
                 case Character.DIRECTIONALITY_LEFT_TO_RIGHT: // L character
                     if (isRALString) {
-                        throw new IllegalArgumentException("Disallowed L directionality character in R/AL string");
+                        throw log.disallowedLDirectionalityInRal();
                     }
                     break;
                 default: // neutral character
                     if (i == len && isRALString) {
-                        throw new IllegalArgumentException("Missing trailing R/AL directionality character");
+                        throw log.missingTrailingRal();
                     }
             }
             if (first) {
@@ -271,19 +273,19 @@ public final class StringPrep {
             else if (isSet(profile, UNMAP_SCRAM_LOGIN_CHARS) || isSet(profile, UNMAP_GS2_LOGIN_CHARS)) {
                 if (cp == '=') {
                     if (i + 1 >= len) {
-                        throw new IllegalArgumentException("Invalid escape sequence");
+                        throw log.invalidEscapeSequence();
                     }
                     char ch1 = string.charAt(i++);
                     char ch2 = string.charAt(i++);
 
-                    if(ch1 == '3' && ch2 == 'D'){
+                    if (ch1 == '3' && ch2 == 'D') {
                         target.append('=');
                         continue;
-                    }else if(ch1 == '2' && ch2 == 'C'){
+                    } else if (ch1 == '2' && ch2 == 'C') {
                         target.append(',');
                         continue;
-                    }else{
-                        throw new IllegalArgumentException("Invalid escape sequence");
+                    } else {
+                        throw log.invalidEscapeSequence();
                     }
                 }
             }

--- a/src/main/java/org/wildfly/security/sasl/util/UsernamePasswordHashUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/util/UsernamePasswordHashUtil.java
@@ -113,7 +113,7 @@ public class UsernamePasswordHashUtil {
     }
 
     /**
-     * Takes the supplied username, realm and password and generates the digested { username ':' realm ':' password}
+     * Takes the supplied username, realm and password and generates the digested { username ':' realm ':' password }
      *
      * @param userName             The username to use in the generated hash.
      * @param realm                The realm to use in the generated hash.
@@ -139,7 +139,7 @@ public class UsernamePasswordHashUtil {
 
             return digest.digest(baos.toByteArray());
         } catch (IOException e) {
-            throw new IllegalStateException("The ByteArrayOutputStream should not be throwing this IOException", e);
+            throw new IllegalStateException(e);
         }
     }
 

--- a/src/test/java/org/wildfly/security/manager/TestPermissionActions.java
+++ b/src/test/java/org/wildfly/security/manager/TestPermissionActions.java
@@ -23,7 +23,6 @@
 package org.wildfly.security.manager;
 
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
 import static org.wildfly.security.permission.PermissionActions.getCanonicalActionString;
 
 import java.util.EnumSet;

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -524,9 +524,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         try{
             server.evaluateResponse(message2);
             fail("Not throwed SaslException!");
-        } catch (SaslException e) {
-            assertTrue(e.getMessage().contains("nonce"));
-        }
+        } catch (SaslException e) {}
         assertFalse(server.isComplete());
     }
 
@@ -552,10 +550,7 @@ public class CompatibilityServerTest extends BaseTestCase {
         try{
             server.evaluateResponse(message2);
             fail("Not throwed SaslException!");
-        } catch (SaslException e) {
-            System.out.println(e.getMessage());
-            assertTrue(e.getMessage().contains("response"));
-        }
+        } catch (SaslException e) {}
         assertFalse(server.isComplete());
 
     }

--- a/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/_private/DigestUtilTest.java
@@ -96,15 +96,15 @@ public class DigestUtilTest {
     @Test
     public void testCreate3desSubKey() throws Exception {
         byte[] input1 = CodePointIterator.ofString("FFFFFFFFFFFFFF").hexDecode().drain();
-        byte[] output1 = create3desSubKey(input1, 0, 7);
+        byte[] output1 = create3desSubKey(input1, 0);
         assertEquals("FEFEFEFEFEFEFEFE".toLowerCase(), ByteIterator.ofBytes(output1).hexEncode().drainToString());
 
         byte[] input2 = CodePointIterator.ofString("d7c920cf2564cec39c570490f7ea").hexDecode().drain();
-        byte[] output2 = create3desSubKey(input2, 0, 7);
+        byte[] output2 = create3desSubKey(input2, 0);
         assertEquals("D6E54919F22A929D".toLowerCase(), ByteIterator.ofBytes(output2).hexEncode().drainToString());
 
         byte[] input3 = CodePointIterator.ofString("d7c920cf2564cec39c570490f7ea").hexDecode().drain();
-        byte[] output3 = create3desSubKey(input3, 7, 7);
+        byte[] output3 = create3desSubKey(input3, 7);
         assertEquals("C2CE15E04986DFD5".toLowerCase(), ByteIterator.ofBytes(output3).hexEncode().drainToString());
     }
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilUnitTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiUtilUnitTest.java
@@ -31,6 +31,7 @@ import javax.security.sasl.SaslException;
 
 import org.jboss.logging.Logger;
 import org.junit.Test;
+import org.wildfly.security._private.ElytronMessages;
 
 /**
  * Tests of Gssapi helpers (don't require started kerberos server)
@@ -42,7 +43,7 @@ public class GssapiUtilUnitTest extends AbstractGssapiMechanism {
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 throw new UnsupportedCallbackException(callbacks[0]);
             }
-        }, Logger.getLogger(GssapiUtilUnitTest.class));
+        }, Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.sasl.gssapi.GssapiUtilUnitTest"));
     }
 
     @Override


### PR DESCRIPTION
i18n internationalization of `sasl` package
* SaslExceptions are now prefixed with `[MECHANISM-NAME]`

refactoring:
* Digest
 * variable `md5` renamed to `digest`
 * in `createCipher()` merged two cipher switches
 * in `_private.DigestUtil` removed unused methods params (`len`)
* `ScramUtil.getTwoWayPasswordChars()` method accept `TwoWayPassword` only

Note: `log.nullParameter(String parameter)` message accept parameter name as String - I hope translating names of parameters of methods is not required.