### PR TITLE
LdapRealm - password persisting

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -373,8 +373,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1085, value = "No Ldap-backed realm's persister support credential name \"%s\"")
     RealmUnavailableException ldapRealmsPersisterNotSupportCredentialName(String credentialName);
 
-    @Message(id = 1086, value = "Persisting credential %s into Ldap-backed realm failed. Identity dn: \"%s\"")
-    RealmUnavailableException ldapRealmCredentialPersistingFailed(String credential, String dn, @Cause Throwable cause);
+    @Message(id = 1086, value = "Persisting credential %s with name \"%s\" into Ldap-backed realm failed. Identity dn: \"%s\"")
+    RealmUnavailableException ldapRealmCredentialPersistingFailed(String credential, String credentialName, String dn, @Cause Throwable cause);
 
     @Message(id = 1087, value = "Clearing credentials from Ldap-backed realm failed. Identity dn: \"%s\"")
     RealmUnavailableException ldapRealmCredentialClearingFailed(String dn, @Cause Throwable cause);
@@ -384,6 +384,9 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1089, value = "Attempting to run as \"%s\" authorization check failed (permission denied)")
     AuthorizationCheckException unauthorizedRunAs(@Param Principal principal, Principal runAsPrincipal, @Param RunAsPrincipalPermission permission);
+
+    @Message(id = 1090, value = "Unknown LDAP password scheme")
+    InvalidKeySpecException unknownLdapPasswordScheme();
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/OtpCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/OtpCredentialLoader.java
@@ -162,7 +162,7 @@ public class OtpCredentialLoader implements CredentialLoader, CredentialPersiste
 
                 context.modifyAttributes(distinguishedName, DirContext.REPLACE_ATTRIBUTE, attributes);
             } catch (NamingException e) {
-                throw log.ldapRealmCredentialPersistingFailed(credential.toString(), distinguishedName, e);
+                throw log.ldapRealmCredentialPersistingFailed(credential.toString(), credentialName, distinguishedName, e);
             } finally {
                 contextFactory.returnContext(context);
             }

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/UserPasswordCredentialLoader.java
@@ -20,7 +20,21 @@ package org.wildfly.security.auth.provider.ldap;
 
 import static org.wildfly.security._private.ElytronMessages.*;
 import static org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil.parseUserPassword;
+import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384;
+import static org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512;
+import static org.wildfly.security.password.interfaces.SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD5;
+import static org.wildfly.security.password.interfaces.SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_1;
+import static org.wildfly.security.password.interfaces.SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_256;
+import static org.wildfly.security.password.interfaces.SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_384;
+import static org.wildfly.security.password.interfaces.SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512;
+import static org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES;
+import static org.wildfly.security.password.interfaces.UnixDESCryptPassword.ALGORITHM_CRYPT_DES;
 
+import java.io.IOException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,11 +42,19 @@ import java.util.Map;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
+import javax.naming.directory.NoSuchAttributeException;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.auth.server.CredentialSupport;
+
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
+
+import org.wildfly.security.auth.server.RealmUnavailableException;
+
 import org.wildfly.security.password.Password;
 
 /**
@@ -40,25 +62,25 @@ import org.wildfly.security.password.Password;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class UserPasswordCredentialLoader implements CredentialLoader {
+class UserPasswordCredentialLoader implements CredentialLoader, CredentialPersister {
 
     static final String DEFAULT_USER_PASSWORD_ATTRIBUTE_NAME = "userPassword";
-    static Map<String, CredentialSupport> DEFAULT_CREDENTIAL_SUPPORT = new HashMap<>();
+    static Map<String, String> CREDENTIAL_TO_ALGORITHM = new HashMap<>();
 
     static {
-        DEFAULT_CREDENTIAL_SUPPORT.put("clear", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("md5", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("sha1", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("sha256", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("sha384", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("sha512", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("smd5", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("ssha", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("ssha256", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("ssha384", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("ssha512", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("crypt_", CredentialSupport.UNKNOWN);
-        DEFAULT_CREDENTIAL_SUPPORT.put("crypt", CredentialSupport.UNKNOWN);
+        CREDENTIAL_TO_ALGORITHM.put("clear", ALGORITHM_CLEAR);
+        CREDENTIAL_TO_ALGORITHM.put("md5", ALGORITHM_SIMPLE_DIGEST_MD5);
+        CREDENTIAL_TO_ALGORITHM.put("sha1", ALGORITHM_SIMPLE_DIGEST_SHA_1);
+        CREDENTIAL_TO_ALGORITHM.put("sha256", ALGORITHM_SIMPLE_DIGEST_SHA_256);
+        CREDENTIAL_TO_ALGORITHM.put("sha384", ALGORITHM_SIMPLE_DIGEST_SHA_384);
+        CREDENTIAL_TO_ALGORITHM.put("sha512", ALGORITHM_SIMPLE_DIGEST_SHA_512);
+        CREDENTIAL_TO_ALGORITHM.put("smd5", ALGORITHM_PASSWORD_SALT_DIGEST_MD5);
+        CREDENTIAL_TO_ALGORITHM.put("ssha", ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1);
+        CREDENTIAL_TO_ALGORITHM.put("ssha256", ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256);
+        CREDENTIAL_TO_ALGORITHM.put("ssha384", ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384);
+        CREDENTIAL_TO_ALGORITHM.put("ssha512", ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512);
+        CREDENTIAL_TO_ALGORITHM.put("crypt_", ALGORITHM_BSD_CRYPT_DES);
+        CREDENTIAL_TO_ALGORITHM.put("crypt", ALGORITHM_CRYPT_DES);
     }
 
     private final String userPasswordAttributeName;
@@ -70,26 +92,25 @@ class UserPasswordCredentialLoader implements CredentialLoader {
     @Override
     public CredentialSupport getCredentialSupport(DirContextFactory contextFactory, String credentialName) {
 
-        String[] credentialNameParts = credentialName.split("-");
-        if (credentialNameParts.length < 2 || ! credentialNameParts[0].equals(userPasswordAttributeName)) {
+        int delimiter = credentialName.lastIndexOf('-');
+        if (delimiter <= 0) {
+            return CredentialSupport.UNSUPPORTED;
+        }
+        String credentialAttribute = credentialName.substring(0, delimiter);
+        String credentialTypeName = credentialName.substring(delimiter + 1);
+        if (! credentialAttribute.equals(userPasswordAttributeName)) {
             return CredentialSupport.UNSUPPORTED;
         }
 
-        CredentialSupport response = DEFAULT_CREDENTIAL_SUPPORT.get(credentialNameParts[1]);
-
-        if (response == null) {
-            return CredentialSupport.UNSUPPORTED;
-        }
-
-        return response;
+        return CREDENTIAL_TO_ALGORITHM.containsKey(credentialTypeName) ? CredentialSupport.UNKNOWN : CredentialSupport.UNSUPPORTED;
     }
 
     @Override
-    public IdentityCredentialLoader forIdentity(DirContextFactory contextFactory, String distinguishedName) {
+    public ForIdentityLoader forIdentity(DirContextFactory contextFactory, String distinguishedName) {
         return new ForIdentityLoader(contextFactory, distinguishedName);
     }
 
-    private class ForIdentityLoader implements IdentityCredentialLoader {
+    private class ForIdentityLoader implements IdentityCredentialLoader, IdentityCredentialPersister {
 
         private final DirContextFactory contextFactory;
         private final String distinguishedName;
@@ -112,20 +133,27 @@ class UserPasswordCredentialLoader implements CredentialLoader {
         @Override
         public <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) {
             DirContext context = null;
-            String[] credentialNameParts = credentialName.split("-");
-            if (credentialNameParts.length < 2) {
+
+            int delimiter = credentialName.lastIndexOf('-');
+            if (delimiter <= 0) {
                 if (log.isTraceEnabled()) log.trace("User-password credential name \"" + credentialName + "\" is not in attribute-type form - not supported by LDAP realm");
                 return null;
             }
+            String credentialAttribute = credentialName.substring(0, delimiter);
+            String credentialTypeName = credentialName.substring(delimiter + 1);
+
             try {
                 context = contextFactory.obtainDirContext(null);
 
-                Attributes attributes = context.getAttributes(distinguishedName, new String[] { credentialNameParts[0] });
-                Attribute attribute = attributes.get(credentialNameParts[0]);
+                Attributes attributes = context.getAttributes(distinguishedName, new String[] { credentialAttribute });
+                Attribute attribute = attributes.get(credentialAttribute);
                 for (int i = 0; i < attribute.size(); i++) {
                     byte[] value = (byte[]) attribute.get(i);
 
-                    Password password = parseUserPassword(value, credentialNameParts[1]);
+                    Password password = parseUserPassword(value);
+
+                    String expectedAlgorithm = CREDENTIAL_TO_ALGORITHM.get(credentialTypeName);
+                    if (expectedAlgorithm != password.getAlgorithm()) return null;
 
                     if (credentialType.isAssignableFrom(PasswordCredential.class)) {
                         return credentialType.cast(new PasswordCredential(password));
@@ -139,6 +167,62 @@ class UserPasswordCredentialLoader implements CredentialLoader {
                 contextFactory.returnContext(context);
             }
             return null;
+        }
+
+        @Override
+        public boolean getCredentialPersistSupport(String credentialName) {
+
+            int delimiter = credentialName.lastIndexOf('-');
+            if (delimiter <= 0) {
+                return false;
+            }
+            String credentialAttribute = credentialName.substring(0, delimiter);
+            String credentialTypeName = credentialName.substring(delimiter + 1);
+            if (! credentialAttribute.equals(userPasswordAttributeName)) {
+                return false;
+            }
+
+            return CREDENTIAL_TO_ALGORITHM.containsKey(credentialTypeName);
+        }
+
+        @Override
+        public void persistCredential(String credentialName, Credential credential) throws RealmUnavailableException {
+            DirContext context = null;
+            try {
+                context = contextFactory.obtainDirContext(null);
+
+                byte[] composedPassword = UserPasswordPasswordUtil.composeUserPassword((Password) credential);
+                Assert.assertNotNull(composedPassword);
+
+                Attributes attributes = new BasicAttributes();
+                attributes.put(userPasswordAttributeName, composedPassword);
+
+                context.modifyAttributes(distinguishedName, DirContext.ADD_ATTRIBUTE, attributes);
+
+            } catch (NamingException | IOException e) {
+                throw log.ldapRealmCredentialPersistingFailed(credential.toString(), credentialName, distinguishedName, e);
+            } finally {
+                contextFactory.returnContext(context);
+            }
+        }
+
+        @Override
+        public void clearCredentials() throws RealmUnavailableException {
+            DirContext context = null;
+            try {
+                context = contextFactory.obtainDirContext(null);
+
+                Attributes attributes = new BasicAttributes();
+                attributes.put(new BasicAttribute(userPasswordAttributeName));
+
+                context.modifyAttributes(distinguishedName, DirContext.REMOVE_ATTRIBUTE, attributes);
+            } catch (NoSuchAttributeException e) {
+                // ignore if already clear
+            } catch (NamingException e) {
+                throw log.ldapRealmCredentialClearingFailed(distinguishedName, e);
+            } finally {
+                contextFactory.returnContext(context);
+            }
         }
     }
 

--- a/src/test/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtilTest.java
+++ b/src/test/java/org/wildfly/security/auth/provider/ldap/UserPasswordPasswordUtilTest.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.provider.ldap;
+
+import org.junit.Test;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
+import org.wildfly.security.password.interfaces.SimpleDigestPassword;
+import org.wildfly.security.password.interfaces.UnixDESCryptPassword;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test of composing and parsing of individual LDAP passwords in {@link org.wildfly.security.auth.provider.ldap.UserPasswordPasswordUtil}
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class UserPasswordPasswordUtilTest {
+
+    @Test
+    public void testClear() throws Exception {
+        byte[] orig = "{clear}alpha".getBytes();
+        ClearPassword parsedPassword = (ClearPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(ClearPassword.ALGORITHM_CLEAR, parsedPassword.getAlgorithm());
+        assertEquals("alpha", new String(parsedPassword.getPassword()));
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("alpha", new String(composed));
+    }
+
+    @Test
+    public void testClearWithoutPrefix() throws Exception {
+        byte[] orig = "alpha".getBytes();
+        ClearPassword parsedPassword = (ClearPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(ClearPassword.ALGORITHM_CLEAR, parsedPassword.getAlgorithm());
+        assertEquals("alpha", new String(parsedPassword.getPassword()));
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("alpha", new String(composed));
+    }
+
+    @Test
+    public void testMd5() throws Exception {
+        byte[] orig = "{md5}WhBei51A4TKXgNYuoiZdig==".getBytes();
+        SimpleDigestPassword parsedPassword = (SimpleDigestPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_MD5, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{md5}WhBei51A4TKXgNYuoiZdig==", new String(composed));
+    }
+
+    @Test
+    public void testSha1() throws Exception {
+        byte[] orig = "{sha}tESsBmE/yNY3lb6a0L6vVQEZNqw=".getBytes();
+        SimpleDigestPassword parsedPassword = (SimpleDigestPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_1, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{sha}tESsBmE/yNY3lb6a0L6vVQEZNqw=", new String(composed));
+    }
+
+    @Test
+    public void testSha256() throws Exception {
+        byte[] orig = "{sha256}5en6G6MezRroT3XKqkdPOmY/BfQ=".getBytes();
+        SimpleDigestPassword parsedPassword = (SimpleDigestPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_256, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{sha256}5en6G6MezRroT3XKqkdPOmY/BfQ=", new String(composed));
+    }
+
+    @Test
+    public void testSha384() throws Exception {
+        byte[] orig = "{sha384}5en6G6MezRroT3XKqkdPOmY/BfQ=".getBytes();
+        SimpleDigestPassword parsedPassword = (SimpleDigestPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_384, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{sha384}5en6G6MezRroT3XKqkdPOmY/BfQ=", new String(composed));
+    }
+
+    @Test
+    public void testSha512() throws Exception {
+        byte[] orig = "{sha512}5en6G6MezRroT3XKqkdPOmY/BfQ=".getBytes();
+        SimpleDigestPassword parsedPassword = (SimpleDigestPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{sha512}5en6G6MezRroT3XKqkdPOmY/BfQ=", new String(composed));
+    }
+
+    @Test
+    public void testSaltedMd5() throws Exception {
+        byte[] orig = "{smd5}i1GhUWtlHIva18fyzSVoSi6pLqk=".getBytes();
+        Password parsedPassword = UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_MD5, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{smd5}i1GhUWtlHIva18fyzSVoSi6pLqk=", new String(composed));
+    }
+
+    @Test
+    public void testSaltedSha1() throws Exception {
+        byte[] orig = "{ssha}uWg1PmLHZsZUqGOncZBiRTNXE3uHSyGC".getBytes();
+        Password parsedPassword = UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{ssha}uWg1PmLHZsZUqGOncZBiRTNXE3uHSyGC", new String(composed));
+    }
+
+    @Test
+    public void testSaltedSha256() throws Exception {
+        byte[] orig = "{ssha256}NnbD5ZmBpVlY8Ice+uANuNGP30AOiGvFIo8uMJAQZfCGasvDn2F6BQ==".getBytes();
+        Password parsedPassword = UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{ssha256}NnbD5ZmBpVlY8Ice+uANuNGP30AOiGvFIo8uMJAQZfCGasvDn2F6BQ==", new String(composed));
+    }
+
+    @Test
+    public void testSaltedSha384() throws Exception {
+        byte[] orig = "{ssha384}q3/C06GNWsP0pJRZU+a+rFwY9zbzbvY04IQP0SVneH88YohMYkT3BNda+LgjTKgTP3sKZZP6fAU=".getBytes();
+        Password parsedPassword = UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{ssha384}q3/C06GNWsP0pJRZU+a+rFwY9zbzbvY04IQP0SVneH88YohMYkT3BNda+LgjTKgTP3sKZZP6fAU=", new String(composed));
+    }
+
+    @Test
+    public void testSaltedSha512() throws Exception {
+        byte[] orig = "{ssha512}j3i1SgOox/ShzZiMIhTj6EGN7kHvq1TehRVf7YIQXuo7GwradZKGCdmEcy8qCZsUaI+4iPkzbsYjcT8L/yFq+D+GCB4lHEF5".getBytes();
+        Password parsedPassword = UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{ssha512}j3i1SgOox/ShzZiMIhTj6EGN7kHvq1TehRVf7YIQXuo7GwradZKGCdmEcy8qCZsUaI+4iPkzbsYjcT8L/yFq+D+GCB4lHEF5", new String(composed));
+    }
+
+    @Test
+    public void testUnixDesCrypt() throws Exception {
+        byte[] orig = "{crypt}k8d0CodT.v5Nw".getBytes();
+        UnixDESCryptPassword parsedPassword = (UnixDESCryptPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(UnixDESCryptPassword.ALGORITHM_CRYPT_DES, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{crypt}k8d0CodT.v5Nw", new String(composed));
+    }
+
+    @Test
+    public void testBsdDesCrypt() throws Exception {
+        byte[] orig = "{crypt}_N.../TTpyByTVvdmWGo".getBytes();
+        BSDUnixDESCryptPassword parsedPassword = (BSDUnixDESCryptPassword) UserPasswordPasswordUtil.parseUserPassword(orig);
+        assertEquals(BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES, parsedPassword.getAlgorithm());
+
+        byte[] composed = UserPasswordPasswordUtil.composeUserPassword(parsedPassword);
+        assertEquals("{crypt}_N.../TTpyByTVvdmWGo", new String(composed));
+    }
+
+}

--- a/src/test/resources/ldap/elytron-otp-tests.ldif
+++ b/src/test/resources/ldap/elytron-otp-tests.ldif
@@ -41,6 +41,16 @@ m-description: OTP sequence counter
 m-equality: integerMatch
 m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
 
+dn: m-oid=1.3.6.1.4.1.26782.2.3.8, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.26782.2.3.8
+m-name: otpTimeout
+m-description: Time when next OTP guess will be possible (unix epoch seconds)
+m-equality: integerMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+
 dn: m-oid=1.3.6.1.4.1.26782.2.4.1, ou=objectclasses, cn=wildfly, ou=schema
 objectclass: metaObjectClass
 objectclass: metaTop
@@ -52,6 +62,7 @@ m-may: otpAlgorithm
 m-may: otpHash
 m-may: otpSeed
 m-may: otpSequence
+m-may: otpTimeout
 
 # testing users
 dn: uid=userWithOtp,dc=elytron,dc=wildfly,dc=org
@@ -67,3 +78,4 @@ otpAlgorithm: otp-sha1
 otpHash: YWJjZA==
 otpSeed: ZWZnaA==
 otpSequence: 1234
+otpTimeout: 1441211642


### PR DESCRIPTION
* Persisting text passwords (attribute `userPassword`) into LDAP
* Loading password from LDAP case-insensitive for type prefix (`{CRYPT}`/`{SHA1}`/...)
 * Checking of type loaded password separated from parsing
* +added timeout into OTP testing LDIF