### PR TITLE
[ELY-282][API-change] type+algorithm replaced by credentialName

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -249,7 +249,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1050, value = "Could not execute query \"%s\"")
     RuntimeException couldNotExecuteQuery(String sql, @Cause Throwable cause);
 
-    // 1051
+    @Message(id = 1051, value = "Could not resolve password algorithm for credential name \"%s\"")
+    InvalidKeyException couldNotResolveAlgorithmByCredentialName(String credentialName);
 
     @Message(id = 1052, value = "Unexpected error when processing authentication query \"%s\"")
     RuntimeException unexpectedErrorWhenProcessingAuthenticationQuery(String sql, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -359,8 +359,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1084, value = "Error while consuming results from search. SearchDn [%s], Filter [%s], Filter Args [%s].")
     RuntimeException ldapRealmErrorWhileConsumingResultsFromSearch(String searchDn, String filter, String filterArgs, @Cause Throwable cause);
 
-    @Message(id = 1085, value = "No Ldap-backed realm's persister support credential of type \"%s\" and algorithm \"%s\"")
-    RealmUnavailableException ldapRealmsPersisterNotSupportCredentialTypeAndAlgorithm(String type, String algorithm);
+    @Message(id = 1085, value = "No Ldap-backed realm's persister support credential name \"%s\"")
+    RealmUnavailableException ldapRealmsPersisterNotSupportCredentialName(String credentialName);
 
     @Message(id = 1086, value = "Persisting credential %s into Ldap-backed realm failed. Identity dn: \"%s\"")
     RealmUnavailableException ldapRealmCredentialPersistingFailed(String credential, String dn, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/auth/provider/AggregateSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/AggregateSecurityRealm.java
@@ -63,8 +63,8 @@ public final class AggregateSecurityRealm implements SecurityRealm {
         }
     }
 
-    public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
-        return authenticationRealm.getCredentialSupport(credentialType, algorithmName);
+    public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
+        return authenticationRealm.getCredentialSupport(credentialName);
     }
 
     static final class Identity implements RealmIdentity {
@@ -77,16 +77,16 @@ public final class AggregateSecurityRealm implements SecurityRealm {
             this.authorizationIdentity = authorizationIdentity;
         }
 
-        public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
-            return authenticationIdentity.getCredentialSupport(credentialType, null);
+        public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
+            return authenticationIdentity.getCredentialSupport(credentialName);
         }
 
-        public <C> C getCredential(final Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
-            return authenticationIdentity.getCredential(credentialType, algorithmName);
+        public <C> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+            return authenticationIdentity.getCredential(credentialName, credentialType);
         }
 
-        public boolean verifyCredential(final Object credential) throws RealmUnavailableException {
-            return authenticationIdentity.verifyCredential(credential);
+        public boolean verifyCredential(final String credentialName, final Object credential) throws RealmUnavailableException {
+            return authenticationIdentity.verifyCredential(credentialName, credential);
         }
 
         public boolean exists() throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
@@ -394,6 +394,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             }
 
             Map<String, Object> credentials = loadedIdentity.getCredentials();
+            if ( ! (credentials instanceof HashMap)) credentials = new HashMap<>(credentials);
             credentials.put(credentialName, credential);
 
             final LoadedIdentity newIdentity = new LoadedIdentity(name, credentials, loadedIdentity.getAttributes());

--- a/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
@@ -32,10 +32,8 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -44,10 +42,10 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -218,13 +216,13 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
         }
     }
 
-    public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
+    public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
         return CredentialSupport.UNKNOWN;
     }
 
     @FunctionalInterface
-    interface CredentialParseFunction<C> {
-        C parseCredential(String algorithm, String format, String body) throws RealmUnavailableException, XMLStreamException;
+    interface CredentialParseFunction {
+        void parseCredential(String name, String algorithm, String format, String body) throws RealmUnavailableException, XMLStreamException;
     }
 
     class Identity implements ModifiableRealmIdentity {
@@ -240,30 +238,28 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             this.path = path;
         }
 
-        public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
-            List<Object> credentials = loadCredentials();
-            for (Object credential : credentials) {
-                if (credentialType.isInstance(credential)) {
-                    return CredentialSupport.FULLY_SUPPORTED;
-                }
-            }
-            return CredentialSupport.UNSUPPORTED;
+        public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialName", credentialName);
+            Map<String, Object> credentials = loadCredentials();
+            return credentials.containsKey(credentialName) ? CredentialSupport.FULLY_SUPPORTED : CredentialSupport.UNSUPPORTED;
         }
 
-        public <C> C getCredential(final Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
-            List<Object> credentials = loadCredentials();
-            for (Object credential : credentials) {
-                if (credentialType.isInstance(credential)) {
-                    return credentialType.cast(credential);
-                }
+        public <C> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialName", credentialName);
+            Assert.checkNotNullParam("credentialType", credentialType);
+            Map<String, Object> credentials = loadCredentials();
+            Object credential = credentials.get(credentialName);
+            if (credentialType.isInstance(credential)) {
+                return credentialType.cast(credential);
             }
             return null;
         }
 
-        public boolean verifyCredential(final Object credential) throws RealmUnavailableException {
+        public boolean verifyCredential(final String credentialName, final Object credential) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialName", credentialName);
+            Assert.checkNotNullParam("credential", credential);
             // we only know how to verify plain-text passwords
             ClearPassword clearPassword = null;
-            // we only know how to verify plain-text passwords
             if (credential instanceof char[]) {
                 try {
                     ClearPasswordSpec keySpec = new ClearPasswordSpec((char[]) credential);
@@ -276,24 +272,22 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                 clearPassword = (ClearPassword) credential;
             }
             if (clearPassword != null) {
-                List<Object> credentials = loadCredentials();
-                for (Object ours : credentials) {
-                    if (ours instanceof Password) try {
-                        final Password password = (Password) ours;
-                        final String algorithm = password.getAlgorithm();
-                        final PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
-                        return passwordFactory.verify(password, clearPassword.getPassword());
-                    } catch (NoSuchAlgorithmException | InvalidKeyException ignored) {
-                        // try next credential
-                    }
+                Map<String, Object> credentials = loadCredentials();
+                Object storedCredential = credentials.get(credentialName);
+                if (storedCredential instanceof Password) try {
+                    final Password storedPassword = (Password) storedCredential;
+                    final PasswordFactory passwordFactory = PasswordFactory.getInstance(storedPassword.getAlgorithm());
+                    return passwordFactory.verify(storedPassword, clearPassword.getPassword());
+                } catch (NoSuchAlgorithmException | InvalidKeyException ignored) {
+                    // ignore
                 }
             }
             return false;
         }
 
-        private List<Object> loadCredentials() throws RealmUnavailableException {
+        private Map<String, Object> loadCredentials() throws RealmUnavailableException {
             final LoadedIdentity loadedIdentity = loadIdentity(false, true);
-            return loadedIdentity == null ? Collections.emptyList() : loadedIdentity.getCredentials();
+            return loadedIdentity == null ? Collections.emptyMap() : loadedIdentity.getCredentials();
         }
 
         public boolean exists() throws RealmUnavailableException {
@@ -377,41 +371,42 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             }
         }
 
-        public void setCredential(final Object credential) throws RealmUnavailableException {
-            Assert.checkNotNullParam("credential", credential);
+        public void deleteCredential(final String credentialName) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialName", credentialName);
             final LoadedIdentity loadedIdentity = loadIdentity(false, false);
             if (loadedIdentity == null) {
                 throw ElytronMessages.log.fileSystemRealmNotFound(name);
             }
-            List<Object> credentials = loadedIdentity.getCredentials();
-            removeCredentialOfTheSameType(credentials, credential);
-            credentials.add(credential);
+
+            Map<String, Object> credentials = loadedIdentity.getCredentials();
+            credentials.remove(credentialName);
 
             final LoadedIdentity newIdentity = new LoadedIdentity(name, credentials, loadedIdentity.getAttributes());
             replaceIdentity(newIdentity);
         }
 
-        private void removeCredentialOfTheSameType(List<Object> credentials, Object pattern) {
-            for (Iterator iterator = credentials.iterator(); iterator.hasNext();) {
-                Object credential = iterator.next();
-                if (credential instanceof Key && pattern instanceof Key) { // keys comparison
-                    if (((Key)credential).getAlgorithm().equals(((Key)pattern).getAlgorithm())) {
-                        iterator.remove();
-                    }
-                } else { // non-keys comparison
-                    if(credential.getClass() == pattern.getClass()) {
-                        iterator.remove();
-                    }
-                }
+        public void setCredential(final String credentialName, final Object credential) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialName", credentialName);
+            Assert.checkNotNullParam("credential", credential);
+            final LoadedIdentity loadedIdentity = loadIdentity(false, false);
+            if (loadedIdentity == null) {
+                throw ElytronMessages.log.fileSystemRealmNotFound(name);
             }
+
+            Map<String, Object> credentials = loadedIdentity.getCredentials();
+            credentials.put(credentialName, credential);
+
+            final LoadedIdentity newIdentity = new LoadedIdentity(name, credentials, loadedIdentity.getAttributes());
+            replaceIdentity(newIdentity);
         }
 
-        public void setCredentials(final List<Object> credentials) throws RealmUnavailableException {
+        public void setCredentials(final Map<String, Object> credentials) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentials", credentials);
             final LoadedIdentity loadedIdentity = loadIdentity(true, false);
             if (loadedIdentity == null) {
                 throw ElytronMessages.log.fileSystemRealmNotFound(name);
             }
+
             final LoadedIdentity newIdentity = new LoadedIdentity(name, credentials, loadedIdentity.getAttributes());
             replaceIdentity(newIdentity);
         }
@@ -487,17 +482,18 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             streamWriter.writeCharacters("\n");
             streamWriter.writeStartElement("identity");
             streamWriter.writeDefaultNamespace(ELYTRON_1_0);
-            final Iterator<Object> credIter = newIdentity.getCredentials().iterator();
-            if (credIter.hasNext()) {
+
+            if (newIdentity.getCredentials().size() > 0) {
                 streamWriter.writeCharacters("\n    ");
                 streamWriter.writeStartElement("credentials");
-                do {
+                for (Map.Entry<String, Object> entry : newIdentity.getCredentials().entrySet()) {
                     streamWriter.writeCharacters("\n        ");
-                    final Object credential = credIter.next();
+                    final Object credential = entry.getValue();
                     if (credential instanceof OneTimePassword) {
                         final OneTimePassword otp = (OneTimePassword) credential;
                         otp.getHash();
                         streamWriter.writeStartElement("otp");
+                        streamWriter.writeAttribute("name", entry.getKey());
                         streamWriter.writeAttribute("algorithm", otp.getAlgorithm());
                         streamWriter.writeAttribute("hash", ByteIterator.ofBytes(otp.getHash()).base64Encode().drainToString());
                         streamWriter.writeAttribute("seed", ByteIterator.ofBytes(otp.getSeed()).base64Encode().drainToString());
@@ -519,6 +515,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                             passwordString = ModularCrypt.encodeAsString(password);
                         }
 
+                        streamWriter.writeAttribute("name", entry.getKey());
                         streamWriter.writeAttribute("algorithm", algorithm);
                         streamWriter.writeAttribute("format", format);
                         streamWriter.writeCharacters(passwordString.toString());
@@ -529,7 +526,8 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                         final String format = publicKey.getFormat();
                         final byte[] encoded = publicKey.getEncoded();
                         final CodePointIterator iterator = ByteIterator.ofBytes(encoded).base64Encode();
-                        streamWriter.writeStartElement("public-key");
+                        streamWriter.writeStartElement("private-key");
+                        streamWriter.writeAttribute("name", entry.getKey());
                         streamWriter.writeAttribute("algorithm", algorithm);
                         streamWriter.writeAttribute("format", format);
                         while (iterator.hasNext()) {
@@ -543,6 +541,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                         final byte[] encoded = certificate.getEncoded();
                         final CodePointIterator iterator = ByteIterator.ofBytes(encoded).base64Encode();
                         streamWriter.writeStartElement("certificate");
+                        streamWriter.writeAttribute("name", entry.getKey());
                         streamWriter.writeAttribute("algorithm", "X.509");
                         while (iterator.hasNext()) {
                             streamWriter.writeCharacters("\n            ");
@@ -551,7 +550,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                         streamWriter.writeCharacters("\n        ");
                         streamWriter.writeEndElement();
                     }
-                } while (credIter.hasNext());
+                }
                 streamWriter.writeCharacters("\n    ");
                 streamWriter.writeEndElement();
             }
@@ -614,7 +613,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             if (attributeCount > 0) {
                 throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
             }
-            List<Object> credentials = Collections.emptyList();
+            Map<String, Object> credentials = Collections.emptyMap();
             Attributes attributes = Attributes.EMPTY;
             boolean gotCredentials = false;
             boolean gotRoles = false;
@@ -644,27 +643,27 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             }
         }
 
-        private List<Object> parseCredentials(final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
+        private Map<String, Object> parseCredentials(final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
             final int attributeCount = streamReader.getAttributeCount();
             if (attributeCount > 0) {
                 throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
             }
             if (streamReader.nextTag() == END_ELEMENT) {
-                return Collections.emptyList();
+                return Collections.emptyMap();
             }
-            List<Object> credentials = new ArrayList<>();
+            Map<String, Object> credentials = new HashMap<>();
             do {
                 if (! ELYTRON_1_0.equals(streamReader.getNamespaceURI())) {
                     throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
                 }
                 if ("password".equals(streamReader.getLocalName())) {
-                    credentials.add(parsePassword(streamReader));
+                    parsePassword(credentials, streamReader);
                 } else if ("private-key".equals(streamReader.getLocalName())) {
-                    credentials.add(parsePrivateKey(streamReader));
+                    parsePrivateKey(credentials, streamReader);
                 } else if ("certificate".equals(streamReader.getLocalName())) {
-                    credentials.add(parseCertificate(streamReader));
+                    parseCertificate(credentials, streamReader);
                 } else if ("otp".equals(streamReader.getLocalName())) {
-                    credentials.add(parseOtp(streamReader));
+                    parseOtp(credentials, streamReader);
                 } else {
                     throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
                 }
@@ -672,8 +671,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             return credentials;
         }
 
-        private <C> C parseCredential(final XMLStreamReader streamReader, CredentialParseFunction<C> function) throws RealmUnavailableException, XMLStreamException {
+        private void parseCredential(final XMLStreamReader streamReader, CredentialParseFunction function) throws RealmUnavailableException, XMLStreamException {
             final int attributeCount = streamReader.getAttributeCount();
+            String name = null;
             String algorithm = null;
             String format = null;
             for (int i = 0; i < attributeCount; i ++) {
@@ -682,7 +682,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                     throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
                 }
                 final String localName = streamReader.getAttributeLocalName(i);
-                if ("algorithm".equals(localName)) {
+                if ("name".equals(localName)) {
+                    name = streamReader.getAttributeValue(i);
+                } else if ("algorithm".equals(localName)) {
                     algorithm = streamReader.getAttributeValue(i);
                 } else if ("format".equals(localName)) {
                     format = streamReader.getAttributeValue(i);
@@ -691,24 +693,25 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                 }
             }
             final String text = streamReader.getElementText().trim();
-            return function.parseCredential(algorithm, format, text);
+            function.parseCredential(name, algorithm, format, text);
         }
 
-        private X509Certificate parseCertificate(final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
-            return parseCredential(streamReader, (algorithm, format, text) -> {
+        private void parseCertificate(final Map<String, Object> credentials, final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
+            parseCredential(streamReader, (name, algorithm, format, text) -> {
                 if (algorithm == null) algorithm = "X.509";
                 if (format == null) format = "X.509";
                 try {
                     final CertificateFactory certificateFactory = CertificateFactory.getInstance(algorithm);
-                    return (X509Certificate) certificateFactory.generateCertificate(CodePointIterator.ofString(text).base64Decode().asInputStream());
+                    credentials.put(name, certificateFactory.generateCertificate(
+                            CodePointIterator.ofString(text).base64Decode().asInputStream()));
                 } catch (CertificateException | ClassCastException e) {
                     throw ElytronMessages.log.fileSystemRealmCertificateReadError(format, path, streamReader.getLocation().getLineNumber(), name);
                 }
             });
         }
 
-        private PrivateKey parsePrivateKey(final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
-            return parseCredential(streamReader, (algorithm, format, text) -> {
+        private void parsePrivateKey(final Map<String, Object> credentials, final XMLStreamReader streamReader) throws RealmUnavailableException, XMLStreamException {
+            parseCredential(streamReader, (name, algorithm, format, text) -> {
                 if (algorithm == null) {
                     throw ElytronMessages.log.fileSystemRealmMissingAttribute("algorithm", path, streamReader.getLocation().getLineNumber(), name);
                 }
@@ -719,7 +722,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                     } else {
                         throw ElytronMessages.log.fileSystemRealmUnsupportedKeyFormat(format, path, streamReader.getLocation().getLineNumber(), name);
                     }
-                    return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+                    credentials.put(name, KeyFactory.getInstance(algorithm).generatePrivate(keySpec));
                 } catch (InvalidKeySpecException e) {
                     throw ElytronMessages.log.fileSystemRealmUnsupportedKeyFormat(format, path, streamReader.getLocation().getLineNumber(), name);
                 } catch (NoSuchAlgorithmException e) {
@@ -728,8 +731,8 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             });
         }
 
-        private Password parsePassword(final XMLStreamReader streamReader) throws XMLStreamException, RealmUnavailableException {
-            return parseCredential(streamReader, (algorithm, format, text) -> {
+        private void parsePassword(final Map<String, Object> credentials, final XMLStreamReader streamReader) throws XMLStreamException, RealmUnavailableException {
+            parseCredential(streamReader, (name, algorithm, format, text) -> {
                 try {
                     if (BASE64_FORMAT.equals(format)) {
                         byte[] passwordBytes = CodePointIterator.ofChars(text.toCharArray()).base64Decode().drain();
@@ -737,12 +740,12 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                         PasswordSpec passwordSpec = BasicPasswordSpecEncoding.decode(passwordBytes);
 
                         if (passwordSpec != null) {
-                            return passwordFactory.generatePassword(passwordSpec);
+                            credentials.put(name, passwordFactory.generatePassword(passwordSpec));
                         } else {
                             throw ElytronMessages.log.fileSystemRealmInvalidPasswordAlgorithm(algorithm, path, streamReader.getLocation().getLineNumber(), name);
                         }
                     } else if (MCF_FORMAT.equals(format)) {
-                        return ModularCrypt.decode(text);
+                        credentials.put(name, ModularCrypt.decode(text));
                     } else {
                         throw ElytronMessages.log.fileSystemRealmInvalidPasswordFormat(format, path, streamReader.getLocation().getLineNumber(), name);
                     }
@@ -752,7 +755,8 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             });
         }
 
-        private Password parseOtp(final XMLStreamReader streamReader) throws XMLStreamException, RealmUnavailableException {
+        private void parseOtp(final Map<String, Object> credentials, final XMLStreamReader streamReader) throws XMLStreamException, RealmUnavailableException {
+            String name = null;
             String algorithm = null;
             byte[] hash = null;
             byte[] seed = null;
@@ -765,7 +769,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
                     throw ElytronMessages.log.fileSystemRealmInvalidContent(path, streamReader.getLocation().getLineNumber(), name);
                 }
                 final String localName = streamReader.getAttributeLocalName(i);
-                if ("algorithm".equals(localName)) {
+                if ("name".equals(localName)) {
+                    name = streamReader.getAttributeValue(i);
+                } else if ("algorithm".equals(localName)) {
                     algorithm = streamReader.getAttributeValue(i);
                 } else if ("hash".equals(localName)) {
                     hash = CodePointIterator.ofString(streamReader.getAttributeValue(i)).base64Decode().drain();
@@ -784,7 +790,8 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
 
             try {
                 PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
-                return passwordFactory.generatePassword(new OneTimePasswordSpec(hash, seed, sequenceNumber));
+                Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(hash, seed, sequenceNumber));
+                credentials.put(name, password);
             } catch (InvalidKeySpecException e) {
                 throw ElytronMessages.log.fileSystemRealmInvalidOtpDefinition(path, streamReader.getLocation().getLineNumber(), name, e);
             } catch (NoSuchAlgorithmException e) {
@@ -861,10 +868,10 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
 
     final class LoadedIdentity {
         private final String name;
-        private final List<Object> credentials;
+        private final Map<String, Object> credentials;
         private final Attributes attributes;
 
-        LoadedIdentity(final String name, final List<Object> credentials, final Attributes attributes) {
+        LoadedIdentity(final String name, final Map<String, Object> credentials, final Attributes attributes) {
             this.name = name;
             this.credentials = credentials;
             this.attributes = attributes;
@@ -878,7 +885,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             return attributes;
         }
 
-        List<Object> getCredentials() {
+        Map<String, Object> getCredentials() {
             return credentials;
         }
     }

--- a/src/main/java/org/wildfly/security/auth/provider/JaasSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/JaasSecurityRealm.java
@@ -55,6 +55,8 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  */
 public class JaasSecurityRealm implements SecurityRealm {
 
+    public final String VERIFIABLE_CREDENTIAL_NAME = "jaas";
+
     private final String loginConfiguration;
 
     private CallbackHandler handler;
@@ -85,17 +87,16 @@ public class JaasSecurityRealm implements SecurityRealm {
     }
 
     @Override
-    public CredentialSupport getCredentialSupport(Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
+    public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
+        Assert.checkNotNullParam("credentialName", credentialName);
         if (handler == null) {
             // we will be using the default handler that only supports char[] and String credentials.
-            if (char[].class.isAssignableFrom(credentialType) || String.class.isAssignableFrom(credentialType) || ClearPassword.class.isAssignableFrom(credentialType)) {
+            if (VERIFIABLE_CREDENTIAL_NAME.equals(credentialName)) {
                 return CredentialSupport.VERIFIABLE_ONLY;
-            }
-            else {
+            } else {
                 return CredentialSupport.UNSUPPORTED;
             }
-        }
-        else {
+        } else {
             // if a custom handler is set then the credential type is possibly verifiable.
             return CredentialSupport.POSSIBLY_VERIFIABLE;
         }
@@ -146,17 +147,17 @@ public class JaasSecurityRealm implements SecurityRealm {
         }
 
         @Override
-        public CredentialSupport getCredentialSupport(Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
-            return JaasSecurityRealm.this.getCredentialSupport(credentialType, algorithmName);
+        public CredentialSupport getCredentialSupport(String credentialName) throws RealmUnavailableException {
+            return JaasSecurityRealm.this.getCredentialSupport(credentialName);
         }
 
         @Override
-        public <C> C getCredential(Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public <C> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException {
             return null;
         }
 
         @Override
-        public boolean verifyCredential(Object credential) throws RealmUnavailableException {
+        public boolean verifyCredential(String credentialName, Object credential) throws RealmUnavailableException {
             this.subject = null;
             boolean successfulLogin;
             final CallbackHandler callbackHandler = createCallbackHandler(principal, credential);

--- a/src/main/java/org/wildfly/security/auth/provider/SimpleRealmEntry.java
+++ b/src/main/java/org/wildfly/security/auth/provider/SimpleRealmEntry.java
@@ -22,34 +22,36 @@ import org.wildfly.common.Assert;
 import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.password.Password;
 
+import java.util.Map;
+
 /**
  * A simple in-memory password-based entry for basic realm implementations.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public class SimpleRealmEntry {
-    private final Password password;
+    private final Map<String, Password> passwords;
     private final Attributes attributes;
 
     /**
      * Construct a new instance.
      *
-     * @param password the entry password (can not be {@code null})
+     * @param passwords the entry password (can not be {@code null})
      */
-    public SimpleRealmEntry(final Password password) {
-        this(password, Attributes.EMPTY);
+    public SimpleRealmEntry(final Map<String, Password> passwords) {
+        this(passwords, Attributes.EMPTY);
     }
 
     /**
      * Construct a new instance.
      *
-     * @param password the entry password (can not be {@code null})
+     * @param passwords the entry password (can not be {@code null})
      * @param attributes the entry attributes (can not be {@code null})
      */
-    public SimpleRealmEntry(final Password password, final Attributes attributes) {
-        Assert.checkNotNullParam("password", password);
+    public SimpleRealmEntry(final Map<String, Password> passwords, final Attributes attributes) {
+        Assert.checkNotNullParam("passwords", passwords);
         Assert.checkNotNullParam("attributes", attributes);
-        this.password = password;
+        this.passwords = passwords;
         this.attributes = attributes;
     }
 
@@ -58,8 +60,8 @@ public class SimpleRealmEntry {
      *
      * @return the entry password (not {@code null})
      */
-    public Password getPassword() {
-        return password;
+    public Password getPassword(String credentialName) {
+        return passwords.get(credentialName);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/KeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/KeyMapper.java
@@ -29,11 +29,11 @@ import java.sql.ResultSet;
 public interface KeyMapper extends ColumnMapper {
 
     /**
-     * Returns the key type supported by this mapper.
+     * Returns the credential name supported by this mapper.
      *
-     * @return the key type supported by this mapper.
+     * @return the credential name supported by this mapper.
      */
-    Class<?> getKeyType();
+    String getCredentialName();
 
     /**
      * <p>Determine whether a given credential is definitely supported, possibly supported (for some identities), or definitely not

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/PasswordKeyMapper.java
@@ -97,6 +97,51 @@ public class PasswordKeyMapper implements KeyMapper {
     /**
      * Constructs a new instance.
      *
+     * @param credentialName name of the credential which is output of this mapper (will be used to determine algorithm)
+     * @param hash the column index from where the password in its clear, hash or encoded form is obtained
+     * @throws InvalidKeyException if the given algorithm is not supported by this mapper.
+     */
+    public PasswordKeyMapper(String credentialName, int hash) throws InvalidKeyException {
+        Assert.checkNotNullParam("credentialName", credentialName);
+        Assert.checkMinimumParameter("hash", 1, hash);
+        this.algorithm = toAlgorithm(credentialName);
+        this.passwordType = toPasswordType(algorithm);
+        this.hash = hash;
+        this.credentialName = credentialName;
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param credentialName name of the credential which is output of this mapper (will be used to determine algorithm)
+     * @param hash the column index from where the password in its clear, hash or encoded form is obtained
+     * @param salt the column index from where the salt, if supported by the given algorithm, is obtained
+     * @throws InvalidKeyException if the given algorithm is not supported by this mapper.
+     */
+    public PasswordKeyMapper(String credentialName, int hash, int salt) throws InvalidKeyException {
+        this(credentialName, hash);
+        Assert.checkMinimumParameter("salt", 1, salt);
+        this.salt = salt;
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param credentialName name of the credential which is output of this mapper (will be used to determine algorithm)
+     * @param hash the column index from where the password in its clear, hash or encoded form is obtained
+     * @param salt the column index from where the salt, if supported by the given algorithm, is obtained
+     * @param iterationCount the column index from where the iteration count or cost, if supported by the given algorithm, is obtained
+     * @throws InvalidKeyException if the given algorithm is not supported by this mapper.
+     */
+    public PasswordKeyMapper(String credentialName, int hash, int salt, int iterationCount) throws InvalidKeyException {
+        this(credentialName, hash, salt);
+        Assert.checkMinimumParameter("iterationCount", 1, iterationCount);
+        this.iterationCount = iterationCount;
+    }
+
+    /**
+     * Constructs a new instance.
+     *
      * @param credentialName name of the credential which is output of this mapper
      * @param algorithm the algorithm that will be used by this mapper to create a specific {@link org.wildfly.security.password.Password} type
      * @param hash the column index from where the password in its clear, hash or encoded form is obtained
@@ -130,6 +175,7 @@ public class PasswordKeyMapper implements KeyMapper {
     /**
      * Constructs a new instance.
      *
+     * @param credentialName name of the credential which is output of this mapper
      * @param algorithm the algorithm that will be used by this mapper to create a specific {@link org.wildfly.security.password.Password} type
      * @param hash the column index from where the password in its clear, hash or encoded form is obtained
      * @param salt the column index from where the salt, if supported by the given algorithm, is obtained
@@ -294,6 +340,42 @@ public class PasswordKeyMapper implements KeyMapper {
 
     private char[] toCharArray(byte[] hash) {
         return CodePointIterator.ofUtf8Bytes(hash).drainToString().toCharArray();
+    }
+
+    private String toAlgorithm(String credentialName) throws InvalidKeyException {
+        if (credentialName.endsWith(ALGORITHM_CLEAR)) return ALGORITHM_CLEAR;
+        if (credentialName.endsWith(ALGORITHM_BCRYPT)) return ALGORITHM_BCRYPT;
+        if (credentialName.endsWith(ALGORITHM_CRYPT_MD5)) return ALGORITHM_CRYPT_MD5;
+        if (credentialName.endsWith(ALGORITHM_SUN_CRYPT_MD5)) return ALGORITHM_SUN_CRYPT_MD5;
+        if (credentialName.endsWith(ALGORITHM_SUN_CRYPT_MD5_BARE_SALT)) return ALGORITHM_SUN_CRYPT_MD5_BARE_SALT;
+        if (credentialName.endsWith(ALGORITHM_CRYPT_SHA_256)) return ALGORITHM_CRYPT_SHA_256;
+        if (credentialName.endsWith(ALGORITHM_CRYPT_SHA_512)) return ALGORITHM_CRYPT_SHA_512;
+        if (credentialName.endsWith(ALGORITHM_DIGEST_MD5)) return ALGORITHM_DIGEST_MD5;
+        if (credentialName.endsWith(ALGORITHM_DIGEST_SHA)) return ALGORITHM_DIGEST_SHA;
+        if (credentialName.endsWith(ALGORITHM_DIGEST_SHA_256)) return ALGORITHM_DIGEST_SHA_256;
+        if (credentialName.endsWith(ALGORITHM_DIGEST_SHA_512)) return ALGORITHM_DIGEST_SHA_512;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_MD2)) return ALGORITHM_SIMPLE_DIGEST_MD2;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_MD5)) return ALGORITHM_SIMPLE_DIGEST_MD5;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_SHA_1)) return ALGORITHM_SIMPLE_DIGEST_SHA_1;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_SHA_256)) return ALGORITHM_SIMPLE_DIGEST_SHA_256;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_SHA_384)) return ALGORITHM_SIMPLE_DIGEST_SHA_384;
+        if (credentialName.endsWith(ALGORITHM_SIMPLE_DIGEST_SHA_512)) return ALGORITHM_SIMPLE_DIGEST_SHA_512;
+        if (credentialName.endsWith(ALGORITHM_PASSWORD_SALT_DIGEST_MD5)) return ALGORITHM_PASSWORD_SALT_DIGEST_MD5;
+        if (credentialName.endsWith(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1)) return ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1;
+        if (credentialName.endsWith(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256)) return ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256;
+        if (credentialName.endsWith(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384)) return ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384;
+        if (credentialName.endsWith(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512)) return ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512;
+        if (credentialName.endsWith(ALGORITHM_SALT_PASSWORD_DIGEST_MD5)) return ALGORITHM_SALT_PASSWORD_DIGEST_MD5;
+        if (credentialName.endsWith(ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1)) return ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1;
+        if (credentialName.endsWith(ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256)) return ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256;
+        if (credentialName.endsWith(ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384)) return ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384;
+        if (credentialName.endsWith(ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512)) return ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512;
+        if (credentialName.endsWith(ALGORITHM_CRYPT_DES)) return ALGORITHM_CRYPT_DES;
+        if (credentialName.endsWith(ALGORITHM_BSD_CRYPT_DES)) return ALGORITHM_BSD_CRYPT_DES;
+        if (credentialName.endsWith(ALGORITHM_SCRAM_SHA_1)) return ALGORITHM_SCRAM_SHA_1;
+        if (credentialName.endsWith(ALGORITHM_SCRAM_SHA_256)) return ALGORITHM_SCRAM_SHA_256;
+
+        throw log.couldNotResolveAlgorithmByCredentialName(credentialName);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/RSAPrivateKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/mapper/RSAPrivateKeyMapper.java
@@ -39,6 +39,8 @@ public class RSAPrivateKeyMapper implements KeyMapper {
 
     private static final String KEY_ALGORITHM = "RSA";
 
+    private final String credentialName;
+
     private final int privateKey;
 
     /**
@@ -46,9 +48,11 @@ public class RSAPrivateKeyMapper implements KeyMapper {
      *
      * @param privateKey The column index from where an array of bytes are read in order to create the private key.
      */
-    public RSAPrivateKeyMapper(int privateKey) {
+    public RSAPrivateKeyMapper(String credentialName, int privateKey) {
+        Assert.checkNotNullParam("credentialName", credentialName);
         Assert.checkMinimumParameter("privateKey", 1, privateKey);
         this.privateKey = privateKey;
+        this.credentialName = credentialName;
     }
 
     /**
@@ -62,8 +66,8 @@ public class RSAPrivateKeyMapper implements KeyMapper {
     }
 
     @Override
-    public Class<?> getKeyType() {
-        return PrivateKey.class;
+    public String getCredentialName() {
+        return credentialName;
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialLoader.java
@@ -42,10 +42,10 @@ interface CredentialLoader {
      * be passed in for each call.
      *
      * @param contextFactory The dir context factory to use if a DirContext is required to query the server directly.
-     * @param credentialType the credential type
+     * @param credentialName the credential name
      * @return the level of support for this credential type
      */
-    CredentialSupport getCredentialSupport(DirContextFactory contextFactory, Class<?> credentialType);
+    CredentialSupport getCredentialSupport(DirContextFactory contextFactory, String credentialName);
 
     /**
      * Obtain an {@link IdentityCredentialLoader} to query the credentials for a specific identity.

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/CredentialPersister.java
@@ -21,10 +21,10 @@ public interface CredentialPersister {
      * be passed in for each call.
      *
      * @param contextFactory The dir context factory to use if a DirContext is required to query the server directly.
-     * @param credentialType the credential type
+     * @param credentialName the credential name
      * @return the level of support for this credential type
      */
-    CredentialSupport getCredentialSupport(DirContextFactory contextFactory, Class<?> credentialType);
+    CredentialSupport getCredentialSupport(DirContextFactory contextFactory, String credentialName);
 
     /**
      * Obtain an {@link IdentityCredentialLoader} to query the credentials for a specific identity.

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialLoader.java
@@ -31,19 +31,20 @@ import org.wildfly.security.auth.server.CredentialSupport;
 interface IdentityCredentialLoader {
 
     /**
-     * Determine whether a given credential is definitely supported, possibly supported, or definitely not
-     * supported.
+     * Determine whether a given credential is definitely supported, possibly supported, or definitely not supported.
      *
-     * @param credentialType the credential type to check
+     * @param credentialName the credential name to check
      * @return the level of support for this credential type
      */
-    CredentialSupport getCredentialSupport(Class<?> credentialType);
+    CredentialSupport getCredentialSupport(String credentialName);
 
     /**
      * Acquire a credential of the given type.
      *
-     * @param credentialType the credential type
-     * @return the credential, or {@code null} if the principal has no credential of that type
+     * @param <C> the type to which should be credential casted
+     * @param credentialName the name of the credential
+     * @param credentialType the class of type to which should be credential casted
+     * @return the credential, or {@code null} if the principal has no credential of that name or cannot be casted to that type
      */
-    <C> C getCredential(Class<C> credentialType);
+    <C> C getCredential(String credentialName, Class<C> credentialType);
 }

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/IdentityCredentialPersister.java
@@ -15,17 +15,18 @@ public interface IdentityCredentialPersister {
     /**
      * Determine whether a given credential is definitely supported, possibly supported, or definitely not supported.
      *
-     * @param credential the credential to check
+     * @param credentialName the credential to store
      * @return {@code true} if persisting of given credential is supported
      */
-    boolean getCredentialPersistSupport(Object credential);
+    boolean getCredentialPersistSupport(String credentialName);
 
     /**
      * Store credential of identity.
      *
+     * @param credentialName the credential to store
      * @param credential the credential
      */
-    void persistCredential(Object credential) throws RealmUnavailableException;
+    void persistCredential(String credentialName, Object credential) throws RealmUnavailableException;
 
     /**
      * Clear all supported credentials of identity.

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtil.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtil.java
@@ -45,7 +45,7 @@ class UserPasswordPasswordUtil {
     private UserPasswordPasswordUtil() {
     }
 
-    public static Password parseUserPassword(byte[] userPassword) throws InvalidKeySpecException {
+    public static Password parseUserPassword(byte[] userPassword, String requiredType) throws InvalidKeySpecException {
         Assert.checkNotNullParam("userPassword", userPassword);
         if (userPassword.length == 0) throw log.emptyParameter("userPassword");
 
@@ -54,47 +54,60 @@ class UserPasswordPasswordUtil {
         } else {
             if (userPassword[1] == 'm' && userPassword[2] == 'd' && userPassword[3] == '5' && userPassword[4] == '}') {
                 // {md5}
+                if ( ! "md5".equals(requiredType)) return null;
                 return createSimpleDigestPassword(ALGORITHM_SIMPLE_DIGEST_MD5, 5, userPassword);
             } else if (userPassword[1] == 's' && userPassword[2] == 'h' && userPassword[3] == 'a') {
                 if (userPassword[4] == '}') {
                     // {sha}
+                    if ( ! "sha1".equals(requiredType)) return null;
                     return createSimpleDigestPassword(ALGORITHM_SIMPLE_DIGEST_SHA_1, 5, userPassword);
                 } else if (userPassword[4] == '2' && userPassword[5] == '5' && userPassword[6] == '6' && userPassword[7] == '}') {
                     // {sha256}
+                    if ( ! "sha256".equals(requiredType)) return null;
                     return createSimpleDigestPassword(ALGORITHM_SIMPLE_DIGEST_SHA_256, 8, userPassword);
                 } else if (userPassword[4] == '3' && userPassword[5] == '8' && userPassword[6] == '4' && userPassword[7] == '}') {
                     // {sha384}
+                    if ( ! "sha384".equals(requiredType)) return null;
                     return createSimpleDigestPassword(ALGORITHM_SIMPLE_DIGEST_SHA_384, 8, userPassword);
                 } else if (userPassword[4] == '5' && userPassword[5] == '1' && userPassword[6] == '2' && userPassword[7] == '}') {
                     // {sha512}
+                    if ( ! "sha512".equals(requiredType)) return null;
                     return createSimpleDigestPassword(ALGORITHM_SIMPLE_DIGEST_SHA_512, 8, userPassword);
                 }
             } else if (userPassword[1] == 's' && userPassword[2] == 'm' && userPassword[3] == 'd' && userPassword[4] == '5' && userPassword[5] == '}') {
                 // {smd5}
+                if ( ! "smd5".equals(requiredType)) return null;
                 return createSaltedSimpleDigestPassword(ALGORITHM_PASSWORD_SALT_DIGEST_MD5, 6, userPassword);
             } else if (userPassword[1] == 's' && userPassword[2] == 's' && userPassword[3] == 'h' && userPassword[4] == 'a') {
                 if (userPassword[5] == '}') {
                     // {ssha}
+                    if ( ! "ssha".equals(requiredType)) return null;
                     return createSaltedSimpleDigestPassword(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, 6, userPassword);
                 } else if (userPassword[5] == '2' && userPassword[6] == '5' && userPassword[7] == '6' && userPassword[8] == '}') {
                     // {ssha256}
+                    if ( ! "ssha256".equals(requiredType)) return null;
                     return createSaltedSimpleDigestPassword(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, 9, userPassword);
                 } else if (userPassword[5] == '3' && userPassword[6] == '8' && userPassword[7] == '4' && userPassword[8] == '}') {
                     // {ssha384}
+                    if ( ! "ssha384".equals(requiredType)) return null;
                     return createSaltedSimpleDigestPassword(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, 9, userPassword);
                 } else if (userPassword[5] == '5' && userPassword[6] == '1' && userPassword[7] == '2' && userPassword[8] == '}') {
                     // {ssha512}
+                    if ( ! "ssha512".equals(requiredType)) return null;
                     return createSaltedSimpleDigestPassword(ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, 9, userPassword);
                 }
             } else if (userPassword[1] == 'c' && userPassword[2] == 'r' && userPassword[3] == 'y' && userPassword[4] == 'p' && userPassword[5] == 't' && userPassword[6] == '}') {
                 if (userPassword[7] == '_') {
                     // {crypt}_
+                    if ( ! "crypt_".equals(requiredType)) return null;
                     return createBsdCryptBasedPassword(userPassword);
                 } else {
                     // {crypt}
+                    if ( ! "crypt".equals(requiredType)) return null;
                     return createCryptBasedPassword(userPassword);
                 }
             }
+            if ( ! "clear".equals(requiredType)) return null;
             for (int i = 1; i < userPassword.length - 1; i++) {
                 if (userPassword[i] == '}') {
                     throw new InvalidKeySpecException();

--- a/src/main/java/org/wildfly/security/auth/server/AuthenticationInformation.java
+++ b/src/main/java/org/wildfly/security/auth/server/AuthenticationInformation.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.server;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+/**
+ * Authentication process information for credential selection mappers.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class AuthenticationInformation {
+
+    private final String mechanismType; // SASL / HTTP / SSL / ...
+
+    private final String mechanismName; // "digest-md5" (SaslMechanismInformation.Names.*)
+
+    private final String protocol; // parameter of same SASL servers (imap for example)
+
+    private final String authenticationName; // authentication name of authenticating user
+
+    private AuthenticationInformation(Builder builder) {
+        this.mechanismType = builder.mechanismType;
+        this.mechanismName = builder.mechanismName;
+        this.protocol = builder.protocol;
+        this.authenticationName = builder.authenticationName;
+    }
+
+    public String getMechanismType() {
+        return mechanismType;
+    }
+
+    public String getMechanismName() {
+        return mechanismName;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getAuthenticationName() {
+        return authenticationName;
+    }
+
+
+    public static final class Builder {
+        private boolean built = false;
+
+        private String mechanismType;
+        private String mechanismName;
+        private String protocol;
+        private String authenticationName;
+
+        /**
+         * Sets a mechanism type: SASL / HTTP / SSL / ...
+         *
+         * @param mechanismType the mechanism type
+         * @return this builder
+         */
+        public Builder setMechanismType(String mechanismType) {
+            assertNotBuilt();
+            this.mechanismType = mechanismType;
+            return this;
+        }
+
+        /**
+         * Sets a mechanism name: "digest-md5" (SaslMechanismInformation.Names.*)
+         *
+         * @param mechanismName the mechanism name
+         * @return this builder
+         */
+        public Builder setMechanismName(String mechanismName) {
+            assertNotBuilt();
+            this.mechanismName = mechanismName;
+            return this;
+        }
+
+        /**
+         * Sets a protocol: "imap" (parameter of same SASL servers, "digest-*" for example)
+         *
+         * @param protocol the protocol name
+         * @return this builder
+         */
+        public Builder setProtocol(String protocol) {
+            assertNotBuilt();
+            this.protocol = protocol;
+            return this;
+        }
+
+        /**
+         * Sets an authentication name (user name) of authenticating user
+         *
+         * @param authenticationName the authentication name
+         * @return this builder
+         */
+        public Builder setAuthenticationName(String authenticationName) {
+            assertNotBuilt();
+            this.authenticationName = authenticationName;
+            return this;
+        }
+
+        /**
+         * Construct this authentication information.
+         *
+         * @return the new authentication information
+         */
+        public AuthenticationInformation build() {
+            built = true;
+            return new AuthenticationInformation(this);
+        }
+
+        private void assertNotBuilt() {
+            if (built) {
+                throw log.builderAlreadyBuilt();
+            }
+        }
+    }
+}

--- a/src/main/java/org/wildfly/security/auth/server/CredentialMapper.java
+++ b/src/main/java/org/wildfly/security/auth/server/CredentialMapper.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.server;
+
+import org.wildfly.security.sasl.util.SaslMechanismInformation.Names;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Credential selection mapper mechanism consume authentication process information and use it to yield a credential name.
+ * Provided to ServerAuthenticationContext for determine credential name(s) which should be acquired from security realm.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public interface CredentialMapper {
+
+    /**
+     * Get credential names by authentication information.
+     * @param information the authentication information (at least mechanism type, name and user name)
+     * @return the list of credential names
+     */
+    List<String> getCredentialNameMapping(AuthenticationInformation information);
+
+    /**
+     * Default implementation of credential mapper
+     */
+    CredentialMapper ELYTRON_CREDENTIAL_MAPPER = information -> {
+        switch (information.getMechanismName()) {
+            case Names.DIGEST_MD5:
+                return Collections.unmodifiableList(Arrays.asList("password-digest-md5", "password-clear"));
+            case Names.DIGEST_SHA:
+                return Collections.unmodifiableList(Arrays.asList("password-digest-sha", "password-clear"));
+            case Names.DIGEST_SHA_256:
+                return Collections.unmodifiableList(Arrays.asList("password-digest-sha256", "password-clear"));
+            case Names.DIGEST_SHA_384:
+                return Collections.unmodifiableList(Arrays.asList("password-digest-sha384", "password-clear"));
+            case Names.DIGEST_SHA_512:
+                return Collections.unmodifiableList(Arrays.asList("password-digest-sha512", "password-clear"));
+            case Names.SCRAM_SHA_1:
+            case Names.SCRAM_SHA_1_PLUS:
+                return Collections.unmodifiableList(Arrays.asList("password-scram-sha1", "password-clear"));
+            case Names.SCRAM_SHA_256:
+            case Names.SCRAM_SHA_256_PLUS:
+                return Collections.unmodifiableList(Arrays.asList("password-scram-sha256", "password-clear"));
+            case Names.SCRAM_SHA_384:
+            case Names.SCRAM_SHA_384_PLUS:
+                return Collections.unmodifiableList(Arrays.asList("password-scram-sha384", "password-clear"));
+            case Names.SCRAM_SHA_512:
+            case Names.SCRAM_SHA_512_PLUS:
+                return Collections.unmodifiableList(Arrays.asList("password-scram-sha512", "password-clear"));
+            case Names.PLAIN:
+                return Collections.singletonList("password");
+            case Names.OTP:
+                return Collections.singletonList("otp");
+            case Names.IEC_ISO_9798_M_DSA_SHA1:
+            case Names.IEC_ISO_9798_U_DSA_SHA1:
+                return Collections.singletonList("certificate-dsa-sha1");
+            case Names.IEC_ISO_9798_M_ECDSA_SHA1:
+            case Names.IEC_ISO_9798_U_ECDSA_SHA1:
+                return Collections.singletonList("certificate-ecdsa-sha1");
+            case Names.IEC_ISO_9798_M_RSA_SHA1_ENC:
+            case Names.IEC_ISO_9798_U_RSA_SHA1_ENC:
+                return Collections.singletonList("certificate-rsa-sha1-enc");
+            default:
+                return Collections.emptyList();
+        }
+    };
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
@@ -18,7 +18,7 @@
 
 package org.wildfly.security.auth.server;
 
-import java.util.List;
+import java.util.Map;
 
 import org.wildfly.security.authz.Attributes;
 
@@ -46,21 +46,30 @@ public interface ModifiableRealmIdentity extends RealmIdentity {
     void create() throws RealmUnavailableException;
 
     /**
-     * Replace list of credentials of this identity.  If the identity does not exist, an exception is thrown.
+     * Replace map of credentials of this identity.  If the identity does not exist, an exception is thrown.
      *
-     * @param credentials the new list of credentials
+     * @param credentials the new map of credentials
      * @throws RealmUnavailableException if updating the credentials fails for some reason
      */
-    void setCredentials(List<Object> credentials) throws RealmUnavailableException;
+    void setCredentials(Map<String, Object> credentials) throws RealmUnavailableException;
 
     /**
      * Add new credential of this identity.  If the identity does not exist, an exception is thrown.
      * If credential of the same type of the same identity already exist, it is replaced.
      *
+     * @param credentialName the name of the credential
      * @param credential the new credential
      * @throws RealmUnavailableException if updating the credentials fails for some reason
      */
-    void setCredential(Object credential) throws RealmUnavailableException;
+    void setCredential(String credentialName, Object credential) throws RealmUnavailableException;
+
+    /**
+     * Delete credential of this identity by name.  If the identity or credential does not exist, an exception is thrown.
+     *
+     * @param credentialName the name of the credential
+     * @throws RealmUnavailableException if updating the credentials fails for some reason
+     */
+    void deleteCredential(String credentialName) throws RealmUnavailableException;
 
     /**
      * Modify the attributes collection of this identity.  If the identity does not exist, an exception is thrown.

--- a/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
@@ -37,24 +37,23 @@ public interface RealmIdentity {
      * identity.  The credential type is defined by its {@code Class} and an optional {@code algorithmName}.  If the
      * algorithm name is not given, then the query is performed for any algorithm of the given type.
      *
-     * @param credentialType the credential type
-     * @param algorithmName the optional algorithm name for the credential type
+     * @param credentialName the name of the credential
      * @return the level of support for this credential type
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
-    CredentialSupport getCredentialSupport(Class<?> credentialType, String algorithmName) throws RealmUnavailableException;
+    CredentialSupport getCredentialSupport(String credentialName) throws RealmUnavailableException;
 
     /**
      * Acquire a credential of the given type.  The credential type is defined by its {@code Class} and an optional {@code algorithmName}.  If the
      * algorithm name is not given, then the query is performed for any algorithm of the given type.
      *
-     * @param <C> the credential type
-     * @param credentialType the credential type class
-     * @param algorithmName the optional algorithm name for the credential type
-     * @return the credential, or {@code null} if the principal has no credential of that type
+     * @param <C> the type to which should be credential casted
+     * @param credentialName the name of the credential
+     * @param credentialType the class of type to which should be credential casted
+     * @return the credential, or {@code null} if the principal has no credential of that name or cannot be casted to that type
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
-    <C> C getCredential(Class<C> credentialType, final String algorithmName) throws RealmUnavailableException;
+    <C> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException;
 
     /**
      * Verify the given credential.
@@ -63,7 +62,7 @@ public interface RealmIdentity {
      * @return {@code true} if verification was successful, {@code false} otherwise
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
-    boolean verifyCredential(Object credential) throws RealmUnavailableException;
+    boolean verifyCredential(String credentialName, Object credential) throws RealmUnavailableException;
 
     /**
      * Determine if the identity exists in lieu of verifying or acquiring a credential.  This method is intended to be
@@ -93,15 +92,19 @@ public interface RealmIdentity {
      */
     RealmIdentity ANONYMOUS = new RealmIdentity() {
 
-        public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public String getName() {
+            return "anonymous";
+        }
+
+        public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
             return CredentialSupport.UNSUPPORTED;
         }
 
-        public <C> C getCredential(final Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public <C> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
             return null;
         }
 
-        public boolean verifyCredential(final Object credential) throws RealmUnavailableException {
+        public boolean verifyCredential(final String credentialName, final Object credential) throws RealmUnavailableException {
             return false;
         }
 
@@ -119,15 +122,15 @@ public interface RealmIdentity {
      */
     RealmIdentity NON_EXISTENT = new RealmIdentity() {
 
-        public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
             return CredentialSupport.UNSUPPORTED;
         }
 
-        public <C> C getCredential(final Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public <C> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
             return null;
         }
 
-        public boolean verifyCredential(final Object credential) throws RealmUnavailableException {
+        public boolean verifyCredential(final String credentialName, final Object credential) throws RealmUnavailableException {
             return false;
         }
 

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomainSaslConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomainSaslConfiguration.java
@@ -20,14 +20,12 @@ package org.wildfly.security.auth.server;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import javax.security.sasl.SaslServerFactory;
 
 import org.wildfly.common.Assert;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.FilterMechanismSaslServerFactory;
-import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.util._private.UnmodifiableArrayList;
 
 /**
@@ -49,12 +47,17 @@ public final class SecurityDomainSaslConfiguration {
     public SecurityDomainSaslConfiguration(final SecurityDomain securityDomain, final SaslServerFactory saslServerFactory) {
         this.securityDomain = Assert.checkNotNullParam("securityDomain", securityDomain);
         Assert.checkNotNullParam("saslServerFactory", saslServerFactory);
+
+        // TODO [ELY-292] filtering should work differently with credential names
+        this.saslServerFactory = saslServerFactory;
+        /*
         this.saslServerFactory = new FilterMechanismSaslServerFactory(saslServerFactory, name -> {
             final Set<Class<?>> credentialTypes = SaslMechanismInformation.getSupportedServerCredentialTypes(name);
             if (credentialTypes == null) {
                 // unknown, just pass
                 return true;
             }
+
             for (Class<?> credentialType : credentialTypes) {
                 final Set<String> algorithms = SaslMechanismInformation.getSupportedServerCredentialAlgorithms(name, credentialType);
                 if (algorithms.isEmpty()) {
@@ -71,6 +74,7 @@ public final class SecurityDomainSaslConfiguration {
             }
             return false;
         });
+        */
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
@@ -41,14 +41,12 @@ public interface SecurityRealm {
 
     /**
      * Determine whether a given credential is definitely supported, possibly supported (for some identities), or definitely not
-     * supported.  The credential type is defined by its {@code Class} and an optional {@code algorithmName}.  If the
-     * algorithm name is not given, then the query is performed for any algorithm of the given type.
+     * supported.  The credential type is defined by its {@code credentialName}.
      *
-     * @param credentialType the credential type
-     * @param algorithmName the optional algorithm name for the credential type
+     * @param credentialName the credential name
      * @return the level of support for this credential type
      */
-    CredentialSupport getCredentialSupport(Class<?> credentialType, String algorithmName) throws RealmUnavailableException;
+    CredentialSupport getCredentialSupport(String credentialName) throws RealmUnavailableException;
 
     /**
      * An empty security realm.
@@ -58,7 +56,7 @@ public interface SecurityRealm {
             return RealmIdentity.NON_EXISTENT;
         }
 
-        public CredentialSupport getCredentialSupport(final Class<?> credentialType, final String algorithmName) throws RealmUnavailableException {
+        public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
             return CredentialSupport.UNSUPPORTED;
         }
     };

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
@@ -82,7 +82,7 @@ final class Gs2SaslServer extends AbstractSaslServer {
         try {
             tryHandleCallbacks(credentialCallback);
             credential = (GSSCredential) credentialCallback.getCredential();
-        } catch (UnsupportedCallbackException e) {
+        } catch (UnsupportedCallbackException | IllegalStateException | SaslException e) {
             try {
                 String localNameStr = protocol + "@" + serverName;
                 GSSName localName = gssManager.createName(localNameStr, GSSName.NT_HOSTBASED_SERVICE, mechanism);

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -39,6 +39,7 @@
     <xsd:complexType name="credentials-type">
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="password" type="credential-type"/>
+            <xsd:element name="otp" type="otp-credential-type"/>
             <xsd:element name="private-key" type="credential-type"/>
             <xsd:element name="certificate" type="credential-type"/>
         </xsd:choice>
@@ -53,8 +54,21 @@
     <xsd:complexType name="credential-type">
         <xsd:simpleContent>
             <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
                 <xsd:attribute name="algorithm" type="xsd:string" use="optional"/>
                 <xsd:attribute name="format" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="otp-credential-type">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="algorithm" type="xsd:string" use="optional"/>
+                <xsd:attribute name="hash" type="xsd:string" use="optional"/>
+                <xsd:attribute name="seed" type="xsd:string" use="optional"/>
+                <xsd:attribute name="sequence" type="xsd:string" use="optional"/>
             </xsd:extension>
         </xsd:simpleContent>
     </xsd:complexType>

--- a/src/test/java/org/wildfly/security/auth/KeyStoreBackedSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/KeyStoreBackedSecurityRealmTest.java
@@ -26,10 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.InputStream;
 import java.security.KeyStore;
-import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.Security;
-import java.security.cert.Certificate;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -75,42 +73,40 @@ public class KeyStoreBackedSecurityRealmTest {
         RealmIdentity realmIdentity = realm.createRealmIdentity("elytron");
 
         // only the Password type credential type is supported in the password file keystore.
-        assertEquals("Invalid credential support", CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(Password.class, null));
-        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport(PrivateKey.class, null));
-        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport(Certificate.class, null));
+        assertEquals("Invalid credential support", CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("credential1"));
+        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport("credential2"));
 
         // as a result, the only type that will yield a non null credential is Password.
-        Password password = realmIdentity.getCredential(Password.class, null);
+        Password password = realmIdentity.getCredential("credential1", Password.class);
         assertNotNull("Invalid null password", password);
         assertTrue("Invalid password type", password instanceof UnixMD5CryptPassword);
 
         // other types must result in a null credential.
-        assertNull("Invalid non null password", realmIdentity.getCredential(PrivateKey.class, null));
-        assertNull("Invalid non null password", realmIdentity.getCredential(Certificate.class, null));
+        assertNull("Invalid non null password", realmIdentity.getCredential("credential2", Password.class));
 
         // the realm identity must be able to verify the password for the user "elytron".
-        assertTrue("Error validating credential", realmIdentity.verifyCredential("passwd12#$".toCharArray()));
-        assertFalse("Error validating credential", realmIdentity.verifyCredential("wrongpass".toCharArray()));
+        assertTrue("Error validating credential", realmIdentity.verifyCredential("credential1", "passwd12#$".toCharArray()));
+        assertFalse("Error validating credential", realmIdentity.verifyCredential("credential1", "wrongpass".toCharArray()));
+        assertFalse("Error validating credential", realmIdentity.verifyCredential("credential2", "wrongpass".toCharArray()));
 
         // now create a realm identity that represents the user "javajoe" (password is of type BCrypt).
         realmIdentity = realm.createRealmIdentity("javajoe");
 
         // only the Password type credential type is supported in the password file keystore.
-        assertEquals("Invalid credential support", CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(Password.class, null));
-        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport(PrivateKey.class, null));
-        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport(Certificate.class, null));
+        assertEquals("Invalid credential support", CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("credential2"));
+        assertEquals("Invalid credential support", CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport("credential1"));
 
         // as a result, the only type that will yield a non null credential is Password.
-        password = realmIdentity.getCredential(Password.class, null);
+        password = realmIdentity.getCredential("credential2", Password.class);
         assertNotNull("Invalid null password", password);
         assertTrue("Invalid password type", password instanceof BCryptPassword);
 
         // other types must result in a null credential.
-        assertNull("Invalid non null password", realmIdentity.getCredential(PrivateKey.class, null));
-        assertNull("Invalid non null password", realmIdentity.getCredential(Certificate.class, null));
+        assertNull("Invalid non null password", realmIdentity.getCredential("credential1", Password.class));
 
         // the realm identity must be able to verify the password for the user "javajoe".
-        assertTrue("Error validating credential", realmIdentity.verifyCredential("$#21pass".toCharArray()));
-        assertFalse("Error validating credential", realmIdentity.verifyCredential("wrongpass".toCharArray()));
+        assertTrue("Error validating credential", realmIdentity.verifyCredential("credential2", "$#21pass".toCharArray()));
+        assertFalse("Error validating credential", realmIdentity.verifyCredential("credential2", "wrongpass".toCharArray()));
+        assertFalse("Error validating credential", realmIdentity.verifyCredential("credential1", "$#21pass".toCharArray()));
     }
 }

--- a/src/test/java/org/wildfly/security/auth/provider/LegacyPropertiesSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/LegacyPropertiesSecurityRealmTest.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.auth.provider;
 
+import static org.wildfly.security.auth.provider.LegacyPropertiesSecurityRealm.PROPERTIES_CLEAR_CREDENTIAL_NAME;
+import static org.wildfly.security.auth.provider.LegacyPropertiesSecurityRealm.PROPERTIES_DIGEST_CREDENTIAL_NAME;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
@@ -92,36 +94,36 @@ public class LegacyPropertiesSecurityRealmTest {
         Password goodGuess = passwordFactory.generatePassword(new ClearPasswordSpec(ELYTRON_PASSWORD_CLEAR.toCharArray()));
         Password badGuess = passwordFactory.generatePassword(new ClearPasswordSpec("I will hack you".toCharArray()));
 
-        assertEquals("ClearPassword", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, realm.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.FULLY_SUPPORTED, realm.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, realm.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
         RealmIdentity elytronIdentity = realm.createRealmIdentity("elytron");
-        assertEquals("ClearPassword", CredentialSupport.FULLY_SUPPORTED, elytronIdentity.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, elytronIdentity.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.FULLY_SUPPORTED, elytronIdentity.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, elytronIdentity.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
-        ClearPassword elytronClear = elytronIdentity.getCredential(ClearPassword.class, null);
+        ClearPassword elytronClear = elytronIdentity.getCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, ClearPassword.class);
         assertNotNull(elytronClear);
         assertEquals(ELYTRON_PASSWORD_CLEAR, new String(elytronClear.getPassword()));
 
-        DigestPassword elytronDigest = elytronIdentity.getCredential(DigestPassword.class, null);
+        DigestPassword elytronDigest = elytronIdentity.getCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, DigestPassword.class);
         assertNotNull(elytronDigest);
         String actualHex = ByteIterator.ofBytes(elytronDigest.getDigest()).hexEncode().drainToString();
         assertEquals(ELYTRON_PASSWORD_HASH, actualHex);
 
-        assertTrue(elytronIdentity.verifyCredential(goodGuess));
-        assertFalse(elytronIdentity.verifyCredential(badGuess));
+        assertTrue(elytronIdentity.verifyCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, goodGuess));
+        assertFalse(elytronIdentity.verifyCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, badGuess));
 
         elytronIdentity.dispose();
 
         RealmIdentity badIdentity = realm.createRealmIdentity("noone");
-        assertEquals("ClearPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
-        assertNull(badIdentity.getCredential(ClearPassword.class, null));
-        assertNull(badIdentity.getCredential(DigestPassword.class, null));
+        assertNull(badIdentity.getCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, Object.class));
+        assertNull(badIdentity.getCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, Object.class));
 
-        assertFalse(badIdentity.verifyCredential(goodGuess));
-        assertFalse(badIdentity.verifyCredential(badGuess));
+        assertFalse(badIdentity.verifyCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, goodGuess));
+        assertFalse(badIdentity.verifyCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, badGuess));
 
         badIdentity.dispose();
     }
@@ -139,34 +141,34 @@ public class LegacyPropertiesSecurityRealmTest {
         Password goodGuess = passwordFactory.generatePassword(new ClearPasswordSpec(ELYTRON_PASSWORD_CLEAR.toCharArray()));
         Password badGuess = passwordFactory.generatePassword(new ClearPasswordSpec("I will hack you".toCharArray()));
 
-        assertEquals("ClearPassword", CredentialSupport.VERIFIABLE_ONLY, realm.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, realm.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.VERIFIABLE_ONLY, realm.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, realm.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
         RealmIdentity elytronIdentity = realm.createRealmIdentity("elytron");
-        assertEquals("ClearPassword", CredentialSupport.VERIFIABLE_ONLY, elytronIdentity.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, elytronIdentity.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.VERIFIABLE_ONLY, elytronIdentity.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.OBTAINABLE_ONLY, elytronIdentity.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
-        assertNull(elytronIdentity.getCredential(ClearPassword.class, null));
+        assertNull(elytronIdentity.getCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, Object.class));
 
-        DigestPassword elytronDigest = elytronIdentity.getCredential(DigestPassword.class, null);
+        DigestPassword elytronDigest = elytronIdentity.getCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, DigestPassword.class);
         assertNotNull(elytronDigest);
         String actualHex = ByteIterator.ofBytes(elytronDigest.getDigest()).hexEncode().drainToString();
         assertEquals(ELYTRON_PASSWORD_HASH, actualHex);
 
-        assertTrue(elytronIdentity.verifyCredential(goodGuess));
-        assertFalse(elytronIdentity.verifyCredential(badGuess));
+        assertTrue(elytronIdentity.verifyCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, goodGuess));
+        assertFalse(elytronIdentity.verifyCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, badGuess));
 
         elytronIdentity.dispose();
 
         RealmIdentity badIdentity = realm.createRealmIdentity("noone");
-        assertEquals("ClearPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(ClearPassword.class, null));
-        assertEquals("DigestPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(DigestPassword.class, null));
+        assertEquals("ClearPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(PROPERTIES_CLEAR_CREDENTIAL_NAME));
+        assertEquals("DigestPassword", CredentialSupport.UNSUPPORTED, badIdentity.getCredentialSupport(PROPERTIES_DIGEST_CREDENTIAL_NAME));
 
-        assertNull(badIdentity.getCredential(ClearPassword.class, null));
-        assertNull(badIdentity.getCredential(DigestPassword.class, null));
+        assertNull(badIdentity.getCredential(PROPERTIES_CLEAR_CREDENTIAL_NAME, Object.class));
+        assertNull(badIdentity.getCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, Object.class));
 
-        assertFalse(badIdentity.verifyCredential(goodGuess));
-        assertFalse(badIdentity.verifyCredential(badGuess));
+        assertFalse(badIdentity.verifyCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, goodGuess));
+        assertFalse(badIdentity.verifyCredential(PROPERTIES_DIGEST_CREDENTIAL_NAME, badGuess));
 
         badIdentity.dispose();
     }

--- a/src/test/java/org/wildfly/security/auth/provider/jdbc/AttributeMappingTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/jdbc/AttributeMappingTest.java
@@ -41,7 +41,7 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password, firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(getDataSource())
                 .build();
 
@@ -59,7 +59,7 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password, firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear", ClearPassword.ALGORITHM_CLEAR, 1))
                     .withMapper(new AttributeMapper(2, "firstName"))
                     .withMapper(new AttributeMapper(3, "lastName"))
                     .withMapper(new AttributeMapper(4, "email"))
@@ -82,10 +82,10 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear1", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(getDataSource())
                 .principalQuery("SELECT firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear2", ClearPassword.ALGORITHM_CLEAR, 1))
                     .withMapper(new AttributeMapper(1, "firstName"))
                     .withMapper(new AttributeMapper(2, "lastName"))
                     .withMapper(new AttributeMapper(3, "email"))
@@ -112,10 +112,10 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear1", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(getDataSource())
                 .principalQuery("SELECT role_name FROM role_mapping_table WHERE user_name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear2", ClearPassword.ALGORITHM_CLEAR, 1))
                     .withMapper(new AttributeMapper(1, RoleDecoder.KEY_ROLES))
                     .from(getDataSource())
                 .build();
@@ -140,7 +140,7 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT role_name FROM role_mapping_table WHERE user_name = ?")
-                .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                .withMapper(new PasswordKeyMapper("clear", ClearPassword.ALGORITHM_CLEAR, 1))
                 .withMapper(new AttributeMapper(1, RoleDecoder.KEY_ROLES))
                 .from(getDataSource())
                 .build();
@@ -167,11 +167,11 @@ public class AttributeMappingTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT role_name FROM role_mapping_table WHERE user_name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear1", ClearPassword.ALGORITHM_CLEAR, 1))
                     .withMapper(new AttributeMapper(1, allInOneAttributeName))
                     .from(getDataSource())
                 .principalQuery("SELECT firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear2", ClearPassword.ALGORITHM_CLEAR, 1))
                     .withMapper(new AttributeMapper(1, allInOneAttributeName))
                     .withMapper(new AttributeMapper(2, allInOneAttributeName))
                     .withMapper(new AttributeMapper(3, allInOneAttributeName))

--- a/src/test/java/org/wildfly/security/auth/provider/jdbc/AuthorizationIdentityTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/jdbc/AuthorizationIdentityTest.java
@@ -40,7 +40,7 @@ public class AuthorizationIdentityTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password, firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(getDataSource())
                 .build();
 
@@ -58,7 +58,7 @@ public class AuthorizationIdentityTest extends AbstractJdbcSecurityRealmTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password, firstName, lastName, email FROM user_table WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("clear", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(getDataSource())
                 .build();
 

--- a/src/test/java/org/wildfly/security/auth/provider/jdbc/PasswordSupportTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/jdbc/PasswordSupportTest.java
@@ -71,27 +71,28 @@ public class PasswordSupportTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password FROM user_clear_password WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("cred1", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(ClearPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred1"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(ClearPassword.class, null));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred1"));
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
         ClearPassword password = (ClearPassword) passwordFactory.generatePassword(new ClearPasswordSpec(userPassword.toCharArray()));
 
-        assertTrue(realmIdentity.verifyCredential(password));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
+        assertTrue(realmIdentity.verifyCredential("cred1", password));
+        assertTrue(realmIdentity.verifyCredential("cred1", userPassword.toCharArray()));
 
         Password invalidPassword = passwordFactory.generatePassword(new ClearPasswordSpec("badpasswd".toCharArray()));
 
-        assertFalse(realmIdentity.verifyCredential(invalidPassword));
+        assertFalse(realmIdentity.verifyCredential("cred1", invalidPassword));
+        assertFalse(realmIdentity.verifyCredential("cred2", invalidPassword));
 
-        ClearPassword storedPassword = realmIdentity.getCredential(ClearPassword.class, null);
+        ClearPassword storedPassword = realmIdentity.getCredential("cred1", ClearPassword.class);
 
         assertNotNull(storedPassword);
         assertArrayEquals(password.getPassword(), storedPassword.getPassword());
@@ -107,20 +108,20 @@ public class PasswordSupportTest {
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password FROM user_bcrypt_password where name = ?")
                 .withMapper(
-                        new PasswordKeyMapper(BCryptPassword.ALGORITHM_BCRYPT, 1)
+                        new PasswordKeyMapper("cred2", BCryptPassword.ALGORITHM_BCRYPT, 1)
                 )
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(BCryptPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred2"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(BCryptPassword.class, null));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
-        assertFalse(realmIdentity.verifyCredential("invalid".toCharArray()));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred2"));
+        assertTrue(realmIdentity.verifyCredential("cred2", userPassword.toCharArray()));
+        assertFalse(realmIdentity.verifyCredential("cred2", "invalid".toCharArray()));
 
-        BCryptPassword storedPassword = realmIdentity.getCredential(BCryptPassword.class, null);
+        BCryptPassword storedPassword = realmIdentity.getCredential("cred2", BCryptPassword.class);
 
         assertNotNull(storedPassword);
 
@@ -140,20 +141,20 @@ public class PasswordSupportTest {
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password, salt, iterationCount FROM user_bcrypt_password where name = ?")
                 .withMapper(
-                        new PasswordKeyMapper(BCryptPassword.ALGORITHM_BCRYPT, 1, 2, 3)
+                        new PasswordKeyMapper("cred3", BCryptPassword.ALGORITHM_BCRYPT, 1, 2, 3)
                 )
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(BCryptPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred3"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(BCryptPassword.class, null));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
-        assertFalse(realmIdentity.verifyCredential("invalid".toCharArray()));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred3"));
+        assertTrue(realmIdentity.verifyCredential("cred3", userPassword.toCharArray()));
+        assertFalse(realmIdentity.verifyCredential("cred3", "invalid".toCharArray()));
 
-        BCryptPassword storedPassword = realmIdentity.getCredential(BCryptPassword.class, null);
+        BCryptPassword storedPassword = realmIdentity.getCredential("cred3", BCryptPassword.class);
 
         assertNotNull(storedPassword);
     }
@@ -177,19 +178,19 @@ public class PasswordSupportTest {
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT digest, salt FROM user_salted_digest_password where name = ?")
                 .withMapper(
-                        new PasswordKeyMapper(algorithm, 1, 2)
+                        new PasswordKeyMapper("cred4", algorithm, 1, 2)
                 )
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(SaltedSimpleDigestPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred4"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(SaltedSimpleDigestPassword.class, null));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred4"));
+        assertTrue(realmIdentity.verifyCredential("cred4", userPassword.toCharArray()));
 
-        SaltedSimpleDigestPassword storedPassword = realmIdentity.getCredential(SaltedSimpleDigestPassword.class, null);
+        SaltedSimpleDigestPassword storedPassword = realmIdentity.getCredential("cred4", SaltedSimpleDigestPassword.class);
 
         assertNotNull(storedPassword);
         assertArrayEquals(password.getDigest(), storedPassword.getDigest());
@@ -212,19 +213,19 @@ public class PasswordSupportTest {
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT digest FROM user_simple_digest_password where name = ?")
                 .withMapper(
-                        new PasswordKeyMapper(algorithm, 1)
+                        new PasswordKeyMapper("cred5", algorithm, 1)
                 )
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(SimpleDigestPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred5"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(SimpleDigestPassword.class, null));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred5"));
+        assertTrue(realmIdentity.verifyCredential("cred5", userPassword.toCharArray()));
 
-        SimpleDigestPassword storedPassword = realmIdentity.getCredential(SimpleDigestPassword.class, null);
+        SimpleDigestPassword storedPassword = realmIdentity.getCredential("cred5", SimpleDigestPassword.class);
 
         assertNotNull(storedPassword);
         assertArrayEquals(password.getDigest(), storedPassword.getDigest());
@@ -240,19 +241,19 @@ public class PasswordSupportTest {
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT digest, salt, iterationCount FROM user_scram_digest_password where name = ?")
                 .withMapper(
-                        new PasswordKeyMapper(ScramDigestPassword.ALGORITHM_SCRAM_SHA_256, 1, 2, 3)
+                        new PasswordKeyMapper("cred6", ScramDigestPassword.ALGORITHM_SCRAM_SHA_256, 1, 2, 3)
                 )
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(ScramDigestPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred6"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(ScramDigestPassword.class, null));
-        assertTrue(realmIdentity.verifyCredential(userPassword.toCharArray()));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred6"));
+        assertTrue(realmIdentity.verifyCredential("cred6", userPassword.toCharArray()));
 
-        ScramDigestPassword storedPassword = realmIdentity.getCredential(ScramDigestPassword.class, null);
+        ScramDigestPassword storedPassword = realmIdentity.getCredential("cred6", ScramDigestPassword.class);
 
         assertNotNull(storedPassword);
         assertArrayEquals(passwordSpec.getHash(), storedPassword.getDigest());
@@ -272,12 +273,12 @@ public class PasswordSupportTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT privateKey FROM user_rsa_keys where name = ?")
-                .withMapper(new RSAPrivateKeyMapper(1))
+                .withMapper(new RSAPrivateKeyMapper("cred7", 1))
                 .from(dataSourceRule.getDataSource())
                 .build();
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
-        PrivateKey identityPrivateKey = realmIdentity.getCredential(PrivateKey.class, null);
+        PrivateKey identityPrivateKey = realmIdentity.getCredential("cred7", PrivateKey.class);
 
         assertNotNull(identityPrivateKey);
         assertEquals(privateKey, identityPrivateKey);
@@ -299,22 +300,22 @@ public class PasswordSupportTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT pk.privateKey, cp.password FROM user_rsa_keys pk INNER JOIN user_clear_password cp on cp.name = pk.name WHERE pk.name = ?")
-                .withMapper(new RSAPrivateKeyMapper(1))
-                .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 2))
+                .withMapper(new RSAPrivateKeyMapper("cred8", 1))
+                .withMapper(new PasswordKeyMapper("cred9", ClearPassword.ALGORITHM_CLEAR, 2))
                 .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(ClearPassword.class, null));
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(PrivateKey.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred8"));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred9"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        PrivateKey identityPrivateKey = realmIdentity.getCredential(PrivateKey.class, null);
+        PrivateKey identityPrivateKey = realmIdentity.getCredential("cred8", PrivateKey.class);
 
         assertNotNull(identityPrivateKey);
         assertEquals(privateKey, identityPrivateKey);
 
-        ClearPassword identityClearPassword = realmIdentity.getCredential(ClearPassword.class, null);
+        ClearPassword identityClearPassword = realmIdentity.getCredential("cred9", ClearPassword.class);
 
         assertNotNull(identityClearPassword);
     }
@@ -332,24 +333,24 @@ public class PasswordSupportTest {
 
         JdbcSecurityRealm securityRealm = JdbcSecurityRealm.builder()
                 .principalQuery("SELECT password FROM user_clear_password WHERE name = ?")
-                    .withMapper(new PasswordKeyMapper(ClearPassword.ALGORITHM_CLEAR, 1))
+                    .withMapper(new PasswordKeyMapper("cred10", ClearPassword.ALGORITHM_CLEAR, 1))
                     .from(dataSourceRule.getDataSource())
                 .principalQuery("SELECT privateKey FROM user_rsa_keys where name = ?")
-                    .withMapper(new RSAPrivateKeyMapper(1))
+                    .withMapper(new RSAPrivateKeyMapper("cred11", 1))
                     .from(dataSourceRule.getDataSource())
                 .build();
 
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(PrivateKey.class, null));
-        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport(ClearPassword.class, null));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred10"));
+        assertEquals(CredentialSupport.UNKNOWN, securityRealm.getCredentialSupport("cred11"));
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity(userName);
 
-        assertEquals(CredentialSupport.OBTAINABLE_ONLY, realmIdentity.getCredentialSupport(PrivateKey.class, null));
-        assertEquals(CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport(ClearPassword.class, null));
+        assertEquals(CredentialSupport.UNSUPPORTED, realmIdentity.getCredentialSupport("cred10"));
+        assertEquals(CredentialSupport.OBTAINABLE_ONLY, realmIdentity.getCredentialSupport("cred11"));
 
         insertUserWithClearPassword(userName, "john_clear_abcd1234");
 
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport(ClearPassword.class, null));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, realmIdentity.getCredentialSupport("cred10"));
     }
 
     private void createRSAKeysTable(String userName, PrivateKey privateKey, PublicKey publicKey) throws Exception {

--- a/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
@@ -213,11 +213,12 @@ public class ElytronPolicyEnforcementTest extends AbstractAuthorizationTestCase 
     }
 
     private void addUser(Map<String, SimpleRealmEntry> securityRealm, String userName, String roles) {
-        Password defaultUnsecurePassword;
+        Map<String, Password> defaultUnsecurePasswords;
 
         try {
-            defaultUnsecurePassword = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR)
-                    .generatePassword(new ClearPasswordSpec("password".toCharArray()));
+            defaultUnsecurePasswords = Collections.singletonMap("clear",
+                    PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR)
+                    .generatePassword(new ClearPasswordSpec("password".toCharArray())));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -226,6 +227,6 @@ public class ElytronPolicyEnforcementTest extends AbstractAuthorizationTestCase 
 
         attributes.addAll(RoleDecoder.KEY_ROLES, Arrays.asList(roles));
 
-        securityRealm.put(userName, new SimpleRealmEntry(defaultUnsecurePassword, attributes));
+        securityRealm.put(userName, new SimpleRealmEntry(defaultUnsecurePasswords, attributes));
     }
 }

--- a/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
@@ -172,7 +172,7 @@ public class LinkPolicyConfigurationTest {
 
         attributes.addAll(RoleDecoder.KEY_ROLES, Arrays.asList(roles));
 
-        realm.setPasswordMap(userName, PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(new ClearPasswordSpec(userName.toCharArray())), attributes);
+        realm.setPasswordMap(userName, "clear", PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(new ClearPasswordSpec(userName.toCharArray())), attributes);
 
         builder.setDefaultRealmName("default");
 

--- a/src/test/java/org/wildfly/security/ldap/PasswordSupportTest.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordSupportTest.java
@@ -38,14 +38,13 @@ import org.wildfly.security.password.interfaces.OneTimePassword;
 import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
 import org.wildfly.security.password.interfaces.SimpleDigestPassword;
 import org.wildfly.security.password.interfaces.UnixDESCryptPassword;
-import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -80,76 +79,54 @@ public class PasswordSupportTest {
 
     @Test
     public void testPlainUser() throws Exception {
-        performSimpleNameTest("plainUser", ClearPassword.class, ClearPassword.ALGORITHM_CLEAR, "plainPassword".toCharArray());
-    }
-
-    @Test
-    public void testPlainUserVerifyOnRealmIdentity() throws Exception {
-        RealmIdentity realmIdentity = simpleToDnRealm.createRealmIdentity("plainUser");
-        ClearPasswordSpec passwordSpec = new ClearPasswordSpec("plainPassword".toCharArray());
-        PasswordFactory instance = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
-        Password password = instance.generatePassword(passwordSpec);
-
-        verifyPasswordSupport(realmIdentity, ClearPassword.class);
-        assertTrue(realmIdentity.verifyCredential(password));
-    }
-
-    @Test
-    public void testPlainUserVerifyFailedOnRealmIdentity() throws Exception {
-        RealmIdentity realmIdentity = simpleToDnRealm.createRealmIdentity("plainUser");
-        ClearPasswordSpec invalidPasswordSpec = new ClearPasswordSpec("invalidPassword".toCharArray());
-        PasswordFactory instance = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
-        Password invalidPassword = instance.generatePassword(invalidPasswordSpec);
-
-        verifyPasswordSupport(realmIdentity, ClearPassword.class);
-        assertFalse(realmIdentity.verifyCredential(invalidPassword));
+        performSimpleNameTest("plainUser", "userPassword-clear", ClearPassword.ALGORITHM_CLEAR, "plainPassword".toCharArray());
     }
 
     @Test
     public void testMd5User() throws Exception {
-        performSimpleNameTest("md5User", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD5,
+        performSimpleNameTest("md5User", "userPassword-md5", SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD5,
                 "md5Password".toCharArray());
     }
 
     @Test
     public void testSmd5User() throws Exception {
-        performSimpleNameTest("smd5User", SaltedSimpleDigestPassword.class, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "smd5Password".toCharArray());
+        performSimpleNameTest("smd5User", "userPassword-smd5", SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "smd5Password".toCharArray());
     }
 
     @Test
     public void testSha512User() throws Exception {
-        performSimpleNameTest("sha512User", SimpleDigestPassword.class, SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512, "sha512Password".toCharArray());
+        performSimpleNameTest("sha512User", "userPassword-sha512", SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512, "sha512Password".toCharArray());
     }
 
     @Test
     public void testSsha512User() throws Exception {
-        performSimpleNameTest("ssha512User", SaltedSimpleDigestPassword.class, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, "ssha512Password".toCharArray());
+        performSimpleNameTest("ssha512User", "userPassword-ssha512", SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, "ssha512Password".toCharArray());
     }
 
     @Test
     public void testCryptUser() throws Exception {
-        performSimpleNameTest("cryptUser", UnixDESCryptPassword.class, UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptIt".toCharArray());
+        performSimpleNameTest("cryptUser", "userPassword-crypt", UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptIt".toCharArray());
     }
 
     @Test
     public void testCryptUserLongPassword() throws Exception {
-        performSimpleNameTest("cryptUserLong", UnixDESCryptPassword.class, UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptPassword".toCharArray());
+        performSimpleNameTest("cryptUserLong", "userPassword-crypt", UnixDESCryptPassword.ALGORITHM_CRYPT_DES, "cryptPassword".toCharArray());
     }
 
     @Test
     public void testBsdCryptUser() throws Exception {
-        performSimpleNameTest("bsdCryptUser", BSDUnixDESCryptPassword.class, BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES, "cryptPassword".toCharArray());
+        performSimpleNameTest("bsdCryptUser", "userPassword-crypt_", BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES, "cryptPassword".toCharArray());
     }
 
     @Test
     public void testOneTimePasswordUser0() throws Exception {
-        CredentialSupport support = simpleToDnRealm.getCredentialSupport(OneTimePassword.class, null);
+        CredentialSupport support = simpleToDnRealm.getCredentialSupport("otp");
         assertEquals("Pre identity", CredentialSupport.UNKNOWN, support);
 
         RealmIdentity identity = simpleToDnRealm.createRealmIdentity("userWithOtp");
-        verifyPasswordSupport(identity, OneTimePassword.class);
+        verifyPasswordSupport(identity, "otp", CredentialSupport.FULLY_SUPPORTED);
 
-        OneTimePassword otp = identity.getCredential(OneTimePassword.class, "otp-sha1");
+        OneTimePassword otp = identity.getCredential("otp", OneTimePassword.class);
         assertNotNull(otp);
         assertEquals(1234, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'a', 'b', 'c', 'd' }, otp.getHash());
@@ -166,17 +143,17 @@ public class PasswordSupportTest {
         ModifiableRealmIdentity identity = (ModifiableRealmIdentity) simpleToDnRealm.createRealmIdentity("userWithOtp");
         assertNotNull(identity);
 
-        assertEquals(CredentialSupport.UNKNOWN, simpleToDnRealm.getCredentialSupport(OneTimePassword.class, "otp-sha1"));
-        assertEquals(CredentialSupport.FULLY_SUPPORTED, identity.getCredentialSupport(OneTimePassword.class, "otp-sha1"));
+        assertEquals(CredentialSupport.UNKNOWN, simpleToDnRealm.getCredentialSupport("otp"));
+        assertEquals(CredentialSupport.FULLY_SUPPORTED, identity.getCredentialSupport("otp"));
 
-        identity.setCredential(password);
+        identity.setCredential("otp", password);
 
         ModifiableRealmIdentity newIdentity = (ModifiableRealmIdentity) simpleToDnRealm.createRealmIdentity("userWithOtp");
         assertNotNull(newIdentity);
 
-        verifyPasswordSupport(newIdentity, OneTimePassword.class);
+        verifyPasswordSupport(newIdentity, "otp", CredentialSupport.FULLY_SUPPORTED);
 
-        OneTimePassword otp = newIdentity.getCredential(OneTimePassword.class, "otp-sha1");
+        OneTimePassword otp = newIdentity.getCredential("otp", OneTimePassword.class);
         assertNotNull(otp);
         assertEquals(4321, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'i', 'j', 'k' }, otp.getHash());
@@ -193,41 +170,41 @@ public class PasswordSupportTest {
         ModifiableRealmIdentity identity = (ModifiableRealmIdentity) simpleToDnRealm.createRealmIdentity("userWithOtp");
         assertNotNull(identity);
 
-        identity.setCredentials(Collections.EMPTY_LIST);
-        identity.setCredentials(Collections.EMPTY_LIST); // double clearing should not fail
+        identity.setCredentials(Collections.EMPTY_MAP);
+        identity.setCredentials(Collections.EMPTY_MAP); // double clearing should not fail
 
-        List<Object> credentials = new LinkedList<>();
-        credentials.add(password);
+        Map<String, Object> credentials = new HashMap<String, Object>();
+        credentials.put("otp", password);
         identity.setCredentials(credentials);
 
         ModifiableRealmIdentity newIdentity = (ModifiableRealmIdentity) simpleToDnRealm.createRealmIdentity("userWithOtp");
         assertNotNull(newIdentity);
 
-        verifyPasswordSupport(newIdentity, OneTimePassword.class);
+        verifyPasswordSupport(newIdentity, "otp", CredentialSupport.FULLY_SUPPORTED);
 
-        OneTimePassword otp = newIdentity.getCredential(OneTimePassword.class, "otp-sha1");
+        OneTimePassword otp = newIdentity.getCredential("otp", OneTimePassword.class);
         assertNotNull(otp);
         assertEquals(65, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'o', 'p', 'q' }, otp.getHash());
         Assert.assertArrayEquals(new byte[] { 'r', 's', 't' }, otp.getSeed());
     }
 
-    private void performSimpleNameTest(String simpleName, Class<?> credentialType, String algorithm, char[] password) throws NoSuchAlgorithmException, InvalidKeyException, RealmUnavailableException {
+    private void performSimpleNameTest(String simpleName, String credentialName, String algorithm, char[] password) throws NoSuchAlgorithmException, InvalidKeyException, RealmUnavailableException {
         RealmIdentity realmIdentity = simpleToDnRealm.createRealmIdentity(simpleName);
-        CredentialSupport support = simpleToDnRealm.getCredentialSupport(credentialType, null);
+        CredentialSupport support = simpleToDnRealm.getCredentialSupport(credentialName);
         assertEquals("Pre identity", CredentialSupport.UNKNOWN, support);
 
-        verifyPasswordSupport(realmIdentity, credentialType);
-        verifyPassword(realmIdentity, credentialType, algorithm, password);
+        verifyPasswordSupport(realmIdentity, credentialName, CredentialSupport.FULLY_SUPPORTED);
+        verifyPassword(realmIdentity, credentialName, algorithm, password);
     }
 
-    private void verifyPasswordSupport(RealmIdentity identity, Class<?> credentialType) throws RealmUnavailableException {
-        CredentialSupport credentialSupport = identity.getCredentialSupport(credentialType, null);
-        assertEquals("Identity level support", CredentialSupport.FULLY_SUPPORTED, credentialSupport);
+    private void verifyPasswordSupport(RealmIdentity identity, String credentialName, CredentialSupport requiredSupport) throws RealmUnavailableException {
+        CredentialSupport credentialSupport = identity.getCredentialSupport(credentialName);
+        assertEquals("Identity level support", requiredSupport, credentialSupport);
     }
 
-    private void verifyPassword(RealmIdentity identity, Class<?> credentialType, String algorithm, char[] password) throws NoSuchAlgorithmException, InvalidKeyException, RealmUnavailableException {
-        Password loadedPassword = (Password) identity.getCredential(credentialType, null);
+    private void verifyPassword(RealmIdentity identity, String credentialName, String algorithm, char[] password) throws NoSuchAlgorithmException, InvalidKeyException, RealmUnavailableException {
+        Password loadedPassword = identity.getCredential(credentialName, Password.class);
 
         PasswordFactory factory = PasswordFactory.getInstance(algorithm);
         final Password translated = factory.translate(loadedPassword);

--- a/src/test/java/org/wildfly/security/ldap/PasswordValidationTest.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordValidationTest.java
@@ -21,6 +21,7 @@ package org.wildfly.security.ldap;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder;
+import org.wildfly.security.auth.server.CredentialSupport;
 import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.password.Password;
@@ -28,6 +29,7 @@ import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -54,7 +56,10 @@ public class PasswordValidationTest {
         PasswordFactory instance = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
         Password password = instance.generatePassword(passwordSpec);
 
-        assertTrue(realmIdentity.verifyCredential(password));
+        CredentialSupport credentialSupport = realmIdentity.getCredentialSupport("ldap-verifiable");
+        assertEquals("Identity level support", CredentialSupport.VERIFIABLE_ONLY, credentialSupport);
+
+        assertTrue(realmIdentity.verifyCredential("ldap-verifiable", password));
     }
 
     @Test
@@ -72,7 +77,10 @@ public class PasswordValidationTest {
         PasswordFactory instance = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
         Password password = instance.generatePassword(passwordSpec);
 
-        assertTrue(realmIdentity.verifyCredential(password));
+        CredentialSupport credentialSupport = realmIdentity.getCredentialSupport("ldap-verifiable");
+        assertEquals("Identity level support", CredentialSupport.VERIFIABLE_ONLY, credentialSupport);
+
+        assertTrue(realmIdentity.verifyCredential("ldap-verifiable", password));
     }
 
     @Test
@@ -88,7 +96,7 @@ public class PasswordValidationTest {
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity("uid=plainUser,dc=elytron,dc=wildfly,dc=org");
 
-        assertTrue(realmIdentity.verifyCredential("plainPassword".toCharArray()));
+        assertTrue(realmIdentity.verifyCredential("ldap-verifiable", "plainPassword".toCharArray()));
     }
 
     @Test (expected = RuntimeException.class)
@@ -104,6 +112,6 @@ public class PasswordValidationTest {
 
         RealmIdentity realmIdentity = securityRealm.createRealmIdentity("uid=plainUser,dc=elytron,dc=wildfly,dc=org");
 
-        assertTrue(realmIdentity.verifyCredential(Integer.valueOf(123456)));
+        realmIdentity.verifyCredential("ldap-verifiable", Integer.valueOf(123456));
     }
 }

--- a/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -25,6 +25,7 @@ import static org.wildfly.security.sasl.test.BaseTestCase.obtainSaslServerFactor
 
 import java.security.Permissions;
 import java.security.spec.KeySpec;
+import java.util.Arrays;
 import java.util.Map;
 
 import javax.net.ssl.X509KeyManager;
@@ -55,6 +56,8 @@ public class SaslServerBuilder {
     //Server factory info
     private final Class<? extends SaslServerFactory> serverFactoryClass;
     private final String mechanismName;
+
+    private String TESTING_CREDENTIAL = "password";
 
     //Security domain info
     private String username;
@@ -164,9 +167,10 @@ public class SaslServerBuilder {
         final SimpleMapBackedSecurityRealm mainRealm = new SimpleMapBackedSecurityRealm();
         domainBuilder.addRealm(realmName, mainRealm);
         domainBuilder.setDefaultRealmName(defaultRealmName);
+        domainBuilder.setCredentialMapper((information -> Arrays.asList(TESTING_CREDENTIAL)));
 
         if (username != null) {
-            mainRealm.setPasswordMap(username, password);
+            mainRealm.setPasswordMap(username, TESTING_CREDENTIAL, password);
         }
 
         if (permissionsMap != null) {

--- a/src/test/resources/org/wildfly/security/auth/passwd
+++ b/src/test/resources/org/wildfly/security/auth/passwd
@@ -1,2 +1,2 @@
-elytron:$1$|¤KL,$ZSvdKpF1mislJPkYPlxtu/
-javajoe:$2a$10$EdB9Mh6gXMycr7FqfFGNXeeTBmyCq3UgGlNEdaMxGqwOnthcN7NRS
+elytron|credential1:$1$|¤KL,$ZSvdKpF1mislJPkYPlxtu/
+javajoe|credential2:$2a$10$EdB9Mh6gXMycr7FqfFGNXeeTBmyCq3UgGlNEdaMxGqwOnthcN7NRS


### PR DESCRIPTION
API change by https://issues.jboss.org/browse/ELY-282

* credentials identified by `credentialName`, not by `type`+`algorithm`
* `FileSystemSecurityRealm`, `SimpleMapBackedSecurityRealm` and `KeyStoreBackedSecurityRealm`  allow store any type of credential into any credential name (store credentialName as part of credential or as username suffix)
* `JaasSecurityRealm` use one special credentialName - `"jass"`
* `LegacyPropertiesSecurityRealm` use one special credentialNames `"properties-clear"` and `"properties-digest"`
* `LdapSecurityRealm` map credentail attribute name and algorithm into credential name
* `JdbcSecurityRealm` allow define credential name as part of credential column definition

Tests:
* Whole testing of `"ldap-verifiable"` in `ldap.PasswordValidationTest` (part was in `ldap.PasswordSupportTest`)