### PR TITLE
Digest Sasl - fix and better default qop

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
@@ -70,7 +70,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
 
         this.hasInitialResponse = hasInitialResponse;
         this.authorizationId = authorizationId;
-        this.clientQops = qops == null ? new String[] {QOP_AUTH} : qops;
+        this.clientQops = qops == null ? QOP_VALUES : qops;
         this.demandedCiphers = ciphers == null ? new String[] {} : ciphers;
         try {
             this.messageDigest = MessageDigest.getInstance(messageDigestAlgorithm(mechanism));

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -255,7 +255,7 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         final NameCallback nameCallback = new NameCallback("User name", userName);
         final CredentialCallback credentialCallback = new CredentialCallback(DigestPassword.class);
         final PasswordCallback passwordCallback = new PasswordCallback("User password", false);
-        final RealmCallback realmCallback = new RealmCallback("User realm");
+        final RealmCallback realmCallback = new RealmCallback("User realm", clientRealm);
         final AuthorizeCallback authorizeCallback = new AuthorizeCallback(userName, authzid==null ? userName : authzid);
 
         byte[] digest_urp;


### PR DESCRIPTION
* RealmCallback on server side should server give realm which client selected
* DigestSaslClient by default support only qop=auth, but I think there is no reason to forbit more secure qops. (If server support integrity and confidency, why should client by default require auth without it? If client want require qop=auth, can use same way by which now set auth-int,auth-conf)