### PR TITLE
Make it possible to configure the realm used on the client

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -564,6 +564,10 @@ public abstract class AuthenticationConfiguration {
         return keyManager == null ? without(SSLClientKeyManagerConfiguration.class) : new SSLClientKeyManagerConfiguration(this, new FixedSecurityFactory<>(keyManager));
     }
 
+    public AuthenticationConfiguration useRealm(String realm) {
+        return realm == null ? this : new SetRealmAuthenticationConfiguration(this, realm);
+    }
+
     // client methods
 
     CallbackHandler getCallbackHandler() {

--- a/src/main/java/org/wildfly/security/auth/client/SetRealmAuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/SetRealmAuthenticationConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+/**
+ * @author <a href="mailto:kkhan@redhat.com">Kabir Khan</a>
+ */
+class SetRealmAuthenticationConfiguration extends AuthenticationConfiguration {
+
+    private final String realm;
+
+    SetRealmAuthenticationConfiguration(final AuthenticationConfiguration parent, final String realm) {
+        super(parent);
+        this.realm = realm;
+    }
+
+    void handleCallback(final Callback[] callbacks, final int index) throws IOException, UnsupportedCallbackException {
+        Callback callback = callbacks[index];
+        if (callback instanceof RealmCallback) {
+            RealmCallback realmCallback = (RealmCallback) callback;
+            realmCallback.setText(realm);
+            return;
+        }
+        super.handleCallback(callbacks, index);
+    }
+
+    AuthenticationConfiguration reparent(final AuthenticationConfiguration newParent) {
+        return new SetRealmAuthenticationConfiguration(newParent, realm);
+    }
+}


### PR DESCRIPTION
This 'turns on' handling of the RealmCallback on the client
https://issues.jboss.org/browse/ELY-237