### PR TITLE
[ELY-283] Add possibility to use keytab in GSS API tests

### DIFF
--- a/src/test/java/org/wildfly/security/sasl/gs2/Gs2Test.java
+++ b/src/test/java/org/wildfly/security/sasl/gs2/Gs2Test.java
@@ -57,6 +57,7 @@ import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.Oid;
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -88,14 +89,20 @@ public class Gs2Test extends BaseTestCase {
     private static Subject serverSubject;
     private SaslServer saslServer;
     private SaslClient saslClient;
+    static String serverKeyTab;
+    static final String SERVER_KEY_TAB = "gs2ServerKeyTab";
+    private static Logger log = Logger.getLogger(Gs2Test.class);
 
     @BeforeClass
     public static void init() throws LoginException {
         testKdc = new TestKDC();
         testKdc.startDirectoryService();
         testKdc.startKDC();
+        serverKeyTab = testKdc.generateKeyTab(SERVER_KEY_TAB, "sasl/test_server_1@WILDFLY.ORG", "servicepwd");
+        log.debug("keytab written to:" + serverKeyTab);
+
         clientSubject = loginClient();
-        serverSubject = loginServer();
+        serverSubject = loginServer(serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/BaseGssapiTests.java
@@ -71,6 +71,8 @@ public abstract class BaseGssapiTests extends BaseTestCase {
     private static final String QOP_AUTH_INT = "auth-int";
     private static final String QOP_AUTH_CONF = "auth-conf";
 
+    static final String SERVER_KEY_TAB = "serverKeyTab";
+
     /*
      * A pair of tests just to verify that a Subject can be obtained, in the event of a failure if these tests are failing focus
      * here first.
@@ -78,7 +80,7 @@ public abstract class BaseGssapiTests extends BaseTestCase {
 
     @Test
     public void obtainServer1Subject() throws Exception {
-        Subject subject = loginServer();
+        Subject subject = loginServer(GssapiTestSuite.serverKeyTab);
         assertNotNull(subject);
     }
 

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiTestSuite.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiTestSuite.java
@@ -41,6 +41,7 @@ public class GssapiTestSuite {
     private static Logger log = Logger.getLogger(GssapiTestSuite.class);
 
     static TestKDC testKdc;
+    static String serverKeyTab;
 
     @BeforeClass
     public static void startServers() {
@@ -50,6 +51,8 @@ public class GssapiTestSuite {
         testKdc.startDirectoryService();
         testKdc.startKDC();
         GssapiTestSuite.testKdc = testKdc;
+        serverKeyTab = testKdc.generateKeyTab(BaseGssapiTests.SERVER_KEY_TAB, "sasl/test_server_1@WILDFLY.ORG", "servicepwd");
+        log.debug("keytab written to:" + serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientJdkServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientJdkServer.java
@@ -45,7 +45,7 @@ public class JdkClientJdkServer extends BaseGssapiTests {
     @BeforeClass
     public static void initialise() throws LoginException {
         clientSubject = loginClient();
-        serverSubject = loginServer();
+        serverSubject = loginServer(GssapiTestSuite.serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientWildFlyServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/JdkClientWildFlyServer.java
@@ -47,7 +47,7 @@ public class JdkClientWildFlyServer extends BaseGssapiTests {
     @BeforeClass
     public static void initialise() throws LoginException {
         clientSubject = loginClient();
-        serverSubject = loginServer();
+        serverSubject = loginServer(GssapiTestSuite.serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientJdkServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientJdkServer.java
@@ -47,7 +47,7 @@ public class WildFlyClientJdkServer extends BaseGssapiTests {
     @BeforeClass
     public static void initialise() throws LoginException {
         clientSubject = loginClient();
-        serverSubject = loginServer();
+        serverSubject = loginServer(GssapiTestSuite.serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientWildFlyServer.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/WildFlyClientWildFlyServer.java
@@ -44,7 +44,7 @@ public class WildFlyClientWildFlyServer extends BaseGssapiTests {
     @BeforeClass
     public static void initialise() throws LoginException {
         clientSubject = loginClient();
-        serverSubject = loginServer();
+        serverSubject = loginServer(GssapiTestSuite.serverKeyTab);
     }
 
     @AfterClass

--- a/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/compatibility/AbstractTest.java
@@ -46,6 +46,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
 
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -76,8 +77,11 @@ public abstract class AbstractTest {
     protected byte[] message;
     protected byte[] wrappedMessage;
     protected byte[] badMessage;
+    static String serverKeyTab;
+    static final String SERVER_KEY_TAB = "compatServerKeyTab";
 
     private static final Provider wildFlyElytronProvider = new WildFlyElytronProvider();
+    private static Logger log = Logger.getLogger(AbstractTest.class);
 
     @BeforeClass
     public static void registerProvider() {
@@ -111,9 +115,11 @@ public abstract class AbstractTest {
         testKdc = new TestKDC();
         testKdc.startDirectoryService();
         testKdc.startKDC();
+        serverKeyTab = testKdc.generateKeyTab(SERVER_KEY_TAB, "sasl/test_server_1@WILDFLY.ORG", "servicepwd");
+        log.debug("keytab written to:" + serverKeyTab);
 
         clientSubject = JaasUtil.loginClient();
-        serverSubject = JaasUtil.loginServer();
+        serverSubject = JaasUtil.loginServer(serverKeyTab);
 
     }
 

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -21,7 +21,7 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=org.apache.directory,net.sf.ehcache,org.apache.directory.api.ldap,javax.security.sasl
+loggers=org.apache.directory,net.sf.ehcache,org.apache.directory.api.ldap,javax.security.sasl,org.wildfly.security.sasl
 
 # Root logger configuration
 logger.level=${test.level:TRACE}
@@ -30,6 +30,7 @@ logger.org.apache.directory.api.ldap.level=OFF
 logger.net.sf.ehcache.level=INFO
 logger.javax.security.sasl.level=DEBUG
 logger.org.wildfly.sasl.test=DEBUG
+logger.org.wildfly.security.sasl.level=INFO
 logger.handlers=CONSOLE
 
 # Console handler configuration


### PR DESCRIPTION
This PR changes only tests. I have configured GssapiServer to use keyTab to get initial credential of the server. It contains also keyTab generation when KDC starts.
To get credentials for server from keyTab is usual use case.