### PR TITLE
TwoWayPassword into Digest SASL + realm callback into AuthenticationConfiguration

### DIFF
--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -500,7 +500,6 @@ public class CompatibilityServerTest extends BaseTestCase {
                         .setProtocol("acap").setServerName("elwood.innosoft.com")
                         .setProperties(serverProps)
                         .build();
-
         assertFalse(server.isComplete());
 
         byte[] message1 = server.evaluateResponse(new byte[0]);


### PR DESCRIPTION
Rewritten getting data from callback handlers to allow using of `TwoWayPassword`.
This should solve Kabir's problem described in #253.

* **DigestMechanism**
 * getting of password hash from individual password types/callbacks into `AbstractDigestMechanism` as standalone methods
 * added support of `CredentialCallback` + `TwoWayPassword`
 * `messageDigest` and `passwordAlgorithm(mechanism)` conversion into `AbstractDigestMechanism`
* **Digest + Scram SASL**
 * using of `password.destroy();`
* **SetRealmAuthenticationConfiguration**
 * support of `RealmChoiceCallback` into `SetRealmAuthenticationConfiguration`
 * support of default realm (`.setRealm(null)` to use `realmCallback.getDefaultText()`)