### PR TITLE
setCredential into ModifiableRealm and FileSystemSecurityRealm

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -378,6 +379,35 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                     // nothing we can do
                 }
                 return;
+            }
+        }
+
+        public void setCredential(final Object credential) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credential", credential);
+            final LoadedIdentity loadedIdentity = loadIdentity(false, false);
+            if (loadedIdentity == null) {
+                throw ElytronMessages.log.fileSystemRealmNotFound(name);
+            }
+            List<Object> credentials = loadedIdentity.getCredentials();
+            removeCredentialOfTheSameType(credentials, credential);
+            credentials.add(credential);
+
+            final LoadedIdentity newIdentity = new LoadedIdentity(getName(), credentials, loadedIdentity.getAttributes());
+            replaceIdentity(newIdentity);
+        }
+
+        private void removeCredentialOfTheSameType(List<Object> credentials, Object pattern) {
+            for (Iterator iterator = credentials.iterator(); iterator.hasNext();) {
+                Object credential = iterator.next();
+                if (credential instanceof Key && pattern instanceof Key) { // keys comparison
+                    if (((Key)credential).getAlgorithm().equals(((Key)pattern).getAlgorithm())) {
+                        iterator.remove();
+                    }
+                } else { // non-keys comparison
+                    if(credential.getClass() == pattern.getClass()) {
+                        iterator.remove();
+                    }
+                }
             }
         }
 

--- a/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
@@ -46,12 +46,21 @@ public interface ModifiableRealmIdentity extends RealmIdentity {
     void create() throws RealmUnavailableException;
 
     /**
-     * Modify the credentials of this identity.  If the identity does not exist, an exception is thrown.
+     * Replace list of credentials of this identity.  If the identity does not exist, an exception is thrown.
      *
-     * @param credentials the new credentials
+     * @param credentials the new list of credentials
      * @throws RealmUnavailableException if updating the credentials fails for some reason
      */
     void setCredentials(List<Object> credentials) throws RealmUnavailableException;
+
+    /**
+     * Add new credential of this identity.  If the identity does not exist, an exception is thrown.
+     * If credential of the same type of the same identity already exist, it is replaced.
+     *
+     * @param credential the new credential
+     * @throws RealmUnavailableException if updating the credentials fails for some reason
+     */
+    void setCredential(Object credential) throws RealmUnavailableException;
 
     /**
      * Modify the attributes collection of this identity.  If the identity does not exist, an exception is thrown.


### PR DESCRIPTION
Modified interface `ModifiableRealm` to allow change one of credentials and implemented into `FileSystemSecurityRealm`.

`setCredential(Object)` replace credential of the same type (and algorithm in case of Password/Key). If identity has not such credential yet, it is added.

Required for Kabirs implementation of OTP auth which need update `OneTimePassword` on every login. (And later for password change and similar.)