### PR TITLE
Missing  	i18n + clearing

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -30,6 +30,7 @@ import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 
+import static org.jboss.logging.Logger.Level.WARN;
 import javax.naming.NamingException;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -290,6 +291,54 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1065, value = "Pattern requires a capture group")
     IllegalArgumentException patternRequiresCaptureGroup();
+
+    @LogMessage(level = WARN)
+    @Message(id = 1066, value = "Invalid string count for mechanism database entry \"%s\"")
+    void warnInvalidStringCountForMechanismDatabaseEntry(String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1067, value = "Invalid key exchange \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidKeyExchangeForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1068, value = "Invalid authentication \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidAuthenticationForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1069, value = "Invalid encryption \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidEncryptionForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1070, value = "Invalid digest \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidDigestForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1071, value = "Invalid protocol \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidProtocolForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1072, value = "Invalid level \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidLevelForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1073, value = "Invalid strength bits \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidStrengthBitsForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1074, value = "Invalid algorithm bits \"%s\" for mechanism database entry \"%s\"")
+    void warnInvalidAlgorithmBitsForMechanismDatabaseEntry(String value, String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1075, value = "Invalid duplicate mechanism database entry \"%s\"")
+    void warnInvalidDuplicateMechanismDatabaseEntry(String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1076, value = "Invalid duplicate OpenSSL-style alias \"%s\" for mechanism database entry \"%s\" (original is \"%s\")")
+    void warnInvalidDuplicateOpenSslStyleAliasForMechanismDatabaseEntry(String alias, String name, String originalName);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1077, value = "Invalid alias \"%s\" for missing mechanism database entry \"%s\"")
+    void warnInvalidAliasForMissingMechanismDatabaseEntry(String value, String name);
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/asn1/DERDecoder.java
+++ b/src/main/java/org/wildfly/security/asn1/DERDecoder.java
@@ -181,7 +181,7 @@ public class DERDecoder implements ASN1Decoder {
         try {
             return new String(octets, charSet);
         } catch (UnsupportedEncodingException e) {
-            throw new ASN1Exception(e.getMessage(), e);
+            throw new ASN1Exception(e);
         }
     }
 

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
@@ -38,11 +38,12 @@ import org.wildfly.security.password.spec.ScramDigestPasswordSpec;
 import org.wildfly.security.password.spec.SimpleDigestPasswordSpec;
 import org.wildfly.security.util.CodePointIterator;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.password.interfaces.BCryptPassword.ALGORITHM_BCRYPT;
@@ -205,7 +206,7 @@ public class PasswordKeyMapper implements KeyMapper {
                     iterationCount = resultSet.getInt(getIterationCount());
                 }
             }
-        } catch (Exception e) {
+        } catch (SQLException e) {
             throw log.couldNotObtainCredentialWithCause(e);
         }
 
@@ -269,9 +270,9 @@ public class PasswordKeyMapper implements KeyMapper {
         }
     }
 
-    private byte[] toByteArray(Object value) throws UnsupportedEncodingException {
+    private byte[] toByteArray(Object value) {
         if (String.class.isInstance(value)) {
-            return value.toString().getBytes("UTF-8");
+            return value.toString().getBytes(StandardCharsets.UTF_8);
         } else if (byte[].class.isInstance(value)) {
             return (byte[]) value;
         }

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.security.auth.provider.ldap;
 
-import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.UTF_8;
 import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.parseUserPassword;
 
 import java.security.spec.InvalidKeySpecException;
@@ -115,8 +114,6 @@ class UserPasswordCredentialLoader implements CredentialLoader {
                     if (credentialType.isInstance(password)) {
                         return credentialType.cast(password);
                     }
-
-                    System.out.println(new String(value, UTF_8));
                 }
 
                 return null;

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtil.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtil.java
@@ -22,7 +22,7 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.password.interfaces.SimpleDigestPassword.*;
 import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.*;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.spec.InvalidKeySpecException;
 
 import org.wildfly.security.password.Password;
@@ -40,8 +40,6 @@ import org.wildfly.security.util.CodePointIterator;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 class UserPasswordPasswordUtil {
-
-    static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private UserPasswordPasswordUtil() {
     }
@@ -107,7 +105,7 @@ class UserPasswordPasswordUtil {
     }
 
     private static Password createClearPassword(byte[] userPassword) {
-        return ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, new String(userPassword, UTF_8).toCharArray());
+        return ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, new String(userPassword, StandardCharsets.UTF_8).toCharArray());
     }
 
     private static Password createSimpleDigestPassword(String algorithm, int prefixSize, byte[] userPassword)

--- a/src/main/java/org/wildfly/security/password/impl/PasswordFactorySpiImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/PasswordFactorySpiImpl.java
@@ -90,19 +90,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new BCryptPasswordImpl((BCryptPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new BCryptPasswordImpl((ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new BCryptPasswordImpl((EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -113,19 +113,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new UnixMD5CryptPasswordImpl((UnixMD5CryptPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new UnixMD5CryptPasswordImpl((ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new UnixMD5CryptPasswordImpl((EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -137,19 +137,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new SunUnixMD5CryptPasswordImpl(algorithm, (SunUnixMD5CryptPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new SunUnixMD5CryptPasswordImpl((ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new SunUnixMD5CryptPasswordImpl(algorithm, (EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -161,19 +161,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new UnixSHACryptPasswordImpl(algorithm, (UnixSHACryptPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new UnixSHACryptPasswordImpl(algorithm, (ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new UnixSHACryptPasswordImpl(algorithm, (EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException | NoSuchAlgorithmException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -199,19 +199,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new SimpleDigestPasswordImpl(algorithm, (SimpleDigestPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new SimpleDigestPasswordImpl(algorithm, (ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new SimpleDigestPasswordImpl(algorithm, (EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -231,19 +231,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new SaltedSimpleDigestPasswordImpl(algorithm, (SaltedSimpleDigestPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new SaltedSimpleDigestPasswordImpl(algorithm, (ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new SaltedSimpleDigestPasswordImpl(algorithm, (EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 }
                 break;
@@ -275,19 +275,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new BSDUnixDESCryptPasswordImpl((BSDUnixDESCryptPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new BSDUnixDESCryptPasswordImpl((ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new BSDUnixDESCryptPasswordImpl((EncryptablePasswordSpec) keySpec);
                     } catch (InvalidParameterSpecException | IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else {
                     break;
@@ -299,19 +299,19 @@ public final class PasswordFactorySpiImpl extends PasswordFactorySpi {
                     try {
                         return new ScramDigestPasswordImpl(algorithm, (ScramDigestPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof ClearPasswordSpec) {
                     try {
                         return new ScramDigestPasswordImpl(algorithm, (ClearPasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 } else if (keySpec instanceof EncryptablePasswordSpec) {
                     try {
                         return new ScramDigestPasswordImpl(algorithm, (EncryptablePasswordSpec) keySpec);
                     } catch (IllegalArgumentException | NullPointerException e) {
-                        throw new InvalidKeySpecException(e.getMessage());
+                        throw new InvalidKeySpecException(e);
                     }
                 }
                 else {

--- a/src/main/java/org/wildfly/security/sasl/entity/EntityUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/EntityUtil.java
@@ -91,7 +91,7 @@ class EntityUtil {
             }
             encoder.endSetOf();
         } catch (CertificateEncodingException e) {
-            throw new ASN1Exception(e.getMessage(), e);
+            throw new ASN1Exception(e);
         }
     }
 
@@ -338,7 +338,7 @@ class EntityUtil {
             try {
                 encoder.writeEncoded(((CertificateTrustedAuthority) trustedAuthority).getIdentifier().getEncoded());
             } catch (CertificateEncodingException e) {
-                throw new ASN1Exception(e.getMessage(), e);
+                throw new ASN1Exception(e);
             }
         } else {
             throw log.asnInvalidTrustedAuthorityType();
@@ -476,7 +476,7 @@ class EntityUtil {
             List<? extends Certificate> certs = certPath.getCertificates();
             return certs.toArray(new X509Certificate[certs.size()]);
         } catch (CertificateException e) {
-            throw new ASN1Exception(e.getMessage(), e);
+            throw new ASN1Exception(e);
         }
     }
 
@@ -569,7 +569,7 @@ class EntityUtil {
                                     CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
                                     trustedAuthority = new CertificateTrustedAuthority((X509Certificate) certFactory.generateCertificate(new ByteArrayInputStream(cert)));
                                 } catch (CertificateException e) {
-                                    throw new ASN1Exception(e.getMessage(), e);
+                                    throw new ASN1Exception(e);
                                 }
                                 break out;
                             }

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
@@ -21,7 +21,7 @@ package org.wildfly.security.sasl.external;
 import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -58,13 +58,11 @@ final class ExternalSaslServer implements SaslServer {
         String authorizationId;
         if (response.length == 0) {
             authorizationId = null;
-        } else try {
-            authorizationId = Normalizer.normalize(new String(response, "UTF-8"), Normalizer.Form.NFKC);
+        } else {
+            authorizationId = Normalizer.normalize(new String(response, StandardCharsets.UTF_8), Normalizer.Form.NFKC);
             if (authorizationId.indexOf(0) != -1) {
                 throw log.saslUserNameContainsInvalidCharacter(getMechanismName());
             }
-        } catch (UnsupportedEncodingException e) {
-            throw log.saslUserNameDecodeFailed(getMechanismName(), "UTF-8");
         }
         final AuthorizeCallback authorizeCallback = new AuthorizeCallback(null, authorizationId);
         try {

--- a/src/main/java/org/wildfly/security/ssl/MechanismDatabase.java
+++ b/src/main/java/org/wildfly/security/ssl/MechanismDatabase.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.ssl;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,8 +32,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import org.wildfly.security._private.ElytronMessages;
 
 class MechanismDatabase {
     private static final MechanismDatabase INSTANCE = new MechanismDatabase();
@@ -74,39 +74,39 @@ class MechanismDatabase {
             if (strings.length == 1 && strings[0].startsWith("alias:")) {
                 aliases.put(name, strings[0].substring(6));
             } else if (strings.length != 11) {
-                ElytronMessages.log.warnf("Invalid string count for mechanism database entry \"%s\"", name);
+                log.warnInvalidStringCountForMechanismDatabaseEntry(name);
             } else {
                 boolean ok = true;
                 final String openSslName = strings[0];
                 final KeyAgreement kex = KeyAgreement.forName(strings[1]);
                 if (kex == null) {
-                    ElytronMessages.log.warnf("Invalid key exchange \"%s\" for mechanism database entry \"%s\"", strings[1], name);
+                    log.warnInvalidKeyExchangeForMechanismDatabaseEntry(strings[1], name);
                     ok = false;
                 }
                 final Authentication auth = Authentication.forName(strings[2]);
                 if (auth == null) {
-                    ElytronMessages.log.warnf("Invalid authentication \"%s\" for mechanism database entry \"%s\"", strings[2], name);
+                    log.warnInvalidAuthenticationForMechanismDatabaseEntry(strings[2], name);
                     ok = false;
                 }
                 final Encryption enc = Encryption.forName(strings[3]);
                 if (enc == null) {
-                    ElytronMessages.log.warnf("Invalid encryption \"%s\" for mechanism database entry \"%s\"", strings[3], name);
+                    log.warnInvalidEncryptionForMechanismDatabaseEntry(strings[3], name);
                     ok = false;
                 }
                 final Digest digest = Digest.forName(strings[4]);
                 if (digest == null) {
-                    ElytronMessages.log.warnf("Invalid digest \"%s\" for mechanism database entry \"%s\"", strings[4], name);
+                    log.warnInvalidDigestForMechanismDatabaseEntry(strings[4], name);
                     ok = false;
                 }
                 final Protocol prot = Protocol.forName(strings[5]);
                 if (prot == null) {
-                    ElytronMessages.log.warnf("Invalid protocol \"%s\" for mechanism database entry \"%s\"", strings[5], name);
+                    log.warnInvalidProtocolForMechanismDatabaseEntry(strings[5], name);
                     ok = false;
                 }
                 final boolean export = Boolean.parseBoolean(strings[6]);
                 final SecurityLevel level = SecurityLevel.forName(strings[7]);
                 if (level == null) {
-                    ElytronMessages.log.warnf("Invalid level \"%s\" for mechanism database entry \"%s\"", strings[7], name);
+                    log.warnInvalidLevelForMechanismDatabaseEntry(strings[7], name);
                     ok = false;
                 }
                 final boolean fips = Boolean.parseBoolean(strings[8]);
@@ -114,7 +114,7 @@ class MechanismDatabase {
                 try {
                     strBits = Integer.parseInt(strings[9], 10);
                 } catch (NumberFormatException ignored) {
-                    ElytronMessages.log.warnf("Invalid strength bits \"%s\" for mechanism database entry \"%s\"", strings[9], name);
+                    log.warnInvalidStrengthBitsForMechanismDatabaseEntry(strings[9], name);
                     strBits = 0;
                     ok = false;
                 }
@@ -122,19 +122,19 @@ class MechanismDatabase {
                 try {
                     algBits = Integer.parseInt(strings[10], 10);
                 } catch (NumberFormatException ignored) {
-                    ElytronMessages.log.warnf("Invalid algorithm bits \"%s\" for mechanism database entry \"%s\"", strings[10], name);
+                    log.warnInvalidAlgorithmBitsForMechanismDatabaseEntry(strings[10], name);
                     algBits = 0;
                     ok = false;
                 }
                 if (ok) {
                     final Entry entry = new Entry(name, openSslName, new ArrayList<String>(0), kex, auth, enc, digest, prot, export, level, fips, strBits, algBits);
                     if (entriesByStdName.containsKey(name)) {
-                        ElytronMessages.log.warnf("Invalid duplicate mechanism database entry \"%s\"", name);
+                        log.warnInvalidDuplicateMechanismDatabaseEntry(name);
                     } else {
                         entriesByStdName.put(name, entry);
                     }
                     if (entriesByOSSLName.containsKey(openSslName)) {
-                        ElytronMessages.log.warnf("Invalid duplicate OpenSSL-style alias \"%s\" for mechanism database entry \"%s\" (original is \"%s\")", openSslName, name, entriesByOSSLName.get(openSslName).getName());
+                        log.warnInvalidDuplicateOpenSslStyleAliasForMechanismDatabaseEntry(openSslName, name, entriesByOSSLName.get(openSslName).getName());
                     } else {
                         entriesByOSSLName.put(openSslName, entry);
                     }
@@ -158,9 +158,9 @@ class MechanismDatabase {
             String name = entry.getKey();
             String value = entry.getValue();
             if (entriesByStdName.containsKey(name)) {
-                ElytronMessages.log.warnf("Invalid duplicate mechanism database entry \"%s\"", name);
+                log.warnInvalidDuplicateMechanismDatabaseEntry(name);
             } else if (! entriesByStdName.containsKey(value)) {
-                ElytronMessages.log.warnf("Invalid alias \"%s\" for missing mechanism database entry \"%s\"", value, name);
+                log.warnInvalidAliasForMissingMechanismDatabaseEntry(value, name);
             } else {
                 final Entry dbEntry = entriesByStdName.get(value);
                 dbEntry.getAliases().add(name);

--- a/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
@@ -132,7 +132,7 @@ public class BasicScramSelfTest extends BaseTestCase {
         testAuthentication(Scram.SCRAM_SHA_1_PLUS, serverHandler, clientHandler, "user", props, props);
     }
 
-    public void testAuthentication(String mechanism, CallbackHandler serverHandler, CallbackHandler clientHandler, String authorizationId, Map<String, ?> serverProps, Map<String, ?> clientProps) throws Exception {
+    private void testAuthentication(String mechanism, CallbackHandler serverHandler, CallbackHandler clientHandler, String authorizationId, Map<String, ?> serverProps, Map<String, ?> clientProps) throws Exception {
         final SaslServerFactory serverFactory = obtainSaslServerFactory(ScramSaslServerFactory.class);
         assertNotNull(serverFactory);
         final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);


### PR DESCRIPTION
* Internationalized forgotten warning messages
* More using of `StandardCharsets.UTF_8`
* Using causes of exceptions instead of takeovering only text of messages
* Removed debug printing of password hash to stdout in `UserPasswordCredentialLoader`