### PR TITLE
[ELY-269] - Wrong message when using a String to verify credentials.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -226,8 +226,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1046, value = "Unknown password type or algorithm \"%s\"")
     InvalidKeyException unknownPasswordTypeOrAlgorithm(String algorithm);
 
-    @Message(id = 1047, value = "Password-based credentials must be either a String, char[] or ClearPassword")
-    RuntimeException passwordBasedCredentialsMustBeStringCharsOrClearPassword();
+    @Message(id = 1047, value = "Password-based credentials must be either a char[] or ClearPassword")
+    RuntimeException passwordBasedCredentialsMustBeCharsOrClearPassword();
 
     @Message(id = 1048, value = "Invalid password key for algorithm \"%s\"")
     RuntimeException invalidPasswordKeyForAlgorithm(String algorithm, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/JdbcSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/JdbcSecurityRealm.java
@@ -202,7 +202,7 @@ public class JdbcSecurityRealm implements SecurityRealm {
                     } else if (ClearPassword.class.isInstance(givenCredential)) {
                         guessCredentialChars = ((ClearPassword) givenCredential).getPassword();
                     } else {
-                        throw log.passwordBasedCredentialsMustBeStringCharsOrClearPassword();
+                        throw log.passwordBasedCredentialsMustBeCharsOrClearPassword();
                     }
 
                     return passwordFactory.verify((Password) credential, guessCredentialChars);

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
@@ -204,13 +204,11 @@ class LdapSecurityRealm implements SecurityRealm {
 
             if (char[].class.isInstance(credential)) {
                 password = (char[]) credential;
-            } else if (String.class.isInstance(credential)) {
-                password = credential.toString().toCharArray();
             } else if (ClearPassword.class.isInstance(credential)) {
                 ClearPassword clearPassword = (ClearPassword) credential;
                 password = clearPassword.getPassword();
             } else {
-                throw log.passwordBasedCredentialsMustBeStringCharsOrClearPassword();
+                throw log.passwordBasedCredentialsMustBeCharsOrClearPassword();
             }
 
             DirContext dirContext = null;

--- a/src/test/java/org/wildfly/security/ldap/PasswordValidationTest.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordValidationTest.java
@@ -76,22 +76,6 @@ public class PasswordValidationTest {
     }
 
     @Test
-    public void testVerifyStringPassword() throws Exception {
-        SecurityRealm securityRealm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(dirContextFactoryRule.create())
-                .setPrincipalMapping(LdapSecurityRealmBuilder.PrincipalMappingBuilder.builder()
-                                .setSearchDn("dc=elytron,dc=wildfly,dc=org")
-                                .setRdnIdentifier("uid")
-                                .build()
-                )
-                .build();
-
-        RealmIdentity realmIdentity = securityRealm.createRealmIdentity("uid=plainUser,dc=elytron,dc=wildfly,dc=org");
-
-        assertTrue(realmIdentity.verifyCredential("plainPassword"));
-    }
-
-    @Test
     public void testVerifyCharArrayPassword() throws Exception {
         SecurityRealm securityRealm = LdapSecurityRealmBuilder.builder()
                 .setDirContextFactory(dirContextFactoryRule.create())


### PR DESCRIPTION
### References

* https://issues.jboss.org/browse/ELY-269

### Overview

Accordingly with previous discussions, we should avoid using String values when verifying credentials.
Beside that, when using the JDBC and LDAP realms, the message is wrong, indicating that String values are also supported.