### PR TITLE
Real callbacks in SASL tests

### DIFF
--- a/src/test/java/org/wildfly/security/auth/client/ClientUtils.java
+++ b/src/test/java/org/wildfly/security/auth/client/ClientUtils.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.security.auth.client;
+
+import static java.security.AccessController.doPrivileged;
+
+import java.net.URI;
+
+import javax.security.auth.callback.CallbackHandler;
+
+/**
+ * @author Kabir Khan
+ */
+public class ClientUtils {
+    private static final AuthenticationContextConfigurationClient AUTH_CONFIGURATION_CLIENT = doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+
+    public static CallbackHandler getCallbackHandler(URI uri, AuthenticationContext context) {
+        AuthenticationConfiguration config = AUTH_CONFIGURATION_CLIENT.getAuthenticationConfiguration(uri, context);
+        return config.getCallbackHandler();
+    }
+}

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.security.sasl.scram;
+
+import java.net.URI;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.ClientUtils;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.password.Password;
+
+/**
+ * @author Kabir Khan
+ */
+class ScramCallbackHandlerUtils {
+
+    static CallbackHandler createClientCallbackHandler(final String username, final char[] password) throws Exception {
+        final AuthenticationContext context = AuthenticationContext.empty()
+                .with(
+                        MatchRule.ALL,
+                        AuthenticationConfiguration.EMPTY
+                                .useName(username)
+                                .usePassword(password)
+                                .allowSaslMechanisms("SCRAM-SHA-256"));
+
+
+        return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
+    }
+
+    static CallbackHandler createClientCallbackHandler(final String username, final Password password) throws Exception {
+        final AuthenticationContext context = AuthenticationContext.empty()
+                .with(
+                        MatchRule.ALL,
+                        AuthenticationConfiguration.EMPTY
+                                .useName(username)
+                                .usePassword(password)
+                                .allowSaslMechanisms("SCRAM-SHA-256"));
+
+
+        return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
+    }
+}

--- a/src/test/java/org/wildfly/security/sasl/test/BaseTestCase.java
+++ b/src/test/java/org/wildfly/security/sasl/test/BaseTestCase.java
@@ -76,7 +76,7 @@ public class BaseTestCase {
      * @param requiredServerFactory - The server factory we are looking for.
      * @return the located server factory.
      */
-    protected SaslServerFactory obtainSaslServerFactory(final Class requiredServerFactory) {
+    protected static SaslServerFactory obtainSaslServerFactory(final Class requiredServerFactory) {
         Enumeration<SaslServerFactory> serverFactories = Sasl.getSaslServerFactories();
         while (serverFactories.hasMoreElements()) {
             SaslServerFactory current = serverFactories.nextElement();

--- a/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ClientCallbackHandler.java
@@ -39,7 +39,9 @@ import org.wildfly.security.password.PasswordFactory;
  * A simple CallbackHandler for testing the client side of the calls.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @deprecated Use real callback handlers where possible
  */
+@Deprecated
 public class ClientCallbackHandler implements CallbackHandler {
 
     private final String username;

--- a/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.security.sasl.test;
+
+import static org.wildfly.security.sasl.test.BaseTestCase.obtainSaslServerFactory;
+
+import java.security.spec.KeySpec;
+import java.util.Map;
+
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.junit.Assert;
+import org.wildfly.security.auth.provider.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.sasl.util.ChannelBindingSaslServerFactory;
+import org.wildfly.security.sasl.util.PropertiesSaslServerFactory;
+import org.wildfly.security.sasl.util.ProtocolSaslServerFactory;
+import org.wildfly.security.sasl.util.ServerNameSaslServerFactory;
+
+/**
+ * @author Kabir Khan
+ */
+public class SaslServerBuilder {
+    //Server factory info
+    private final Class<? extends SaslServerFactory> serverFactoryClass;
+    private final String mechanismName;
+
+    //Security domain info
+    private String username;
+    private Password password = NULL_PASSWORD;
+    private String realmName = "mainRealm";
+    private String defaultRealmName = realmName;
+
+    //Server factory decorators
+    private Map<String, Object> properties;
+    private Tuple<String, byte[]> bindingTypeAndData;
+    private String protocol;
+    private String serverName;
+
+    public SaslServerBuilder(Class<? extends SaslServerFactory> serverFactoryClass, String mechanismName) {
+        this.serverFactoryClass = serverFactoryClass;
+        this.mechanismName = mechanismName;
+    }
+
+    public SaslServerBuilder setUserName(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public SaslServerBuilder setPassword(char[] password) throws Exception {
+        Assert.assertNotNull(password);
+        setPassword(ClearPassword.ALGORITHM_CLEAR, new ClearPasswordSpec(password));
+        return this;
+    }
+
+    public SaslServerBuilder setPassword(final String algorithm, final KeySpec keySpec) throws Exception {
+        Assert.assertNotNull(algorithm);
+        Assert.assertNotNull(password);
+        final PasswordFactory factory = PasswordFactory.getInstance(algorithm);
+        this.password = factory.generatePassword(keySpec);
+        Assert.assertNotNull(this.password);
+        return this;
+    }
+
+    public SaslServerBuilder setRealmName(String realmName) {
+        Assert.assertNotNull(realmName);
+        this.realmName = realmName;
+        return this;
+    }
+
+    public SaslServerBuilder setDefaultRealmName(String realmName) {
+        this.defaultRealmName = realmName;
+        return this;
+    }
+
+    public SaslServerBuilder setProperties(Map<String, Object> properties) {
+        Assert.assertNotNull(properties);
+        this.properties = properties;
+        return this;
+    }
+
+    public SaslServerBuilder setChannelBinding(final String bindingType, byte[] bindingData) {
+        Assert.assertNotNull(bindingType);
+        Assert.assertNotNull(bindingData);
+        bindingTypeAndData = new Tuple<>(bindingType, bindingData);
+        return this;
+    }
+
+    public SaslServerBuilder setProtocol(final String protocol) {
+        this.protocol = protocol;
+        return this;
+    }
+
+    public SaslServerBuilder setServerName(final String serverName) {
+        this.serverName = serverName;
+        return this;
+    }
+
+    public SaslServer build() throws Exception {
+        final SecurityDomain.Builder domainBuilder = SecurityDomain.builder();
+        final SimpleMapBackedSecurityRealm mainRealm = new SimpleMapBackedSecurityRealm();
+        domainBuilder.addRealm(realmName, mainRealm);
+        domainBuilder.setDefaultRealmName(defaultRealmName);
+        if (username != null) {
+            mainRealm.setPasswordMap(username, password);
+        }
+        SecurityDomain domain = domainBuilder.build();
+        SaslServerFactory factory = obtainSaslServerFactory(serverFactoryClass);
+        if (properties != null && properties.size() > 0) {
+            factory = new PropertiesSaslServerFactory(factory, properties);
+        }
+        if (bindingTypeAndData != null) {
+            factory = new ChannelBindingSaslServerFactory(factory, bindingTypeAndData.key, bindingTypeAndData.value);
+        }
+        if (protocol != null) {
+            factory = new ProtocolSaslServerFactory(factory, protocol);
+        }
+        if (serverName != null) {
+            factory = new ServerNameSaslServerFactory(factory, serverName);
+        }
+        SaslServer server = domain.createNewAuthenticationContext().createSaslServer(factory, mechanismName);
+        Assert.assertNotNull(server);
+        return server;
+    }
+
+    private static class Tuple<K, V> {
+        private final K key;
+        private final V value;
+
+        public Tuple(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    private static Password NULL_PASSWORD = new Password() {
+        @Override
+        public String getAlgorithm() {
+            return null;
+        }
+
+        @Override
+        public String getFormat() {
+            return null;
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new byte[0];
+        }
+    };
+
+
+}

--- a/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
+++ b/src/test/java/org/wildfly/security/sasl/test/ServerCallbackHandler.java
@@ -45,7 +45,9 @@ import org.wildfly.security.password.PasswordFactory;
  * required failures.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @deprecated Use real callback handlers where possible
  */
+@Deprecated
 public class ServerCallbackHandler implements CallbackHandler {
 
     private final String expectedUsername;


### PR DESCRIPTION
This is an attempt to eliminate the usage of the test ClientCallbackHandler and the ServerCallbackHandler, and to instead use the real callback handlers. This PR contains the parts which I am happy/confident-ish about, and is a straight-forward port of the tests in question.

There are also parts where I had to change the main classes, mainly working on doing the same for sasl digest. For that I have opened https://github.com/wildfly-security/wildfly-elytron/pull/253, which can be the basis for discussion of what I have found.