### PR TITLE
[ELY-248] - Inconsistent behavior in FileSystemRealm when verifying credentials and multiple credentials are set.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
@@ -286,7 +286,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                         final Password password = (Password) ours;
                         final String algorithm = password.getAlgorithm();
                         final PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
-                        return passwordFactory.verify(password, clearPassword.getPassword());
+                        if (passwordFactory.verify(password, clearPassword.getPassword())) {
+                            return true;
+                        }
                     } catch (NoSuchAlgorithmException | InvalidKeyException ignored) {
                         // try next credential
                     }


### PR DESCRIPTION
When a ```RealmIdentity``` has multiple credentials set, the ```verifyCredential``` method is only checking the first one (accordingly to the order they were previously loaded from the XML).