### PR TITLE
PasswordSpec encoders/decoders and filesystem-realm echancements.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -150,8 +150,11 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1019, value = "Filesystem-backed realm encountered invalid password format \"%s\" in path \"%s\" line %d for identity name \"%s\"")
     RealmUnavailableException fileSystemRealmInvalidPasswordFormat(String format, Path path, int lineNumber, String name);
 
-    @Message(id = 1020, value = "Filesystem-backed realm failed to rename \"%s\" to \"%s\"")
-    RealmUnavailableException fileSystemRealmRenameFailed(String name, String finalName, @Cause IOException e);
+    @Message(id = 8031, value = "Filesystem-backed realm encountered invalid password algorithm \"%s\" in path \"%s\" line %d for identity name \"%s\"")
+    RealmUnavailableException fileSystemRealmInvalidPasswordAlgorithm(String algorithm, Path path, int lineNumber, String name);
+
+    @Message(id = 1020, value = "Filesystem-backed realm failed to update identity \"%s\"")
+    RealmUnavailableException fileSystemUpdatedFailed(String name, @Cause Throwable cause);
 
     @Message(id = 1021, value = "Filesystem-backed realm failed to delete identity \"%s\"")
     RealmUnavailableException fileSystemRealmDeleteFailed(String name, @Cause IOException e);
@@ -1148,4 +1151,7 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 8028, value = "Invalid algorithm \"%s\"")
     NoSuchAlgorithmException noSuchAlgorithmInvalidAlgorithm(String algorithm);
+
+    @Message(id = 8032, value = "Could not obtain key spec encoding identifier.")
+    IllegalArgumentException couldNotObtainKeySpecEncodingIdentifier();
 }

--- a/src/main/java/org/wildfly/security/auth/provider/KeyStoreBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/KeyStoreBackedSecurityRealm.java
@@ -163,7 +163,8 @@ public class KeyStoreBackedSecurityRealm implements SecurityRealm {
             if (entry instanceof PasswordEntry) {
                 final Password password = ((PasswordEntry) entry).getPassword();
                 if (credential instanceof char[]) try {
-                    return PasswordFactory.getInstance(password.getAlgorithm()).verify(password, (char[]) credential);
+                    PasswordFactory passwordFactory = PasswordFactory.getInstance(password.getAlgorithm());
+                    return passwordFactory.verify(passwordFactory.translate(password), (char[]) credential);
                 } catch (NoSuchAlgorithmException | InvalidKeyException e) {
                     throw new RealmUnavailableException(e);
                 } else {

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
@@ -21,7 +21,7 @@ import org.wildfly.common.Assert;
 import org.wildfly.security.auth.provider.jdbc.KeyMapper;
 import org.wildfly.security.auth.server.CredentialSupport;
 import org.wildfly.security.password.PasswordFactory;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.ModularCrypt;
 import org.wildfly.security.password.interfaces.BCryptPassword;
 import org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword;
 import org.wildfly.security.password.interfaces.ClearPassword;
@@ -219,7 +219,7 @@ public class PasswordKeyMapper implements KeyMapper {
                 if (ClearPassword.class.equals(credentialType)) {
                     return toClearPassword(hash, passwordFactory);
                 } else if (BCryptPassword.class.equals(credentialType)) {
-                    return PasswordUtil.parseCryptString(toCharArray(hash));
+                    return passwordFactory.translate(ModularCrypt.decode(toCharArray(hash)));
                 } else if (SaltedSimpleDigestPassword.class.equals(credentialType)) {
                     return toSaltedSimpleDigestPassword(hash, salt, passwordFactory);
                 } else if (SimpleDigestPassword.class.equals(credentialType)) {
@@ -227,7 +227,7 @@ public class PasswordKeyMapper implements KeyMapper {
                 } else if (ScramDigestPassword.class.equals(credentialType)) {
                     return toScramDigestPassword(hash, salt, iterationCount, passwordFactory);
                 }
-            } catch (InvalidKeySpecException e) {
+            } catch (InvalidKeySpecException | InvalidKeyException e) {
                 throw log.invalidPasswordKeySpecificationForAlgorithm(algorithm, e);
             }
         }

--- a/src/main/java/org/wildfly/security/keystore/PasswordKeyStoreSpi.java
+++ b/src/main/java/org/wildfly/security/keystore/PasswordKeyStoreSpi.java
@@ -49,7 +49,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.wildfly.security.password.Password;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.ModularCrypt;
 
 /**
  * A password file formatted {@link KeyStore} implementation.
@@ -192,7 +192,7 @@ public final class PasswordKeyStoreSpi extends KeyStoreSpi {
                 final char[] chars;
                 final String alias = entry.getKey();
                 try {
-                    chars = PasswordUtil.getCryptStringChars(pw);
+                    chars = ModularCrypt.encode(pw);
                 } catch (InvalidKeySpecException e) {
                     throw log.keyStoreFailedToTranslate(alias, e);
                 }
@@ -261,13 +261,13 @@ public final class PasswordKeyStoreSpi extends KeyStoreSpi {
                             // finished
                             char[] c = new char[b.length()];
                             b.getChars(0, b.length(), c, 0);
-                            final String algorithm = PasswordUtil.identifyAlgorithm(c);
+                            final String algorithm = ModularCrypt.identifyAlgorithm(c);
                             if (algorithm == null) {
                                 throw log.noAlgorithmForPassword(alias);
                             }
                             final Password pw;
                             try {
-                                pw = PasswordUtil.parseCryptString(c);
+                                pw = ModularCrypt.decode(c);
                             } catch (InvalidKeySpecException e) {
                                 throw log.noAlgorithmForPassword(alias);
                             }

--- a/src/main/java/org/wildfly/security/password/impl/BCryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/BCryptPasswordImpl.java
@@ -27,7 +27,8 @@ import java.security.spec.KeySpec;
 import java.util.Arrays;
 
 import org.wildfly.common.Assert;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
+import org.wildfly.security.password.util.ModularCrypt;
 import org.wildfly.security.password.interfaces.BCryptPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;
@@ -291,7 +292,7 @@ class BCryptPasswordImpl extends AbstractPasswordImpl implements BCryptPassword 
      * </p>
      * <p>
      * This implementation differs from the above algorithm in that it returns the encrypted ctext in its raw form. The
-     * {@link org.wildfly.security.password.PasswordUtil} class can be used to obtain the hashed password in its crypt
+     * {@link ModularCrypt} class can be used to obtain the hashed password in its crypt
      * string format (i.e. $2a$cost$encodedSaltencodedPassword).
      * </p>
      * <p>

--- a/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
@@ -28,7 +28,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
 
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;

--- a/src/main/java/org/wildfly/security/password/impl/ScramDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/ScramDigestPasswordImpl.java
@@ -31,7 +31,7 @@ import java.util.Arrays;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.password.interfaces.ScramDigestPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;

--- a/src/main/java/org/wildfly/security/password/impl/SunUnixMD5CryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SunUnixMD5CryptPasswordImpl.java
@@ -29,7 +29,7 @@ import java.security.spec.KeySpec;
 import java.util.Arrays;
 
 import org.wildfly.common.Assert;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.password.interfaces.SunUnixMD5CryptPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;

--- a/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
@@ -28,7 +28,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
 
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.password.interfaces.UnixMD5CryptPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;

--- a/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
@@ -31,7 +31,7 @@ import java.security.spec.KeySpec;
 import java.util.Arrays;
 
 import org.wildfly.common.Assert;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.password.interfaces.UnixSHACryptPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;

--- a/src/main/java/org/wildfly/security/password/spec/BasicPasswordSpecEncoding.java
+++ b/src/main/java/org/wildfly/security/password/spec/BasicPasswordSpecEncoding.java
@@ -1,0 +1,184 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.password.spec;
+
+import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.util.ByteIterator;
+import org.wildfly.security.util.ByteStringBuilder;
+import org.wildfly.security.util.CodePointIterator;
+
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * Provide methods for encoding and decoding of {@link PasswordSpec}.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public final class BasicPasswordSpecEncoding {
+
+    // the value for each identifier must be kept and can not change
+    private static final byte CLEAR_PASSWORD_SPEC_ID = 1;
+    private static final byte DIGEST_PASSWORD_SPEC_ID = 2;
+    private static final byte HASH_PASSWORD_SPEC_ID = 3;
+    private static final byte SALTED_HASH_PASSWORD_SPEC_ID = 4;
+    private static final byte ITERATED_SALTED_HASH_SPEC_ID = 5;
+
+    private BasicPasswordSpecEncoding() {}
+
+    /**
+     * Encode the given {@link PasswordSpec} to a byte array.
+     *
+     * @param password the password to encode
+     * @return a byte array representing the encoded password or null if no encoder was capable to encode the given password
+     */
+    public static byte[] encode(PasswordSpec passwordSpec) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        if (passwordSpec instanceof ClearPasswordSpec) {
+            return encodeClearPasswordSpec((ClearPasswordSpec) passwordSpec);
+        } else if (passwordSpec instanceof DigestPasswordSpec) {
+            return encodeDigestPasswordSpec((DigestPasswordSpec) passwordSpec);
+        } else if (passwordSpec instanceof SaltedHashPasswordSpec) {
+            return encodeSaltedHashPasswordSpec((SaltedHashPasswordSpec) passwordSpec);
+        } else if (passwordSpec instanceof IteratedSaltedHashPasswordSpec) {
+            return encodeIteratedSaltedHashSpec((IteratedSaltedHashPasswordSpec) passwordSpec);
+        } else if (passwordSpec instanceof HashPasswordSpec) {
+            return encodeHashPasswordSpec((HashPasswordSpec) passwordSpec);
+        }
+
+        return null;
+    }
+
+    /**
+     * Encode the given {@link Password} to a byte array.
+     *
+     * @param password the password to encode
+     * @return a byte array representing the encoded password or null if no encoder was capable to encode the given password
+     */
+    public static byte[] encode(Password password) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(password.getAlgorithm());
+
+        if (passwordFactory.convertibleToKeySpec(password, ClearPasswordSpec.class)) {
+            return encodeClearPasswordSpec(passwordFactory.getKeySpec(password, ClearPasswordSpec.class));
+        } else if (passwordFactory.convertibleToKeySpec(password, DigestPasswordSpec.class)) {
+            return encodeDigestPasswordSpec(passwordFactory.getKeySpec(password, DigestPasswordSpec.class));
+        } else if (passwordFactory.convertibleToKeySpec(password, SaltedHashPasswordSpec.class)) {
+            return encodeSaltedHashPasswordSpec(passwordFactory.getKeySpec(password, SaltedHashPasswordSpec.class));
+        } else if (passwordFactory.convertibleToKeySpec(password, IteratedSaltedHashPasswordSpec.class)) {
+            return encodeIteratedSaltedHashSpec(passwordFactory.getKeySpec(password, IteratedSaltedHashPasswordSpec.class));
+        } else if (passwordFactory.convertibleToKeySpec(password, HashPasswordSpec.class)) {
+            return encodeHashPasswordSpec(passwordFactory.getKeySpec(password, HashPasswordSpec.class));
+        }
+
+        return null;
+    }
+
+    /**
+     * Decode the given byte array and create a {@link PasswordSpec} from it.
+     *
+     * @param encoded the byte array representing the encoded password
+     * @return a {@link PasswordSpec} instance created from the encoded password or null if no decoder was capable to decode the given format.
+     */
+    public static PasswordSpec decode(byte[] encoded) {
+        ByteIterator iterator = ByteIterator.ofBytes(encoded);
+
+        int identifier;
+
+        try {
+            identifier = iterator.next();
+        } catch (Exception e) {
+            throw ElytronMessages.log.couldNotObtainKeySpecEncodingIdentifier();
+        }
+
+        switch (identifier) {
+            case CLEAR_PASSWORD_SPEC_ID:
+                return decodeClearPasswordSpec(iterator);
+            case DIGEST_PASSWORD_SPEC_ID:
+                return decodeDigestPasswordSpec(iterator);
+            case HASH_PASSWORD_SPEC_ID:
+                return decodeHashPasswordSpec(iterator);
+            case SALTED_HASH_PASSWORD_SPEC_ID:
+                return decodeSaltedHashPasswordSpec(iterator);
+            case ITERATED_SALTED_HASH_SPEC_ID:
+                return decodeIteratedSaltedHashPasswordSpec(iterator);
+            default:
+                return null;
+        }
+    }
+
+    private static byte[] encodeIteratedSaltedHashSpec(IteratedSaltedHashPasswordSpec keySpec) throws InvalidKeySpecException {
+        byte[] salt = keySpec.getSalt();
+        return new ByteStringBuilder().append(ITERATED_SALTED_HASH_SPEC_ID)
+                .appendPackedUnsignedBE(keySpec.getIterationCount()).appendPackedUnsignedBE(salt.length).append(salt).append(keySpec.getHash()).toArray();
+    }
+
+    private static PasswordSpec decodeIteratedSaltedHashPasswordSpec(ByteIterator iterator) {
+        int iterationCount = iterator.getPackedBE32();
+        byte[] salt = iterator.drain(iterator.getPackedBE32());
+        byte[] hash = iterator.drain();
+        return new IteratedSaltedHashPasswordSpec(hash, salt, iterationCount);
+    }
+
+    private static byte[] encodeSaltedHashPasswordSpec(SaltedHashPasswordSpec keySpec) throws InvalidKeySpecException {
+        byte[] salt = keySpec.getSalt();
+        return new ByteStringBuilder().append(SALTED_HASH_PASSWORD_SPEC_ID)
+                .appendPackedUnsignedBE(salt.length).append(salt).append(keySpec.getHash()).toArray();
+    }
+
+    private static PasswordSpec decodeSaltedHashPasswordSpec(ByteIterator iterator) {
+        byte[] salt = iterator.drain(iterator.getPackedBE32());
+        byte[] hash = iterator.drain();
+        return new SaltedHashPasswordSpec(hash, salt);
+    }
+
+    private static byte[] encodeHashPasswordSpec(HashPasswordSpec keySpec) throws InvalidKeySpecException {
+        return new ByteStringBuilder().append(HASH_PASSWORD_SPEC_ID).append(keySpec.getDigest()).toArray();
+    }
+
+    private static PasswordSpec decodeHashPasswordSpec(ByteIterator iterator) {
+        return new HashPasswordSpec(iterator.drain());
+    }
+
+    private static byte[] encodeDigestPasswordSpec(DigestPasswordSpec keySpec) throws InvalidKeySpecException {
+        byte[] u = keySpec.getUsername().getBytes(StandardCharsets.UTF_8);
+        byte[] r = keySpec.getRealm().getBytes(StandardCharsets.UTF_8);
+        return new ByteStringBuilder().append(DIGEST_PASSWORD_SPEC_ID)
+                .appendPackedUnsignedBE(u.length).append(u)
+                .appendPackedUnsignedBE(r.length).append(r)
+                .append(keySpec.getDigest()).toArray();
+    }
+
+    private static PasswordSpec decodeDigestPasswordSpec(ByteIterator iterator) {
+        String username = iterator.drainToUtf8(iterator.getPackedBE32());
+        String realm = iterator.drainToUtf8(iterator.getPackedBE32());
+        byte[] digest = iterator.drain();
+        return new DigestPasswordSpec(username, realm, digest);
+    }
+
+    private static byte[] encodeClearPasswordSpec(ClearPasswordSpec keySpec) throws InvalidKeySpecException {
+        byte[] passwordBytes = CodePointIterator.ofChars(keySpec.getEncodedPassword()).asUtf8().drain();
+        return new ByteStringBuilder().append(CLEAR_PASSWORD_SPEC_ID).append(passwordBytes).toArray();
+    }
+
+    private static PasswordSpec decodeClearPasswordSpec(ByteIterator iterator) {
+        return new ClearPasswordSpec(iterator.asUtf8String().drainToString().toCharArray());
+    }
+}

--- a/src/main/java/org/wildfly/security/password/util/PasswordUtil.java
+++ b/src/main/java/org/wildfly/security/password/util/PasswordUtil.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.password.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Helper utility methods for operations on passwords.
+ *
+ * @author <a href="mailto:jpkroehling.javadoc@redhat.com">Juraci Paixão Kröhling</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public final class PasswordUtil {
+
+    /**
+     * Generate a random salt as byte array.
+     *
+     * @param saltSize the size of the salt
+     * @return a byte array representing the random salt
+     */
+    public static byte[] generateRandomSalt(int saltSize) {
+        byte[] randomSalt = new byte[saltSize];
+        ThreadLocalRandom.current().nextBytes(randomSalt);
+        return randomSalt;
+    }
+}

--- a/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
@@ -1,0 +1,317 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.provider.FileSystemSecurityRealm;
+import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.authz.Attributes;
+import org.wildfly.security.authz.AuthorizationIdentity;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.BCryptPassword;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.interfaces.DigestPassword;
+import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
+import org.wildfly.security.password.interfaces.ScramDigestPassword;
+import org.wildfly.security.password.interfaces.SimpleDigestPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.password.spec.DigestPasswordAlgorithmSpec;
+import org.wildfly.security.password.spec.EncryptablePasswordSpec;
+import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
+import org.wildfly.security.password.spec.SaltedPasswordAlgorithmSpec;
+import org.wildfly.security.password.util.PasswordUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.security.password.interfaces.BCryptPassword.BCRYPT_SALT_SIZE;
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class FileSystemSecurityRealmTest {
+
+    private static final Provider provider = new WildFlyElytronProvider();
+
+    @BeforeClass
+    public static void onBefore() throws Exception {
+        Security.addProvider(provider);
+    }
+
+    @AfterClass
+    public static void onAfter() throws Exception {
+        Security.removeProvider(provider.getName());
+    }
+
+    @Test
+    public void testCreateIdentityWithNoLevels() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 0);
+        ModifiableRealmIdentity identity = securityRealm.createRealmIdentity("plainUser");
+
+        assertFalse(identity.exists());
+
+        identity.create();
+
+        assertTrue(identity.exists());
+    }
+
+    @Test
+    public void testCreateIdentityWithLevels() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 3);
+        ModifiableRealmIdentity identity = securityRealm.createRealmIdentity("plainUser");
+
+        identity.create();
+
+        assertTrue(identity.exists());
+    }
+
+    @Test
+    public void testCreateAndLoadIdentity() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 3);
+        ModifiableRealmIdentity newIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        newIdentity.create();
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 3);
+
+        ModifiableRealmIdentity existingIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        assertTrue(existingIdentity.exists());
+    }
+
+    @Test
+    public void testCreateAndLoadAndDeleteIdentity() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 3);
+        ModifiableRealmIdentity newIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        newIdentity.create();
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 3);
+
+        ModifiableRealmIdentity existingIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        assertTrue(existingIdentity.exists());
+
+        existingIdentity.delete();
+
+        assertFalse(existingIdentity.exists());
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 3);
+
+        existingIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        assertFalse(existingIdentity.exists());
+    }
+
+    @Test
+    public void testCreateIdentityWithAttributes() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 1);
+        ModifiableRealmIdentity newIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        newIdentity.create();
+
+        MapAttributes newAttributes = new MapAttributes();
+
+        newAttributes.addFirst("name", "plainUser");
+        newAttributes.addAll("roles", Arrays.asList("Employee", "Manager", "Admin"));
+
+        newIdentity.setAttributes(newAttributes);
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 1);
+
+        ModifiableRealmIdentity existingIdentity = securityRealm.createRealmIdentity("plainUser");
+        AuthorizationIdentity authorizationIdentity = existingIdentity.getAuthorizationIdentity();
+        Attributes existingAttributes = authorizationIdentity.getAttributes();
+
+        assertEquals(newAttributes.size(), existingAttributes.size());
+        assertTrue(newAttributes.get("name").containsAll(existingAttributes.get("name")));
+        assertTrue(newAttributes.get("roles").containsAll(existingAttributes.get("roles")));
+    }
+
+    @Test
+    public void testCreateIdentityWithClearPassword() throws Exception {
+        char[] actualPassword = "secretPassword".toCharArray();
+        PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+        ClearPassword clearPassword = (ClearPassword) factory.generatePassword(new ClearPasswordSpec(actualPassword));
+
+        assertCreateIdentityWithPassword(actualPassword, clearPassword);
+    }
+
+    @Test
+    public void testCreateIdentityWithBcryptCredential() throws Exception {
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(BCryptPassword.ALGORITHM_BCRYPT);
+        char[] actualPassword = "secretPassword".toCharArray();
+        BCryptPassword bCryptPassword = (BCryptPassword) passwordFactory.generatePassword(
+                new EncryptablePasswordSpec(actualPassword, new IteratedSaltedPasswordAlgorithmSpec(10, PasswordUtil.generateRandomSalt(BCRYPT_SALT_SIZE)))
+        );
+
+        assertCreateIdentityWithPassword(actualPassword, bCryptPassword);
+    }
+
+    @Test
+    public void testCreateIdentityWithScramCredential() throws Exception {
+        char[] actualPassword = "secretPassword".toCharArray();
+        byte[] salt = PasswordUtil.generateRandomSalt(BCRYPT_SALT_SIZE);
+        PasswordFactory factory = PasswordFactory.getInstance(ScramDigestPassword.ALGORITHM_SCRAM_SHA_256);
+        EncryptablePasswordSpec encSpec = new EncryptablePasswordSpec(actualPassword, new IteratedSaltedPasswordAlgorithmSpec(4096, salt));
+        ScramDigestPassword scramPassword = (ScramDigestPassword) factory.generatePassword(encSpec);
+
+        assertCreateIdentityWithPassword(actualPassword, scramPassword);
+    }
+
+    @Test
+    public void testCreateIdentityWithDigest() throws Exception {
+        char[] actualPassword = "secretPassword".toCharArray();
+        PasswordFactory factory = PasswordFactory.getInstance(DigestPassword.ALGORITHM_DIGEST_SHA_512);
+        DigestPasswordAlgorithmSpec dpas = new DigestPasswordAlgorithmSpec("jsmith", "elytron");
+        EncryptablePasswordSpec encryptableSpec = new EncryptablePasswordSpec(actualPassword, dpas);
+        DigestPassword digestPassword = (DigestPassword) factory.generatePassword(encryptableSpec);
+
+        assertCreateIdentityWithPassword(actualPassword, digestPassword);
+    }
+
+    @Test
+    public void testCreateIdentityWithSimpleDigest() throws Exception {
+        char[] actualPassword = "secretPassword".toCharArray();
+        EncryptablePasswordSpec eps = new EncryptablePasswordSpec(actualPassword, null);
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512);
+        SimpleDigestPassword tsdp = (SimpleDigestPassword) passwordFactory.generatePassword(eps);
+
+        assertCreateIdentityWithPassword(actualPassword, tsdp);
+    }
+
+    @Test
+    public void testCreateIdentityWithSimpleSaltedDigest() throws Exception {
+        char[] actualPassword = "secretPassword".toCharArray();
+        byte[] salt = PasswordUtil.generateRandomSalt(BCRYPT_SALT_SIZE);
+        SaltedPasswordAlgorithmSpec spac = new SaltedPasswordAlgorithmSpec(salt);
+        EncryptablePasswordSpec eps = new EncryptablePasswordSpec(actualPassword, spac);
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512);
+        SaltedSimpleDigestPassword tsdp = (SaltedSimpleDigestPassword) passwordFactory.generatePassword(eps);
+
+        assertCreateIdentityWithPassword(actualPassword, tsdp);
+    }
+
+    @Test
+    public void testCreateIdentityWithEverything() throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 1);
+        ModifiableRealmIdentity newIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        newIdentity.create();
+
+        MapAttributes newAttributes = new MapAttributes();
+
+        newAttributes.addFirst("firstName", "John");
+        newAttributes.addFirst("lastName", "Smith");
+        newAttributes.addAll("roles", Arrays.asList("Employee", "Manager", "Admin"));
+
+        newIdentity.setAttributes(newAttributes);
+
+        ArrayList<Object> credentials = new ArrayList<>();
+
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(BCryptPassword.ALGORITHM_BCRYPT);
+        BCryptPassword bCryptPassword = (BCryptPassword) passwordFactory.generatePassword(
+                new EncryptablePasswordSpec("secretPassword".toCharArray(), new IteratedSaltedPasswordAlgorithmSpec(10, PasswordUtil.generateRandomSalt(BCRYPT_SALT_SIZE)))
+        );
+
+        credentials.add(bCryptPassword);
+
+        newIdentity.setCredentials(credentials);
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 1);
+
+        ModifiableRealmIdentity existingIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        assertTrue(existingIdentity.exists());
+        assertTrue(existingIdentity.verifyCredential("secretPassword".toCharArray()));
+
+        AuthorizationIdentity authorizationIdentity = existingIdentity.getAuthorizationIdentity();
+        Attributes existingAttributes = authorizationIdentity.getAttributes();
+
+        assertEquals(newAttributes.size(), existingAttributes.size());
+        assertTrue(newAttributes.get("firstName").containsAll(existingAttributes.get("firstName")));
+        assertTrue(newAttributes.get("lastName").containsAll(existingAttributes.get("lastName")));
+        assertTrue(newAttributes.get("roles").containsAll(existingAttributes.get("roles")));
+    }
+
+    public void assertCreateIdentityWithPassword(char[] actualPassword, Password credential) throws Exception {
+        FileSystemSecurityRealm securityRealm = new FileSystemSecurityRealm(getRootPath(), 1);
+        ModifiableRealmIdentity newIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        newIdentity.create();
+
+        ArrayList<Object> credentials = new ArrayList<>();
+
+        credentials.add(credential);
+
+        newIdentity.setCredentials(credentials);
+
+        securityRealm = new FileSystemSecurityRealm(getRootPath(false), 1);
+
+        ModifiableRealmIdentity existingIdentity = securityRealm.createRealmIdentity("plainUser");
+
+        assertTrue(existingIdentity.exists());
+        assertTrue(existingIdentity.verifyCredential(actualPassword));
+    }
+
+    private Path getRootPath(boolean deleteIfExists) throws Exception {
+        Path rootPath = Paths.get(getClass().getResource(File.separator).toURI())
+                .resolve("filesystem-realm");
+
+        if (rootPath.toFile().exists() && !deleteIfExists) {
+            return rootPath;
+        }
+
+        return Files.walkFileTree(Files.createDirectories(rootPath), new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private Path getRootPath() throws Exception {
+        return getRootPath(true);
+    }
+
+}

--- a/src/test/java/org/wildfly/security/auth/provider/jdbc/PasswordSupportTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/jdbc/PasswordSupportTest.java
@@ -25,7 +25,7 @@ import org.wildfly.security.auth.server.CredentialSupport;
 import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
-import org.wildfly.security.password.PasswordUtil;
+import org.wildfly.security.password.util.ModularCrypt;
 import org.wildfly.security.password.interfaces.BCryptPassword;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
@@ -36,6 +36,7 @@ import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.IteratedSaltedHashPasswordSpec;
 import org.wildfly.security.password.spec.SaltedPasswordAlgorithmSpec;
+import org.wildfly.security.password.util.PasswordUtil;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -124,8 +125,7 @@ public class PasswordSupportTest {
         assertNotNull(storedPassword);
 
         // use the new password to obtain a spec and then check if the spec yields the same crypt string.
-        PasswordFactory passwordFactory = PasswordFactory.getInstance(BCryptPassword.ALGORITHM_BCRYPT);
-        assertEquals(cryptString, PasswordUtil.getCryptString(storedPassword));
+        assertEquals(cryptString, ModularCrypt.encodeAsString(storedPassword));
     }
 
     @Test
@@ -443,7 +443,7 @@ public class PasswordSupportTest {
             BCryptPassword bCryptPassword = (BCryptPassword) passwordFactory.generatePassword(
                     new EncryptablePasswordSpec(userPassword.toCharArray(), new IteratedSaltedPasswordAlgorithmSpec(10, salt))
             );
-            String cryptString = PasswordUtil.getCryptString(bCryptPassword);
+            String cryptString = ModularCrypt.encodeAsString(bCryptPassword);
 
             preparedStatement.setString(1, userName);
             preparedStatement.setString(2, cryptString);

--- a/src/test/java/org/wildfly/security/password/impl/BCryptPasswordTest.java
+++ b/src/test/java/org/wildfly/security/password/impl/BCryptPasswordTest.java
@@ -31,12 +31,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.password.PasswordFactory;
-import org.wildfly.security.password.PasswordUtil;
 import org.wildfly.security.password.interfaces.BCryptPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.IteratedSaltedHashPasswordSpec;
+import org.wildfly.security.password.util.ModularCrypt;
 
 /**
  * <p>
@@ -65,19 +65,20 @@ public class BCryptPasswordTest {
         String cryptString = "$2a$12$D4G5f18o7aMMfwasBL7GpuQWuP3pkrZrOAnqP.bmezbMng.QwJ/pG";
 
         // get the spec by parsing the crypt string.
-        BCryptPassword password = (BCryptPassword) PasswordUtil.parseCryptString(cryptString);
+        PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_BCRYPT);
+        BCryptPassword password = (BCryptPassword) factory.translate(ModularCrypt.decode(cryptString));
         Assert.assertEquals(12, password.getIterationCount());
         Assert.assertEquals(BCryptPassword.BCRYPT_SALT_SIZE, password.getSalt().length);
 
         // use the spec to build a new crypt string and compare it to the original one.
-        Assert.assertEquals(cryptString, PasswordUtil.getCryptString(password));
+        Assert.assertEquals(cryptString, ModularCrypt.encodeAsString(password));
     }
 
     @Test
     public void testHashEmptyString() throws Exception {
         String cryptString = "$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye";
-        BCryptPassword password = (BCryptPassword) PasswordUtil.parseCryptString(cryptString);
         PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_BCRYPT);
+        BCryptPassword password = (BCryptPassword) factory.translate(ModularCrypt.decode(cryptString));
 
         // use the obtained spec to build a BCryptPasswordImpl, then verify the hash using the correct password.
         Assert.assertTrue(factory.verify(password, "".toCharArray()));
@@ -92,15 +93,17 @@ public class BCryptPasswordTest {
         Assert.assertArrayEquals(password.getHash(), password.getHash());
 
         // use the new password to obtain a spec and then check if the spec yields the same crypt string.
-        Assert.assertEquals(cryptString, PasswordUtil.getCryptString(password));
+        Assert.assertEquals(cryptString, ModularCrypt.encodeAsString(password));
     }
 
     @Test
     public void testHashSimpleString() throws Exception {
         String cryptString = "$2a$10$fVH8e28OQRj9tqiDXs1e1uxpsjN0c7II7YPKXua2NAKYvM6iQk7dq";
         char[] correctPassword = "abcdefghijklmnopqrstuvwxyz".toCharArray();
-        BCryptPassword password = (BCryptPassword) PasswordUtil.parseCryptString(cryptString);
         PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_BCRYPT);
+        BCryptPassword password = (BCryptPassword) factory.translate(ModularCrypt.decode(cryptString));
+
+        password = (BCryptPassword) factory.translate(password);
 
         // use the obtained spec to build a BCryptPasswordImpl, then verify the hash using the correct password.
         Assert.assertTrue(factory.verify(password, correctPassword));
@@ -115,15 +118,15 @@ public class BCryptPasswordTest {
         Assert.assertArrayEquals(password.getHash(), password.getHash());
 
         // use the new password to obtain a spec and then check if the spec yields the same crypt string.
-        Assert.assertEquals(cryptString, PasswordUtil.getCryptString(password));
+        Assert.assertEquals(cryptString, ModularCrypt.encodeAsString(password));
     }
 
     @Test
     public void testHashComplexString() throws Exception {
         String cryptString = "$2a$12$WApznUOJfkEGSmYRfnkrPOr466oFDCaj4b6HY3EXGvfxm43seyhgC";
         char[] correctPassword = "~!@#$%^&*()      ~!@#$%^&*()PNBFRD".toCharArray();
-        BCryptPassword password = (BCryptPassword) PasswordUtil.parseCryptString(cryptString);
         PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_BCRYPT);
+        BCryptPassword password = (BCryptPassword) factory.translate(ModularCrypt.decode(cryptString));
 
         // use the obtained spec to build a BCryptPasswordImpl, then verify the hash using the correct password.
         Assert.assertTrue(factory.verify(password, correctPassword));
@@ -138,7 +141,7 @@ public class BCryptPasswordTest {
         Assert.assertArrayEquals(password.getHash(), password.getHash());
 
         // use the new password to obtain a spec and then check if the spec yields the same crypt string.
-        Assert.assertEquals(cryptString, PasswordUtil.getCryptString(password));
+        Assert.assertEquals(cryptString, ModularCrypt.encodeAsString(password));
     }
 
     /**
@@ -177,8 +180,8 @@ public class BCryptPasswordTest {
     public void testHashAgainstPassLib() throws Exception {
         String cryptString = "$2a$12$NT0I31Sa7ihGEWpka9ASYeEFkhuTNeBQ2xfZskIiiJeyFXhRgS.Sy";
         char[] correctPassword = "password".toCharArray();
-        BCryptPassword password = (BCryptPassword) PasswordUtil.parseCryptString(cryptString);
         PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_BCRYPT);
+        BCryptPassword password = (BCryptPassword) factory.translate(ModularCrypt.decode(cryptString));
 
         // use the obtained spec to build a BCryptPasswordImpl, then verify the hash using the correct password.
         Assert.assertTrue(factory.verify(password, correctPassword));
@@ -193,7 +196,7 @@ public class BCryptPasswordTest {
         Assert.assertArrayEquals(password.getHash(), password.getHash());
 
         // use the new password to obtain a spec and then check if the spec yields the same crypt string.
-        Assert.assertEquals(cryptString, PasswordUtil.getCryptString(password));
+        Assert.assertEquals(cryptString, ModularCrypt.encodeAsString(password));
     }
 
     @Test


### PR DESCRIPTION
This pull request contains two commits:

* 6d7f443e48fb9482aacf20111d675133d11e5040 is all about supporting encoders and decoders for ```PasswordSpec``` types. It also contains enhancements to the ```PasswordUtil`` in order to better separate MCF and non-MCF helper methods.
* b7f8b01477f28b8dba34a6ce2299c42ccd0a980b is all about changes to to the ```FileSystemSecurityRealm``` in order to better support credential management and some minor fixes.

This PR depends on https://github.com/wildfly-security/wildfly-elytron/pull/248.