### PR TITLE
[ELY-326] Switch to use a Builder for creating CredentialCallback

### DIFF
--- a/src/main/java/org/wildfly/security/auth/callback/CredentialCallback.java
+++ b/src/main/java/org/wildfly/security/auth/callback/CredentialCallback.java
@@ -19,8 +19,13 @@
 package org.wildfly.security.auth.callback;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.wildfly.security.credential.Credential;
 
 /**
@@ -38,9 +43,9 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
     private static final long serialVersionUID = 4756568346009259703L;
 
     /**
-     * @serial The map of allowed credential types.
+     * @serial The map of supported credential types.
      */
-    private final Map<Class<? extends Credential>, Set<String>> allowedTypes;
+    private final Map<Class<? extends Credential>, Set<String>> supportedTypes;
     /**
      * @serial The credential itself.
      */
@@ -49,21 +54,10 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
     /**
      * Construct a new instance.
      *
-     * @param allowedTypes the allowed types of credential
+     * @param supportedTypes the supported types of credential
      */
-    public CredentialCallback(final Map<Class<? extends Credential>, Set<String>> allowedTypes) {
-        this.allowedTypes = allowedTypes;
-    }
-
-    /**
-     * Construct a new instance.
-     *
-     * @param credential the default credential value, if any
-     * @param allowedTypes the allowed types of credential
-     */
-    public CredentialCallback(final Credential credential, final Map<Class<? extends Credential>, Set<String>> allowedTypes) {
-        this(allowedTypes);
-        this.credential = credential;
+    private CredentialCallback(final Map<Class<? extends Credential>, Set<String>> supportedTypes) {
+        this.supportedTypes = supportedTypes;
     }
 
     /**
@@ -94,7 +88,7 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
      * @return {@code true} if the credential is non-{@code null} and supported, {@code false} otherwise
      */
     public boolean isCredentialSupported(final Class<? extends Credential> credentialType, final String algorithm) {
-        final Set<String> set = allowedTypes.get(credentialType);
+        final Set<String> set = supportedTypes.get(credentialType);
         if (set != null) {
             return algorithm == null || set.isEmpty() || set.contains(algorithm);
         } else {
@@ -115,24 +109,24 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
     }
 
     /**
-     * Get the set of allowed types for this credential.
+     * Get the set of supported types for this credential.
      *
-     * @return the (immutable) set of allowed types
+     * @return the (immutable) set of supported types
      */
-    public Set<Class<? extends Credential>> getAllowedTypes() {
-        return allowedTypes.keySet();
+    public Set<Class<? extends Credential>> getSupportedTypes() {
+        return Collections.unmodifiableSet(supportedTypes.keySet());
     }
 
     /**
-     * Get the allowed algorithms for the given exact credential type.  The returned set may be empty, indicating that
+     * Get the supported algorithms for the given exact credential type.  The returned set may be empty, indicating that
      * no algorithm is required for the given credential, or {@code null} indicating that the credential type is not
      * supported.
      *
      * @param type the credential type
-     * @return the (immutable) set of allowed algorithms
+     * @return the (immutable) set of supported algorithms
      */
-    public Set<String> getAllowedAlgorithms(Class<? extends Credential> type) {
-        return allowedTypes.get(type);
+    public Set<String> getSupportedAlgorithms(Class<? extends Credential> type) {
+        return Collections.unmodifiableSet(supportedTypes.get(type));
     }
 
     public boolean isOptional() {
@@ -142,4 +136,84 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
     public boolean needsInformation() {
         return true;
     }
+
+    /**
+     * Factory method to create a builder for a {@link CredentialCallback}.
+     *
+     * @return A builder for a {@link CredentialCallback}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * The non-Thread safe builder of {@link CredentialCallback} instances.
+     */
+    public static class Builder {
+
+        private final Map<Class<? extends Credential>, Set<String>> supportedTypes = new HashMap<>();
+        private boolean built = false;
+
+        private Builder() {};
+
+        private void assertNotBuilt() {
+            if (built) {
+                throw new IllegalStateException("CredentialCallback has already been built.");
+            }
+        }
+
+        /**
+         * Add a credential type to be supported by the {@link CredentialCallback}.
+         *
+         * The specified credential type is considered supported for all algorithms.
+         *
+         * @param credentialType the supported {@link Credential} type.
+         * @return This {@link Builder} to allow additional types to be added.
+         */
+        public Builder addSupportedCredentialType(final Class<? extends Credential> credentialType) {
+            assertNotBuilt();
+            if (supportedTypes.containsKey(credentialType)) {
+                throw new IllegalStateException("Credential type already added.");
+            }
+
+            supportedTypes.put(credentialType, Collections.emptySet());
+
+            return this;
+        }
+
+        /**
+         * Add a credential type to be supported by the {@link CredentialCallback} along with the list of algorithms it is supported with.
+         *
+         * @param credentialType credentialType the supported {@link Credential} type.
+         * @param supportedAlgorithms the names of the algorithms the credential type is supported with.
+         * @return This {@link Builder} to allow additional types to be added.
+         */
+        public Builder addSupportedCredentialType(final Class<? extends Credential> credentialType, final String... supportedAlgorithms) {
+            assertNotBuilt();
+            if (supportedTypes.containsKey(credentialType)) {
+                throw new IllegalStateException("Credential type already added.");
+            }
+
+            supportedTypes.put(credentialType, new HashSet<String>(Arrays.asList(supportedAlgorithms)));
+
+            return this;
+        }
+
+        /**
+         * Build the {@link CredentialCallback} with the set of supported credential types added to this builder.
+         *
+         * Once this builder is built no further modifications are allowed.
+         *
+         * @return The {@link CredentialCallback} with the set of supported credential types added to this builder.
+         */
+        public CredentialCallback build() {
+            assertNotBuilt();
+            built = true;
+
+            return new CredentialCallback(supportedTypes);
+        }
+
+    }
+
+
 }

--- a/src/main/java/org/wildfly/security/auth/client/SetKeyManagerCredentialAuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/SetKeyManagerCredentialAuthenticationConfiguration.java
@@ -79,8 +79,8 @@ class SetKeyManagerCredentialAuthenticationConfiguration extends AuthenticationC
                     throw log.unableToCreateKeyManager(e);
                 }
                 final CredentialCallback credentialCallback = (CredentialCallback) callback;
-                for (Class<? extends Credential> allowedType : credentialCallback.getAllowedTypes()) {
-                    final Set<String> allowedAlgorithms = credentialCallback.getAllowedAlgorithms(allowedType);
+                for (Class<? extends Credential> allowedType : credentialCallback.getSupportedTypes()) {
+                    final Set<String> allowedAlgorithms = credentialCallback.getSupportedAlgorithms(allowedType);
                     if (allowedAlgorithms != null) {
                         final String[] keyType = allowedAlgorithms.toArray(new String[allowedAlgorithms.size()]);
                         final String alias = keyManager.chooseClientAlias(keyType, getAcceptableIssuers(trustedAuthorities), null);

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -796,11 +796,11 @@ public final class ServerAuthenticationContext {
             }
 
             private boolean isAllowedTypeAlgorithm(Credential credential, CredentialCallback credentialCallback) {
-                for (Class<? extends Credential> allowedType : credentialCallback.getAllowedTypes()) {
+                for (Class<? extends Credential> allowedType : credentialCallback.getSupportedTypes()) {
                     if (allowedType.isInstance(credential)) {
                         if (credential instanceof AlgorithmCredential) {
                             String algorithm = ((AlgorithmCredential) credential).getAlgorithm();
-                            for (String allowedAlgorithm : credentialCallback.getAllowedAlgorithms(allowedType)) {
+                            for (String allowedAlgorithm : credentialCallback.getSupportedAlgorithms(allowedType)) {
                                 if(allowedAlgorithm.equals(algorithm)) {
                                     return true; // allowed type, allowed algorithm
                                 }

--- a/src/main/java/org/wildfly/security/auth/util/ElytronAuthenticator.java
+++ b/src/main/java/org/wildfly/security/auth/util/ElytronAuthenticator.java
@@ -19,8 +19,6 @@
 package org.wildfly.security.auth.util;
 
 import static java.security.AccessController.doPrivileged;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonMap;
 
 import java.io.IOException;
 import java.net.Authenticator;
@@ -35,10 +33,10 @@ import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
+import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
-import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.TwoWayPassword;
@@ -82,7 +80,10 @@ public final class ElytronAuthenticator extends Authenticator {
         if (authenticationConfiguration == null) return null;
         final CallbackHandler callbackHandler = client.getCallbackHandler(authenticationConfiguration);
         final NameCallback nameCallback = new NameCallback(getRequestingPrompt());
-        final CredentialCallback credentialCallback = new CredentialCallback(singletonMap(PasswordCredential.class, emptySet()));
+        final CredentialCallback credentialCallback = CredentialCallback.builder()
+                .addSupportedCredentialType(PasswordCredential.class)
+                .build();
+
         char[] password = null;
         try {
             callbackHandler.handle(new Callback[] { nameCallback, credentialCallback });

--- a/src/main/java/org/wildfly/security/mechanism/MechanismUtil.java
+++ b/src/main/java/org/wildfly/security/mechanism/MechanismUtil.java
@@ -18,8 +18,6 @@
 
 package org.wildfly.security.mechanism;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
 import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.security.InvalidKeyException;
@@ -70,7 +68,9 @@ public final class MechanismUtil {
         try {
             final PasswordFactory passwordFactory = PasswordFactory.getInstance(passwordAlgorithm);
 
-            CredentialCallback credentialCallback = new CredentialCallback(singletonMap(PasswordCredential.class, singleton(passwordAlgorithm)));
+            CredentialCallback credentialCallback = CredentialCallback.builder()
+                    .addSupportedCredentialType(PasswordCredential.class, passwordAlgorithm)
+                    .build();
 
             try {
                 MechanismUtil.handleCallbacks(passwordAlgorithm, callbackHandler, credentialCallback);
@@ -89,7 +89,9 @@ public final class MechanismUtil {
                 // fall out
             }
 
-            credentialCallback = new CredentialCallback(singletonMap(PasswordCredential.class, singleton(ClearPassword.ALGORITHM_CLEAR)));
+            credentialCallback = CredentialCallback.builder()
+                    .addSupportedCredentialType(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR)
+                    .build();
 
             try {
                 MechanismUtil.handleCallbacks(passwordAlgorithm, callbackHandler, credentialCallback);

--- a/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
@@ -18,13 +18,23 @@
 
 package org.wildfly.security.sasl.digest;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.HASH_algorithm;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.HMAC_algorithm;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.computeHMAC;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.create3desSecretKey;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.createDesSecretKey;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.decodeByteOrderedInteger;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.integerByteOrdered;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.messageDigestAlgorithm;
+import static org.wildfly.security.sasl.digest._private.DigestUtil.userRealmPasswordDigest;
+
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 
 import javax.crypto.Cipher;
@@ -56,9 +66,6 @@ import org.wildfly.security.util.DefaultTransformationMapper;
 import org.wildfly.security.util.TransformationMapper;
 import org.wildfly.security.util.TransformationSpec;
 import org.wildfly.security.util._private.Arrays2;
-
-import static org.wildfly.security.sasl.digest._private.DigestUtil.*;
-import static org.wildfly.security._private.ElytronMessages.log;
 
 /**
  *
@@ -607,7 +614,9 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
     }
 
     protected byte[] getPredigestedSaltedPassword(RealmCallback realmCallback, NameCallback nameCallback) throws SaslException {
-        CredentialCallback credentialCallback = new CredentialCallback(Collections.singletonMap(PasswordCredential.class, Collections.singleton(passwordAlgorithm(getMechanismName()))));
+        CredentialCallback credentialCallback = CredentialCallback.builder()
+                .addSupportedCredentialType(PasswordCredential.class, passwordAlgorithm(getMechanismName()))
+                .build();
         try {
             tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
             PasswordCredential credential = (PasswordCredential) credentialCallback.getCredential();
@@ -625,7 +634,9 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
     }
 
     protected byte[] getSaltedPasswordFromTwoWay(RealmCallback realmCallback, NameCallback nameCallback, boolean readOnlyRealmUsername) throws SaslException {
-        CredentialCallback credentialCallback = new CredentialCallback(Collections.singletonMap(PasswordCredential.class, Collections.emptySet()));
+        CredentialCallback credentialCallback = CredentialCallback.builder()
+                .addSupportedCredentialType(PasswordCredential.class)
+                .build();
         try {
             tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
         } catch (UnsupportedCallbackException e) {

--- a/src/main/java/org/wildfly/security/sasl/entity/EntitySaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/EntitySaslClient.java
@@ -18,12 +18,9 @@
 
 package org.wildfly.security.sasl.entity;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
-import static org.wildfly.security.asn1.ASN1.*;
-import static org.wildfly.security.sasl.entity.Entity.*;
-import static org.wildfly.security.sasl.entity.GeneralName.*;
 import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.security.asn1.ASN1.CONTEXT_SPECIFIC_MASK;
+import static org.wildfly.security.sasl.entity.Entity.keyType;
 
 import java.io.IOException;
 import java.net.URL;
@@ -48,9 +45,11 @@ import org.wildfly.security.asn1.DEREncoder;
 import org.wildfly.security.auth.callback.CredentialCallback;
 import org.wildfly.security.auth.callback.TrustedAuthoritiesCallback;
 import org.wildfly.security.auth.callback.VerifyPeerTrustedCallback;
+import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
+import org.wildfly.security.sasl.entity.GeneralName.DNSName;
+import org.wildfly.security.sasl.entity.GeneralName.DirectoryName;
 import org.wildfly.security.sasl.util.AbstractSaslClient;
 import org.wildfly.security.util.ByteStringBuilder;
-import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 
 /**
  * SaslClient for the ISO/IEC 9798-3 authentication mechanism as defined by
@@ -165,8 +164,10 @@ final class EntitySaslClient extends AbstractSaslClient {
                     encoder.startExplicit(1);
                     TrustedAuthoritiesCallback trustedAuthoritiesCallback = new TrustedAuthoritiesCallback();
                     trustedAuthoritiesCallback.setTrustedAuthorities(trustedAuthorities); // Server's preferred certificates
-                    CredentialCallback credentialCallback = new CredentialCallback(singletonMap(X509CertificateChainPrivateCredential.class,
-                            singleton(keyType(signature.getAlgorithm()))));
+                    CredentialCallback credentialCallback = CredentialCallback.builder()
+                            .addSupportedCredentialType(X509CertificateChainPrivateCredential.class, keyType(signature.getAlgorithm()))
+                            .build();
+
                     PrivateKey privateKey;
                     try {
                         tryHandleCallbacks(trustedAuthoritiesCallback, credentialCallback);

--- a/src/main/java/org/wildfly/security/sasl/entity/EntitySaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/entity/EntitySaslServer.java
@@ -18,12 +18,9 @@
 
 package org.wildfly.security.sasl.entity;
 
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
 import static org.wildfly.security._private.ElytronMessages.log;
-import static org.wildfly.security.asn1.ASN1.*;
-import static org.wildfly.security.sasl.entity.Entity.*;
-import static org.wildfly.security.sasl.entity.GeneralName.*;
+import static org.wildfly.security.asn1.ASN1.CONTEXT_SPECIFIC_MASK;
+import static org.wildfly.security.sasl.entity.Entity.keyType;
 
 import java.net.URL;
 import java.security.InvalidKeyException;
@@ -52,9 +49,10 @@ import org.wildfly.security.auth.callback.TrustedAuthoritiesCallback;
 import org.wildfly.security.auth.callback.VerifyPeerTrustedCallback;
 import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.credential.X509CertificateChainPublicCredential;
-import org.wildfly.security.x500.X509CertificateCredentialDecoder;
+import org.wildfly.security.sasl.entity.GeneralName.DNSName;
 import org.wildfly.security.sasl.util.AbstractSaslServer;
 import org.wildfly.security.util.ByteStringBuilder;
+import org.wildfly.security.x500.X509CertificateCredentialDecoder;
 
 /**
  * SaslServer for the ISO/IEC 9798-3 authentication mechanism as defined by
@@ -223,8 +221,10 @@ final class EntitySaslServer extends AbstractSaslServer {
 
                 // Get the server's certificate data, if necessary
                 if ((entityB != null) || mutual) {
-                    CredentialCallback credentialCallback = new CredentialCallback(singletonMap(X509CertificateChainPrivateCredential.class,
-                            singleton(keyType(signature.getAlgorithm()))));
+                    CredentialCallback credentialCallback = CredentialCallback.builder()
+                            .addSupportedCredentialType(X509CertificateChainPrivateCredential.class,keyType(signature.getAlgorithm()))
+                            .build();
+
                     try {
                         tryHandleCallbacks(credentialCallback);
                         final X509CertificateChainPrivateCredential serverCertChainPrivateCredential = (X509CertificateChainPrivateCredential) credentialCallback.getCredential();

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClient.java
@@ -19,10 +19,9 @@
 package org.wildfly.security.sasl.gs2;
 
 import static org.wildfly.security._private.ElytronMessages.log;
-import static org.wildfly.security.asn1.ASN1.*;
-import static org.wildfly.security.sasl.gs2.Gs2Util.*;
+import static org.wildfly.security.asn1.ASN1.APPLICATION_SPECIFIC_MASK;
+import static org.wildfly.security.sasl.gs2.Gs2Util.TOKEN_HEADER_TAG;
 
-import java.util.Collections;
 import java.util.Map;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -89,7 +88,8 @@ final class Gs2SaslClient extends AbstractSaslClient {
 
         // Attempt to obtain a credential
         GSSCredential credential = null;
-        CredentialCallback credentialCallback = new CredentialCallback(Collections.singletonMap(GSSCredentialCredential.class, Collections.emptySet()));
+        CredentialCallback credentialCallback = CredentialCallback.builder().addSupportedCredentialType(GSSCredentialCredential.class).build();
+
         try {
             tryHandleCallbacks(credentialCallback);
             final Credential credentialHolder = credentialCallback.getCredential();

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
@@ -19,9 +19,7 @@
 package org.wildfly.security.sasl.gs2;
 
 import static org.wildfly.security._private.ElytronMessages.log;
-import static org.wildfly.security.asn1.ASN1.*;
-
-import java.util.Collections;
+import static org.wildfly.security.asn1.ASN1.APPLICATION_SPECIFIC_MASK;
 
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
@@ -80,7 +78,10 @@ final class Gs2SaslServer extends AbstractSaslServer {
 
         // Attempt to obtain a credential
         GSSCredential credential = null;
-        CredentialCallback credentialCallback = new CredentialCallback(Collections.singletonMap(GSSCredentialCredential.class, Collections.emptySet()));
+        CredentialCallback credentialCallback = CredentialCallback.builder()
+                .addSupportedCredentialType(GSSCredentialCredential.class)
+                .build();
+
         try {
             tryHandleCallbacks(credentialCallback);
             Credential credentialHolder = credentialCallback.getCredential();

--- a/src/main/java/org/wildfly/security/sasl/util/KeyManagerCredentialSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/KeyManagerCredentialSaslServerFactory.java
@@ -78,8 +78,8 @@ public final class KeyManagerCredentialSaslServerFactory extends AbstractDelegat
                     final CredentialCallback credentialCallback = (CredentialCallback) callback;
                     out:
                     {
-                        for (Class<? extends Credential> allowedType : credentialCallback.getAllowedTypes()) {
-                            for (String algorithmName : credentialCallback.getAllowedAlgorithms(allowedType)) {
+                        for (Class<? extends Credential> allowedType : credentialCallback.getSupportedTypes()) {
+                            for (String algorithmName : credentialCallback.getSupportedAlgorithms(allowedType)) {
                                 final String alias = keyManager.chooseServerAlias(algorithmName, null, null);
                                 if (alias != null) {
                                     final X509Certificate[] certificateChain = keyManager.getCertificateChain(alias);


### PR DESCRIPTION
This means anything using the Callback does not need to understand the structure of the internal Map.

Also it felt like we were using 'Supported' and 'Allowed' interchangeable so have just switched to 'Supported'. 