### PR TITLE
Make EntityTest use real callback handlers

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security._private;
 
+import static org.jboss.logging.Logger.Level.WARN;
+
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,7 +32,6 @@ import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 
-import static org.jboss.logging.Logger.Level.WARN;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
@@ -1140,4 +1141,7 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 8029, value = "Could not obtain key spec encoding identifier.")
     IllegalArgumentException couldNotObtainKeySpecEncodingIdentifier();
+
+    @Message(id = 8030, value = "No compliant certificate was found for the list of trusted authorities returned by the server")
+    SaslException noCompliantCertificateFound();
 }

--- a/src/main/java/org/wildfly/security/sasl/entity/ConfiguredEntitySaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/ConfiguredEntitySaslClientFactory.java
@@ -1,0 +1,153 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.entity;
+
+import static org.wildfly.security.sasl.entity.EntityUtil.isCertChainTrusted;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.x500.X500Principal;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.auth.callback.CredentialCallback;
+import org.wildfly.security.auth.callback.TrustedAuthoritiesCallback;
+import org.wildfly.security.auth.callback.VerifyPeerTrustedCallback;
+import org.wildfly.security.sasl.util.AbstractDelegatingSaslClientFactory;
+
+/**
+ * A {@link SaslClientFactory} which can be configured with the necessary information for entity auth.
+ *
+ * @author Kabir Khan
+ */
+public final class ConfiguredEntitySaslClientFactory extends AbstractDelegatingSaslClientFactory {
+    private final KeyStore keyStore;
+    private final KeyStore trustStore;
+    private final String keyStoreAlias;
+    private final char[] keyStorePassword;
+
+    /**
+     * Construct a new instance.
+     * @param delegate the delegate SASL server factory
+     * @param trustStore the trust store
+     * @param keyStore the key store
+     * @param keyStoreAlias the key store alias. If the server responds with a list of trusted authorities, this will be ignored.
+     * @param keyStorePassword the key store password
+     */
+        public ConfiguredEntitySaslClientFactory(final SaslClientFactory delegate,
+                                             KeyStore trustStore, KeyStore keyStore, String keyStoreAlias, char[] keyStorePassword) {
+        super(delegate);
+        this.trustStore = trustStore;
+        this.keyStore = keyStore;
+        this.keyStoreAlias = keyStoreAlias;
+        this.keyStorePassword = keyStorePassword;
+    }
+
+    @Override
+    public SaslClient createSaslClient(String[] mechanisms, String authorizationId, String protocol, String serverName, Map<String, ?> props, CallbackHandler cbh) throws SaslException {
+        return super.createSaslClient(mechanisms, authorizationId, protocol, serverName, props, callbacks -> {
+
+            List<TrustedAuthority> trustedAuthorities = null;
+            String privateKeyAlias = keyStoreAlias;
+
+            ArrayList<Callback> list = new ArrayList<>(Arrays.asList(callbacks));
+            final Iterator<Callback> iterator = list.iterator();
+            while (iterator.hasNext()) {
+                Callback callback = iterator.next();
+
+                try {
+                    boolean handled = true;
+                    if (callback instanceof TrustedAuthoritiesCallback) {
+                        trustedAuthorities = ((TrustedAuthoritiesCallback) callback).getTrustedAuthorities();
+                    } else if (callback instanceof CredentialCallback) {
+                        final CredentialCallback credentialCallback = (CredentialCallback) callback;
+                        for (Class<?> allowedType : credentialCallback.getAllowedTypes()) {
+                            if (allowedType == X509Certificate[].class) {
+                                Certificate[] certChain = null;
+                                if (trustedAuthorities != null) {
+                                    boolean compliantCertFound = false;
+                                    List<String> aliases = Collections.list(keyStore.aliases());
+                                    out: {
+                                        for (String alias : aliases) {
+                                            if (keyStore.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                                                certChain = keyStore.getCertificateChain(alias);
+                                                for (Certificate cert : certChain) {
+                                                    X500Principal principal = ((X509Certificate) cert).getSubjectX500Principal();
+                                                    for (TrustedAuthority trustedAuthority : trustedAuthorities) {
+                                                        if (trustedAuthority instanceof TrustedAuthority.NameTrustedAuthority) {
+                                                            String authorityName = ((TrustedAuthority.NameTrustedAuthority) trustedAuthority).getIdentifier();
+                                                            if (principal.equals(new X500Principal(authorityName))) {
+                                                                compliantCertFound = true;
+                                                                privateKeyAlias = alias;
+                                                                break out;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if (! compliantCertFound) {
+                                        throw ElytronMessages.log.noCompliantCertificateFound();
+                                    }
+                                } else {
+                                    certChain = keyStore.getCertificateChain(keyStoreAlias);
+                                }
+                                credentialCallback.setCredential(Arrays.copyOf(certChain, certChain.length, X509Certificate[].class));
+                                break;
+                            } else if (allowedType == PrivateKey.class) {
+                                credentialCallback.setCredential(keyStore.getKey(privateKeyAlias, keyStorePassword));
+                                break;
+                            }
+                        }
+                    } else if (callback instanceof VerifyPeerTrustedCallback) {
+                        final VerifyPeerTrustedCallback verifyTrustedCallback = (VerifyPeerTrustedCallback) callback;
+                        verifyTrustedCallback.setVerified(isCertChainTrusted(trustStore, verifyTrustedCallback.getCertificateChain()));
+                    } else {
+                        handled = false;
+                    }
+                    if (handled) {
+                        iterator.remove();
+                    }
+                } catch (GeneralSecurityException e) {
+                    SaslException ex = new SaslException(e.getLocalizedMessage());
+                    ex.initCause(e);
+                    throw ex;
+                }
+            }
+            if (!list.isEmpty()) {
+                cbh.handle(list.toArray(new Callback[list.size()]));
+            }
+        });
+    }
+}

--- a/src/main/java/org/wildfly/security/sasl/entity/ConfiguredEntitySaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/ConfiguredEntitySaslServerFactory.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.entity;
+
+import static org.wildfly.security.sasl.entity.EntityUtil.isCertChainTrusted;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.wildfly.security.auth.callback.CredentialCallback;
+import org.wildfly.security.auth.callback.TrustedAuthoritiesCallback;
+import org.wildfly.security.auth.callback.VerifyPeerTrustedCallback;
+import org.wildfly.security.sasl.util.AbstractDelegatingSaslServerFactory;
+
+/**
+ * A {@link SaslServerFactory} which can be configured with the necessary information for entity auth.
+ *
+ * @author Kabir Khan
+ */
+public final class ConfiguredEntitySaslServerFactory extends AbstractDelegatingSaslServerFactory {
+    private final List<TrustedAuthority> trustedAuthorities;
+    private final KeyStore trustStore;
+    private final KeyStore keyStore;
+    private final String keyStoreAlias;
+    private final char[] keyStorePassword;
+
+    /**
+     * Construct a new instance.
+     * @param delegate the delegate SASL server factory
+     * @param trustedAuthorities the trusted authorities
+     * @param trustStore the trust store
+     * @param keyStore the key store
+     * @param keyStoreAlias the key store alias
+     * @param keyStorePassword the key store password
+     */
+    public ConfiguredEntitySaslServerFactory(final SaslServerFactory delegate, List<TrustedAuthority> trustedAuthorities,
+                                             KeyStore trustStore, KeyStore keyStore, String keyStoreAlias, char[] keyStorePassword) {
+        super(delegate);
+        this.trustedAuthorities = trustedAuthorities;
+        this.trustStore = trustStore;
+        this.keyStore = keyStore;
+        this.keyStoreAlias = keyStoreAlias;
+        this.keyStorePassword = keyStorePassword;
+    }
+
+    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName, final Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        return delegate.createSaslServer(mechanism, protocol, serverName, props, callbacks -> {
+            ArrayList<Callback> list = new ArrayList<>(Arrays.asList(callbacks));
+            final Iterator<Callback> iterator = list.iterator();
+            while (iterator.hasNext()) {
+                Callback callback = iterator.next();
+                try {
+                    boolean handled = true;
+                    if (callback instanceof VerifyPeerTrustedCallback) {
+                        final VerifyPeerTrustedCallback verifyTrustedCallback = (VerifyPeerTrustedCallback) callback;
+                        verifyTrustedCallback.setVerified(isCertChainTrusted(trustStore, verifyTrustedCallback.getCertificateChain()));
+                    } else if (callback instanceof TrustedAuthoritiesCallback) {
+                        ((TrustedAuthoritiesCallback) callback).setTrustedAuthorities(trustedAuthorities);
+                    } else if (callback instanceof CredentialCallback) {
+                        final CredentialCallback credentialCallback = (CredentialCallback) callback;
+                        for (Class<?> allowedType : credentialCallback.getAllowedTypes()) {
+                            if (allowedType == X509Certificate[].class) {
+                                Certificate[] certChain;
+                                certChain = keyStore.getCertificateChain(keyStoreAlias);
+                                credentialCallback.setCredential(Arrays.copyOf(certChain, certChain.length, X509Certificate[].class));
+                                break;
+                            } else if (allowedType == PrivateKey.class) {
+                                credentialCallback.setCredential(keyStore.getKey(keyStoreAlias, keyStorePassword));
+                                break;
+                            }
+                        }
+                    } else {
+                        handled = false;
+                    }
+                    if (handled) {
+                        iterator.remove();
+                    }
+                } catch (GeneralSecurityException e) {
+                    SaslException ex = new SaslException(e.getLocalizedMessage());
+                    ex.initCause(e);
+                    throw ex;
+                }
+            }
+            if (!list.isEmpty()) {
+                cbh.handle(list.toArray(new Callback[list.size()]));
+            }
+        });
+    }
+
+
+}


### PR DESCRIPTION
@darranl @fjuma I have put the configurable parts into extra factories. Farah suggested putting the client part into AuthenticationConfiguration, but I wanted to get something working first. these extra callbacks appear to only happen for Entity, so I didn't want to pollute the core code. And it felt a bit strange using a server factory, while not having a corresponding client one.

Anyway, please let me know what I should change to fit more in with the philosophy of the project and I'll do it.

