### PR TITLE
[ELY-240] Public JBoss Repository Group added to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,4 +387,18 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>public-jboss</id>
+            <name>Public JBoss Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>public-jboss-plugins</id>
+            <name>Public JBoss Repository Group</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/ELY-240

Add JBoss maven repository directly to `pom.xml`. This commit prevents "missing dependencies" build failures when users don't use a custom `.m2/settings.xml` with JBoss repositories defined.