### PR TITLE
LDAP OTP credential loading + persisting

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -343,6 +343,21 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1082, value = "Filesystem-backed realm encountered invalid OTP algorithm \"%s\" in path \"%s\" line %d for identity name \"%s\"")
     RealmUnavailableException fileSystemRealmInvalidOtpAlgorithm(String algorithm, Path path, int lineNumber, String name, @Cause Throwable cause);
 
+    @Message(id = 1083, value = "Ldap-backed realm cannot to obtain not existing identity \"%s\"")
+    RealmUnavailableException ldapRealmIdentityNotExists(String identity);
+
+    @Message(id = 1084, value = "Error while consuming results from search. SearchDn [%s], Filter [%s], Filter Args [%s].")
+    RuntimeException ldapRealmErrorWhileConsumingResultsFromSearch(String searchDn, String filter, String filterArgs, @Cause Throwable cause);
+
+    @Message(id = 1085, value = "No Ldap-backed realm's persister support credential of type \"%s\" and algorithm \"%s\"")
+    RealmUnavailableException ldapRealmsPersisterNotSupportCredentialTypeAndAlgorithm(String type, String algorithm);
+
+    @Message(id = 1086, value = "Persisting credential %s into Ldap-backed realm failed. Identity dn: \"%s\"")
+    RealmUnavailableException ldapRealmCredentialPersistingFailed(String credential, String dn, @Cause Throwable cause);
+
+    @Message(id = 1087, value = "Clearing credentials from Ldap-backed realm failed. Identity dn: \"%s\"")
+    RealmUnavailableException ldapRealmCredentialClearingFailed(String dn, @Cause Throwable cause);
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialPersister.java
@@ -1,0 +1,41 @@
+package org.wildfly.security.auth.provider.ldap;
+
+import org.wildfly.security.auth.server.CredentialSupport;
+
+/**
+ * Within LDAP credentials could be stored in different ways, splitting out a CredentialPersister allows different strategies to
+ * be plugged into the realm.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public interface CredentialPersister {
+
+    /**
+     * Determine whether a given credential is definitely supported, possibly supported (for some identities), or definitely not
+     * supported.
+     *
+     * A DirContextFactory is made available if the directory server is going to be queried but most likely this call will need
+     * to be generic as querying a whole directory is not realistic.
+     *
+     * Note: The DirContextFactory approach will be evolved further for better referral support so it makes it easier for it to
+     * be passed in for each call.
+     *
+     * @param contextFactory The dir context factory to use if a DirContext is required to query the server directly.
+     * @param credentialType the credential type
+     * @return the level of support for this credential type
+     */
+    CredentialSupport getCredentialSupport(DirContextFactory contextFactory, Class<?> credentialType);
+
+    /**
+     * Obtain an {@link IdentityCredentialLoader} to query the credentials for a specific identity.
+     *
+     * Note: By this point referrals relating to the identity should have been resolved so the {@link DirContextFactory} should
+     * be suitable for use with the supplied {@code distinguishedName}
+     *
+     * @param contextFactory the {@link DirContextFactory} to use to connect to LDAP.
+     * @param distinguishedName the distinguished name of the identity.
+     * @return An {@link IdentityCredentialLoader} for the specified identity identified by their distinguished name.
+     */
+    IdentityCredentialPersister forIdentity(DirContextFactory contextFactory, String distinguishedName);
+
+}

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialLoader.java
@@ -21,7 +21,7 @@ package org.wildfly.security.auth.provider.ldap;
 import org.wildfly.security.auth.server.CredentialSupport;
 
 /**
- * A {@link CredentialLoader} for loading credentials stored within the 'userPassword' attribute of LDAP entries.
+ * A {@link CredentialLoader} for loading credentials stored in LDAP directory.
  *
  * Implementations of this interface are instantiated for a specific identity, as a result all of the methods on this interface
  * are specific to that identity.

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialPersister.java
@@ -1,0 +1,34 @@
+package org.wildfly.security.auth.provider.ldap;
+
+import org.wildfly.security.auth.server.RealmUnavailableException;
+
+/**
+ * A {@link CredentialPersister} for persisting credentials into LDAP directory.
+ *
+ * Implementations of this interface are instantiated for a specific identity, as a result all of the methods on this
+ * interface are specific to that identity.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public interface IdentityCredentialPersister {
+
+    /**
+     * Determine whether a given credential is definitely supported, possibly supported, or definitely not supported.
+     *
+     * @param credential the credential to check
+     * @return {@code true} if persisting of given credential is supported
+     */
+    boolean getCredentialPersistSupport(Object credential);
+
+    /**
+     * Store credential of identity.
+     *
+     * @param credential the credential
+     */
+    void persistCredential(Object credential) throws RealmUnavailableException;
+
+    /**
+     * Clear all supported credentials of identity.
+     */
+    void clearCredentials() throws RealmUnavailableException;
+}

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
@@ -77,6 +77,10 @@ class LdapSecurityRealm implements SecurityRealm {
         this.nameRewriter = nameRewriter;
         this.principalMapping = principalMapping;
         this.credentialLoaders.add(new UserPasswordCredentialLoader(this.principalMapping.passwordAttribute));
+        if (this.principalMapping.otpAlgorithmAttribute != null) {
+            this.credentialLoaders.add(new OtpCredentialLoader(this.principalMapping.otpAlgorithmAttribute, this.principalMapping.otpHashAttribute,
+                    this.principalMapping.otpSeedAttribute, this.principalMapping.otpSequenceAttribute));
+        }
     }
 
     @Override
@@ -545,11 +549,17 @@ class LdapSecurityRealm implements SecurityRealm {
         private final boolean searchRecursive;
         private final String rdnIdentifier;
         private final String passwordAttribute;
+        private final String otpAlgorithmAttribute;
+        private final String otpHashAttribute;
+        private final String otpSeedAttribute;
+        private final String otpSequenceAttribute;
         private final List<PrincipalMappingBuilder.Attribute> attributes;
         public final int searchTimeLimit;
 
         public PrincipalMapping(String searchDn, boolean searchRecursive, int searchTimeLimit, String rdnIdentifier,
-                                String passwordAttribute, List<PrincipalMappingBuilder.Attribute> attributes) {
+                                String passwordAttribute, String otpAlgorithmAttribute, String otpHashAttribute,
+                                String otpSeedAttribute, String otpSequenceAttribute,
+                                List<PrincipalMappingBuilder.Attribute> attributes) {
             Assert.checkNotNullParam("rdnIdentifier", rdnIdentifier);
             Assert.checkNotNullParam("passwordAttribute", passwordAttribute);
             this.searchDn = searchDn;
@@ -557,6 +567,10 @@ class LdapSecurityRealm implements SecurityRealm {
             this.searchTimeLimit = searchTimeLimit;
             this.rdnIdentifier = rdnIdentifier;
             this.passwordAttribute = passwordAttribute;
+            this.otpAlgorithmAttribute = otpAlgorithmAttribute;
+            this.otpHashAttribute = otpHashAttribute;
+            this.otpSeedAttribute = otpSeedAttribute;
+            this.otpSequenceAttribute = otpSequenceAttribute;
             this.attributes = attributes;
         }
     }

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
@@ -22,10 +22,10 @@ import org.wildfly.common.Assert;
 import org.wildfly.security._private.ElytronMessages;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder.PrincipalMappingBuilder;
 import org.wildfly.security.auth.server.CredentialSupport;
+import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.NameRewriter;
-import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
-import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.authz.MapAttributes;
 import org.wildfly.security.password.Password;
@@ -43,8 +43,10 @@ import javax.naming.ldap.Rdn;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
+import java.security.Key;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,33 +66,46 @@ import static org.wildfly.security._private.ElytronMessages.log;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class LdapSecurityRealm implements SecurityRealm {
+class LdapSecurityRealm implements ModifiableSecurityRealm {
 
     private final DirContextFactory dirContextFactory;
     private final NameRewriter nameRewriter;
     private final PrincipalMapping principalMapping;
     private final List<CredentialLoader> credentialLoaders = new ArrayList<>();
+    private final List<CredentialPersister> credentialPersisters = new ArrayList<>();
 
     LdapSecurityRealm(final DirContextFactory dirContextFactory, final NameRewriter nameRewriter,
                       final PrincipalMapping principalMapping) {
+
         this.dirContextFactory = dirContextFactory;
         this.nameRewriter = nameRewriter;
         this.principalMapping = principalMapping;
         this.credentialLoaders.add(new UserPasswordCredentialLoader(this.principalMapping.passwordAttribute));
+
         if (this.principalMapping.otpAlgorithmAttribute != null) {
-            this.credentialLoaders.add(new OtpCredentialLoader(this.principalMapping.otpAlgorithmAttribute, this.principalMapping.otpHashAttribute,
-                    this.principalMapping.otpSeedAttribute, this.principalMapping.otpSequenceAttribute));
+            OtpCredentialLoader otpCredentialLoader = new OtpCredentialLoader(
+                    this.principalMapping.otpAlgorithmAttribute,
+                    this.principalMapping.otpHashAttribute,
+                    this.principalMapping.otpSeedAttribute,
+                    this.principalMapping.otpSequenceAttribute
+            );
+            this.credentialLoaders.add(otpCredentialLoader);
+            this.credentialPersisters.add(otpCredentialLoader);
         }
     }
 
     @Override
-    public RealmIdentity createRealmIdentity(String name) {
+    public ModifiableRealmIdentity createRealmIdentity(String name) {
         name = nameRewriter.rewriteName(name);
         if (name == null) {
             throw log.invalidName();
         }
 
         return new LdapRealmIdentity(name);
+    }
+
+    @Override public Iterator<ModifiableRealmIdentity> getRealmIdentityIterator() throws RealmUnavailableException {
+        return null;
     }
 
     @Override
@@ -101,8 +116,8 @@ class LdapSecurityRealm implements SecurityRealm {
             return response;
         }
 
-        for (CredentialLoader current : credentialLoaders) {
-            CredentialSupport support = current.getCredentialSupport(dirContextFactory, credentialType);
+        for (CredentialLoader loader : credentialLoaders) {
+            CredentialSupport support = loader.getCredentialSupport(dirContextFactory, credentialType);
             if (support.isDefinitelyObtainable()) {
                 // One claiming it is definitely supported is enough!
                 return support;
@@ -115,7 +130,7 @@ class LdapSecurityRealm implements SecurityRealm {
         return response;
     }
 
-    private class LdapRealmIdentity implements RealmIdentity {
+    private class LdapRealmIdentity implements ModifiableRealmIdentity {
 
         private final String name;
         private LdapIdentity identity;
@@ -142,9 +157,9 @@ class LdapSecurityRealm implements SecurityRealm {
 
             CredentialSupport support = null;
 
-            for (CredentialLoader current : credentialLoaders) {
-                if (current.getCredentialSupport(dirContextFactory, credentialType).mayBeObtainable()) {
-                    IdentityCredentialLoader icl = current.forIdentity(dirContextFactory, identity.getDistinguishedName());
+            for (CredentialLoader loader : credentialLoaders) {
+                if (loader.getCredentialSupport(dirContextFactory, credentialType).mayBeObtainable()) {
+                    IdentityCredentialLoader icl = loader.forIdentity(dirContextFactory, identity.getDistinguishedName());
 
                     CredentialSupport temp = icl.getCredentialSupport(credentialType);
                     if (temp != null && temp.isDefinitelyObtainable()) {
@@ -176,9 +191,9 @@ class LdapSecurityRealm implements SecurityRealm {
                 return null;
             }
 
-            for (CredentialLoader current : credentialLoaders) {
-                if (current.getCredentialSupport(dirContextFactory, credentialType).mayBeObtainable()) {
-                    IdentityCredentialLoader icl = current.forIdentity(dirContextFactory, this.identity.getDistinguishedName());
+            for (CredentialLoader loader : credentialLoaders) {
+                if (loader.getCredentialSupport(dirContextFactory, credentialType).mayBeObtainable()) {
+                    IdentityCredentialLoader icl = loader.forIdentity(dirContextFactory, this.identity.getDistinguishedName());
 
                     C credential = icl.getCredential(credentialType);
                     if (credential != null) {
@@ -188,6 +203,48 @@ class LdapSecurityRealm implements SecurityRealm {
             }
 
             return null;
+        }
+
+        private boolean persistCredential(Object credential) throws RealmUnavailableException {
+            for (CredentialPersister persister : credentialPersisters) {
+                IdentityCredentialPersister icp = persister.forIdentity(dirContextFactory, this.identity.getDistinguishedName());
+                if (icp.getCredentialPersistSupport(credential)) {
+                    icp.persistCredential(credential);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void setCredential(Object credential) throws RealmUnavailableException {
+            if (!exists()) {
+                throw log.ldapRealmIdentityNotExists(name);
+            }
+
+            if ( ! persistCredential(credential)) {
+                String algorithm = credential instanceof Key ? ((Key) credential).getAlgorithm() : null;
+                throw log.ldapRealmsPersisterNotSupportCredentialTypeAndAlgorithm(credential.getClass().getName(), algorithm);
+            }
+        }
+
+        @Override
+        public void setCredentials(List<Object> credentials) throws RealmUnavailableException {
+            if (!exists()) {
+                throw log.ldapRealmIdentityNotExists(name);
+            }
+
+            for (CredentialPersister persister : credentialPersisters) {
+                IdentityCredentialPersister icp = persister.forIdentity(dirContextFactory, this.identity.getDistinguishedName());
+                icp.clearCredentials();
+            }
+
+            for (Object credential : credentials) {
+                if ( ! persistCredential(credential)) {
+                    String algorithm = credential instanceof Key ? ((Key) credential).getAlgorithm() : null;
+                    throw log.ldapRealmsPersisterNotSupportCredentialTypeAndAlgorithm(credential.getClass().getName(), algorithm);
+                }
+            }
         }
 
         @Override
@@ -470,6 +527,18 @@ class LdapSecurityRealm implements SecurityRealm {
                     }));
         }
 
+        @Override public void delete() throws RealmUnavailableException {
+            throw Assert.unsupported();
+        }
+
+        @Override public void create() throws RealmUnavailableException {
+            throw Assert.unsupported();
+        }
+
+        @Override public void setAttributes(org.wildfly.security.authz.Attributes attributes) throws RealmUnavailableException {
+            throw Assert.unsupported();
+        }
+
         private class LdapIdentity {
 
             private final String distinguishedName;
@@ -521,7 +590,7 @@ class LdapSecurityRealm implements SecurityRealm {
 
                                 return true;
                             } catch (NamingException e) {
-                                throw new RuntimeException("Error while consuming results from search. SearchDn [" + searchDn + "], Filter [" + filter + "], Filter Args [" + filterArgs + "].", e);
+                                throw log.ldapRealmErrorWhileConsumingResultsFromSearch(searchDn, filter, filterArgs.toString(), e);
                             }
                         }
                     }, false).onClose(() -> {

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
@@ -126,6 +126,10 @@ public class LdapSecurityRealmBuilder {
         private boolean searchRecursive = false;
         private String nameAttribute;
         private String passwordAttribute = UserPasswordCredentialLoader.DEFAULT_USER_PASSWORD_ATTRIBUTE_NAME;
+        private String otpAlgorithmAttribute = null;
+        private String otpHashAttribute = null;
+        private String otpSeedAttribute = null;
+        private String otpSequenceAttribute = null;
         private int searchTimeLimit = 10000;
         private List<Attribute> attributes = new ArrayList<>();
 
@@ -196,6 +200,14 @@ public class LdapSecurityRealmBuilder {
             return this;
         }
 
+        public PrincipalMappingBuilder setOtpAttributes(String otpAlgorithmAttribute, String otpHashAttribute, String otpSeedAttribute, String otpSequenceAttribute) {
+            this.otpAlgorithmAttribute = otpAlgorithmAttribute;
+            this.otpHashAttribute = otpHashAttribute;
+            this.otpSeedAttribute = otpSeedAttribute;
+            this.otpSequenceAttribute = otpSequenceAttribute;
+            return this;
+        }
+
         /**
          * Define an attribute mapping configuration.
          *
@@ -214,7 +226,8 @@ public class LdapSecurityRealmBuilder {
          */
         public LdapSecurityRealm.PrincipalMapping build() {
             return new LdapSecurityRealm.PrincipalMapping(
-                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, this.passwordAttribute, this.attributes);
+                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, passwordAttribute, otpAlgorithmAttribute,
+                    otpHashAttribute, otpSeedAttribute, otpSequenceAttribute, attributes);
         }
 
         public static class Attribute {

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/OtpCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/OtpCredentialLoader.java
@@ -1,0 +1,110 @@
+package org.wildfly.security.auth.provider.ldap;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.auth.server.CredentialSupport;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.OneTimePassword;
+import org.wildfly.security.password.spec.OneTimePasswordSpec;
+import org.wildfly.security.util.Alphabet;
+import org.wildfly.security.util.CodePointIterator;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * A {@link CredentialLoader} for loading OTP credentials stored within defined attributes of LDAP entries.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class OtpCredentialLoader implements CredentialLoader {
+
+    private final String algorithmAttributeName;
+    private final String hashAttributeName;
+    private final String seedAttributeName;
+    private final String sequenceAttributeName;
+
+    public OtpCredentialLoader(String algorithmAttributeName, String hashAttributeName, String seedAttributeName, String sequenceAttributeName) {
+        Assert.assertNotNull(algorithmAttributeName);
+        Assert.assertNotNull(hashAttributeName);
+        Assert.assertNotNull(seedAttributeName);
+        Assert.assertNotNull(sequenceAttributeName);
+        this.algorithmAttributeName = algorithmAttributeName;
+        this.hashAttributeName = hashAttributeName;
+        this.seedAttributeName = seedAttributeName;
+        this.sequenceAttributeName = sequenceAttributeName;
+    }
+
+    @Override public CredentialSupport getCredentialSupport(DirContextFactory contextFactory, Class<?> credentialType) {
+        return credentialType == OneTimePassword.class ? CredentialSupport.UNKNOWN : CredentialSupport.UNSUPPORTED;
+    }
+
+    @Override
+    public IdentityCredentialLoader forIdentity(DirContextFactory contextFactory, String distinguishedName) {
+        return new ForIdentityLoader(contextFactory, distinguishedName);
+    }
+
+    private class ForIdentityLoader implements IdentityCredentialLoader {
+
+        private final DirContextFactory contextFactory;
+        private final String distinguishedName;
+
+        public ForIdentityLoader(DirContextFactory contextFactory, String distinguishedName) {
+            this.contextFactory = contextFactory;
+            this.distinguishedName = distinguishedName;
+        }
+
+        @Override
+        public CredentialSupport getCredentialSupport(Class<?> credentialType) {
+            Object credential = getCredential(credentialType);
+            // By this point it is either supported or it isn't - no in-between.
+            if (credential != null && credentialType.isInstance(credential)) {
+                return CredentialSupport.FULLY_SUPPORTED;
+            }
+
+            return CredentialSupport.UNSUPPORTED;
+        }
+
+        @Override
+        public <C> C getCredential(Class<C> credentialType) {
+            DirContext context = null;
+            try {
+                context = contextFactory.obtainDirContext(null);
+
+                Attributes attributes = context.getAttributes(distinguishedName,
+                        new String[] { algorithmAttributeName, hashAttributeName, seedAttributeName, sequenceAttributeName });
+                Attribute algorithmAttribute = attributes.get(algorithmAttributeName);
+                Attribute hashAttribute = attributes.get(hashAttributeName);
+                Attribute seedAttribute = attributes.get(seedAttributeName);
+                Attribute sequenceAttribute = attributes.get(sequenceAttributeName);
+
+                if (algorithmAttribute == null || hashAttribute == null || seedAttribute == null || sequenceAttribute == null) {
+                    return null;
+                }
+
+                PasswordFactory passwordFactory = PasswordFactory.getInstance(((String) algorithmAttribute.get()));
+                Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(
+                                CodePointIterator.ofString((String) hashAttribute.get())
+                                        .base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(),
+                                CodePointIterator.ofString((String) seedAttribute.get())
+                                        .base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(),
+                                Integer.valueOf((String) sequenceAttribute.get())));
+                if (credentialType.isInstance(password)) {
+                    return credentialType.cast(password);
+                }
+
+            } catch (NamingException | InvalidKeySpecException | NoSuchAlgorithmException e) {
+                if (ElytronMessages.log.isTraceEnabled()) ElytronMessages.log.trace("Getting OTP credential of type "
+                        + credentialType.getName() + " failed. dn=" + distinguishedName, e);
+            } finally {
+                contextFactory.returnContext(context);
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.auth.provider.ldap;
 
+import static org.wildfly.security._private.ElytronMessages.*;
 import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.parseUserPassword;
 
 import java.security.spec.InvalidKeySpecException;
@@ -116,12 +117,13 @@ class UserPasswordCredentialLoader implements CredentialLoader {
                     }
                 }
 
-                return null;
             } catch (NamingException | InvalidKeySpecException e) {
-                return null;
+                if (log.isTraceEnabled()) log.trace("Getting user-password credential of type "
+                        + credentialType.getName() + " failed. dn=" + distinguishedName, e);
             } finally {
                 contextFactory.returnContext(context);
             }
+            return null;
         }
     }
 

--- a/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
@@ -271,11 +271,11 @@ public class FileSystemSecurityRealmTest {
         assertTrue(existingIdentity.verifyCredential("secretPassword".toCharArray()));
 
         OneTimePassword otp = existingIdentity.getCredential(OneTimePassword.class, OneTimePassword.ALGORITHM_OTP_SHA1);
+        assertNotNull(otp);
         assertEquals(OneTimePassword.ALGORITHM_OTP_SHA1, otp.getAlgorithm());
         assertArrayEquals(hash, otp.getHash());
         assertArrayEquals(seed, otp.getSeed());
         assertEquals(500, otp.getSequenceNumber());
-        assertNotNull(otp);
 
         AuthorizationIdentity authorizationIdentity = existingIdentity.getAuthorizationIdentity();
         Attributes existingAttributes = authorizationIdentity.getAttributes();

--- a/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
+++ b/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
@@ -47,7 +47,7 @@ public class DirContextFactoryRule implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 Security.addProvider(provider);
-                LdapService embeddedServer = starEmbeddedServer();
+                LdapService embeddedServer = startEmbeddedServer();
 
                 try {
                     current.evaluate();
@@ -76,7 +76,7 @@ public class DirContextFactoryRule implements TestRule {
                 .build();
     }
 
-    private LdapService starEmbeddedServer() {
+    private LdapService startEmbeddedServer() {
         try {
             return LdapService.builder()
                     .setWorkingDir(new File("./target/apache-ds/working"))
@@ -87,6 +87,7 @@ public class DirContextFactoryRule implements TestRule {
                     .importLdif(PasswordSupportTest.class.getResourceAsStream("/ldap/elytron-attribute-tests.ldif"))
                     .importLdif(PasswordSupportTest.class.getResourceAsStream("/ldap/elytron-role-mapping-tests.ldif"))
                     .importLdif(PasswordSupportTest.class.getResourceAsStream("/ldap/elytron-group-mapping-tests.ldif"))
+                    .importLdif(PasswordSupportTest.class.getResourceAsStream("/ldap/elytron-otp-tests.ldif"))
                     .addTcpServer("Default TCP", "localhost", LDAP_PORT)
                     .start();
         } catch (Exception e) {

--- a/src/test/resources/ldap/elytron-otp-tests.ldif
+++ b/src/test/resources/ldap/elytron-otp-tests.ldif
@@ -1,0 +1,69 @@
+version: 1
+
+# schema for OTP (OIDs are for testing only - should be replaced before production usage)
+dn: m-oid=1.3.6.1.4.1.26782.2.3.1, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.26782.2.3.1
+m-name: otpAlgorithm
+m-description: OTP algorithm ("otp-sha1" for example)
+m-equality: caseIgnoreMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.15
+
+dn: m-oid=1.3.6.1.4.1.26782.2.3.4.1, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.1466.115.121.1.6
+m-name: otpHash
+m-description: OTP previous hash
+m-equality: octetStringMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.40
+
+dn: m-oid=1.3.6.1.4.1.26782.2.2.3.3, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.26782.2.2.3.3
+m-name: otpSeed
+m-description: OTP seed
+m-equality: octetStringMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.40
+
+dn: m-oid=1.3.6.1.4.1.26782.2.2.3.99, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.26782.2.2.3.99
+m-name: otpSequence
+m-description: OTP sequence counter
+m-equality: integerMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+
+dn: m-oid=1.3.6.1.4.1.26782.2.4.1, ou=objectclasses, cn=wildfly, ou=schema
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.26782.2.4.1
+m-name: otpToken
+m-typeObjectClass: AUXILIARY
+m-may: otpAlgorithm
+m-may: otpHash
+m-may: otpSeed
+m-may: otpSequence
+
+# testing users
+dn: uid=userWithOtp,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+objectClass: otpToken
+cn: My First Name
+sn: My Last Name
+uid: userWithOtp
+otpAlgorithm: otp-sha1
+otpHash: YWJjZA==
+otpSeed: ZWZnaA==
+otpSequence: 1234


### PR DESCRIPTION
OTP credential loading from ldap (OtpCredentialLoader).

* Parts of OTP credential (hash, seed, iterations count) stored in standalone attributes.
* Binary attributes are stored in base64.

Used my testing ldap schema, because only schema I found similar to what we need is http://code.google.com/p/otpd/source/browse/trunk/userops/otp.schema?r=51 where would have to be same attribute names used in little different meaning (hash => key, seed => serial, algorithm => vendor) - I think using custom schema is better in such case.

Writing credentials back to LDAP is not implemented yet - do you have same comments about current way of storing otp credential before I start implement it?