### PR TITLE
[ELY-345]  Enhancements to the getCredential API on the realm identities.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/callback/CredentialCallback.java
+++ b/src/main/java/org/wildfly/security/auth/callback/CredentialCallback.java
@@ -126,7 +126,16 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
      * @return the (immutable) set of supported algorithms
      */
     public Set<String> getSupportedAlgorithms(Class<? extends Credential> type) {
-        return Collections.unmodifiableSet(supportedTypes.get(type));
+        return supportedTypes.get(type);
+    }
+
+    /**
+     * Get the map of supported types along with the supported algorithms for each of those types.
+     *
+     * @return the map of supported types along with the supported algorithms for each of those types
+     */
+    public Map<Class<? extends Credential>, Set<String>> getSupportedTypesWithAlgorithms() {
+        return Collections.unmodifiableMap(supportedTypes);
     }
 
     public boolean isOptional() {
@@ -194,7 +203,7 @@ public final class CredentialCallback implements ExtendedCallback, Serializable 
                 throw new IllegalStateException("Credential type already added.");
             }
 
-            supportedTypes.put(credentialType, new HashSet<String>(Arrays.asList(supportedAlgorithms)));
+            supportedTypes.put(credentialType, Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(supportedAlgorithms))));
 
             return this;
         }

--- a/src/main/java/org/wildfly/security/auth/provider/AggregateSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/AggregateSecurityRealm.java
@@ -18,6 +18,10 @@
 
 package org.wildfly.security.auth.provider;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.auth.server.CredentialSupport;
 import org.wildfly.security.auth.server.RealmIdentity;
@@ -81,6 +85,21 @@ public final class AggregateSecurityRealm implements SecurityRealm {
 
         public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
             return authenticationIdentity.getCredentialSupport(credentialName);
+        }
+
+        @Override
+        public Credential getCredential(String credentialName) throws RealmUnavailableException {
+            return authenticationIdentity.getCredential(credentialName);
+        }
+
+        @Override
+        public <C extends Credential> C getCredential(String credentialName, Class<C> credentialType, Set<String> supportedAlgorithms) throws RealmUnavailableException {
+            return authenticationIdentity.getCredential(credentialName, credentialType, supportedAlgorithms);
+        }
+
+        @Override
+        public Credential getCredential(List<String> credentialNames, Map<Class<? extends Credential>, Set<String>> supportedTypesWithAlgorithms) throws RealmUnavailableException {
+            return authenticationIdentity.getCredential(credentialNames, supportedTypesWithAlgorithms);
         }
 
         public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/FileSystemSecurityRealm.java
@@ -245,15 +245,10 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
             return credentials.containsKey(credentialName) ? CredentialSupport.FULLY_SUPPORTED : CredentialSupport.UNSUPPORTED;
         }
 
-        public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(final String credentialName) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentialName", credentialName);
-            Assert.checkNotNullParam("credentialType", credentialType);
             Map<String, Credential> credentials = loadCredentials();
-            Object credential = credentials.get(credentialName);
-            if (credentialType.isInstance(credential)) {
-                return credentialType.cast(credential);
-            }
-            return null;
+            return credentials.get(credentialName);
         }
 
         public boolean verifyEvidence(final String credentialName, final Evidence evidence) throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/provider/JaasSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/JaasSecurityRealm.java
@@ -154,7 +154,7 @@ public class JaasSecurityRealm implements SecurityRealm {
         }
 
         @Override
-        public <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(String credentialName) throws RealmUnavailableException {
             return null;
         }
 

--- a/src/main/java/org/wildfly/security/auth/provider/KeyStoreBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/KeyStoreBackedSecurityRealm.java
@@ -141,6 +141,11 @@ public class KeyStoreBackedSecurityRealm implements SecurityRealm {
         }
 
         @Override
+        public Credential getCredential(String credentialName) throws RealmUnavailableException {
+            return getCredential(credentialName, Credential.class);
+        }
+
+        @Override
         public AuthorizationIdentity getAuthorizationIdentity() {
             return new AuthorizationIdentity() {
             };

--- a/src/main/java/org/wildfly/security/auth/provider/LegacyPropertiesSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/LegacyPropertiesSecurityRealm.java
@@ -98,11 +98,8 @@ public class LegacyPropertiesSecurityRealm implements SecurityRealm {
             }
 
             @Override
-            public <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException {
+            public Credential getCredential(String credentialName) throws RealmUnavailableException {
                 if (accountEntry == null) {
-                    return null;
-                }
-                if (!credentialType.isAssignableFrom(PasswordCredential.class)) {
                     return null;
                 }
 
@@ -125,7 +122,7 @@ public class LegacyPropertiesSecurityRealm implements SecurityRealm {
                 }
 
                 try {
-                    return credentialType.cast(new PasswordCredential(passwordFactory.generatePassword(passwordSpec)));
+                    return new PasswordCredential(passwordFactory.generatePassword(passwordSpec));
                 } catch (InvalidKeySpecException e) {
                     throw new IllegalStateException(e);
                 }

--- a/src/main/java/org/wildfly/security/auth/provider/SimpleMapBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/SimpleMapBackedSecurityRealm.java
@@ -139,13 +139,12 @@ public class SimpleMapBackedSecurityRealm implements SecurityRealm {
         }
 
         @Override
-        public <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) {
+        public Credential getCredential(String credentialName) {
             Assert.checkNotNullParam("credentialName", credentialName);
-            Assert.checkNotNullParam("credentialType", credentialType);
             final SimpleRealmEntry entry = map.get(name);
             if (entry == null) return null;
             final Password password = entry.getPassword(credentialName);
-            return credentialType.isAssignableFrom(PasswordCredential.class) ? credentialType.cast(new PasswordCredential(password)) : null;
+            return new PasswordCredential(password);
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/auth/provider/jdbc/JdbcSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/jdbc/JdbcSecurityRealm.java
@@ -104,11 +104,11 @@ public class JdbcSecurityRealm implements SecurityRealm {
         }
 
         @Override
-        public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(final String credentialName) throws RealmUnavailableException {
             for (QueryConfiguration configuration : JdbcSecurityRealm.this.queryConfiguration) {
                 for (KeyMapper keyMapper : configuration.getColumnMappers(KeyMapper.class)) {
                     if (keyMapper.getCredentialName().equals(credentialName)) {
-                        return executePrincipalQuery(configuration, resultSet -> credentialType.cast(keyMapper.map(resultSet)));
+                        return executePrincipalQuery(configuration, resultSet -> keyMapper.map(resultSet));
                     }
                 }
             }

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
@@ -185,9 +185,8 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
         }
 
         @Override
-        public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(final String credentialName) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentialName", credentialName);
-            Assert.checkNotNullParam("credentialType", credentialType);
             if (!exists()) {
                 return null;
             }
@@ -201,7 +200,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
                 if (loader.getCredentialSupport(dirContextFactory, credentialName).mayBeObtainable()) {
                     IdentityCredentialLoader icl = loader.forIdentity(dirContextFactory, this.identity.getDistinguishedName());
 
-                    C credential = icl.getCredential(credentialName, credentialType);
+                    Credential credential = icl.getCredential(credentialName, Credential.class);
                     if (credential != null) {
                         return credential;
                     }

--- a/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
@@ -19,12 +19,18 @@
 package org.wildfly.security.auth.server;
 
 import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import org.wildfly.security.authz.AuthorizationIdentity;
+import org.wildfly.security.credential.AlgorithmCredential;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.X509CertificateChainCredential;
@@ -56,16 +62,76 @@ public interface RealmIdentity {
     CredentialSupport getCredentialSupport(String credentialName) throws RealmUnavailableException;
 
     /**
-     * Acquire a credential of the given type.  The credential type is defined by its {@code Class} and an optional {@code algorithmName}.  If the
-     * algorithm name is not given, then the query is performed for any algorithm of the given type.
+     * Acquire a credential of the given name.
      *
-     * @param <C> the type to which should be credential casted
      * @param credentialName the name of the credential
+     * @return the credential, or {@code null} if the principal has no credential of that name
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
+     */
+    Credential getCredential(String credentialName) throws RealmUnavailableException;
+
+    /**
+     * Acquire a credential of the given name, cast to the given type.
+     *
+     * @param credentialName the name of the credential
+     * @param <C> the type to which should be credential casted
      * @param credentialType the class of type to which should be credential casted
      * @return the credential, or {@code null} if the principal has no credential of that name or cannot be casted to that type
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
-    <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException;
+    default <C extends Credential> C getCredential(String credentialName, Class<C> credentialType) throws RealmUnavailableException {
+        Credential c = getCredential(checkNotNullParam("credentialName", credentialName));
+        if (checkNotNullParam("credentialType", credentialType).isInstance(c)) {
+            return credentialType.cast(c);
+        }
+
+        return null;
+    }
+
+    /**
+     * Acquire a credential of the given name, if the {@link Credential} instance also implements {@link AlgorithmCredential}
+     * verify that the algorithm is also in the list of supported algorithms, then cast to the given type.
+     *
+     * @param credentialName the name of the credential
+     * @param <C> the type to which should be credential casted
+     * @param supportedAlgorithms the Set of algorithm names with which the algorithm of the credential must match if it has one.
+     * @return the credential, or {@code null} if the principal has no credential of that name, or the algorithm of the available credential was not available, or cannot be casted to that type
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
+     */
+    default <C extends Credential> C getCredential(String credentialName, Class<C> credentialType, Set<String> supportedAlgorithms) throws RealmUnavailableException {
+        checkNotNullParam("supportedAlgorithms", supportedAlgorithms);
+        C c = getCredential(credentialName, credentialType);
+        if (c != null && ( c instanceof AlgorithmCredential == false || supportedAlgorithms.contains(((AlgorithmCredential)c).getAlgorithm()))) {
+            return c;
+        }
+
+        return null;
+    }
+
+    /**
+     * Acquire a credential after resolving a List of possible credential names against a Map of supported credential types against Sets of supported algorithms for each of those types.
+     *
+     * @param credentialNames the list of credential names to attempt to load and cross reference against the Map of supported credentials along with their supported algorithms
+     * @param supportedTypesWithAlgorithms the mapping of supported credential types associated with a set of supported algorithms for each of those types.
+     * @return the credential resolved by the realm
+     * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
+     */
+    default Credential getCredential(List<String> credentialNames, Map<Class<? extends Credential>, Set<String>> supportedTypesWithAlgorithms) throws RealmUnavailableException {
+        for (String credentialName : credentialNames) {
+            Credential c = getCredential(credentialName);
+            if (c != null) {
+                for (Entry<Class<? extends Credential>, Set<String>> currentEntry : supportedTypesWithAlgorithms.entrySet()) {
+                    if (currentEntry.getKey().isInstance(c)) {
+                        if (  c instanceof AlgorithmCredential == false || currentEntry.getValue().isEmpty() || currentEntry.getValue().contains(((AlgorithmCredential)c).getAlgorithm())) {
+                            return c;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
 
     /**
      * Verify the given credential.
@@ -136,15 +202,11 @@ public interface RealmIdentity {
      */
     RealmIdentity ANONYMOUS = new RealmIdentity() {
 
-        public String getName() {
-            return "anonymous";
-        }
-
         public CredentialSupport getCredentialSupport(final String credentialName) throws RealmUnavailableException {
             return CredentialSupport.UNSUPPORTED;
         }
 
-        public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(String credentialName) {
             return null;
         }
 
@@ -162,7 +224,7 @@ public interface RealmIdentity {
             return CredentialSupport.UNSUPPORTED;
         }
 
-        public <C extends Credential> C getCredential(final String credentialName, final Class<C> credentialType) throws RealmUnavailableException {
+        public Credential getCredential(String credentialName) {
             return null;
         }
 


### PR DESCRIPTION
Allow getCredential on the RealmIdentity to be able to reso…lve the full credential name list against the Map of supported credential types with their supported algorithms.

At the same time the getCredential method that realms are required to implement on their identity is reduced down to the most basic: -
  Credential getCredential(String credentialName);

Realms can then optionally choose to implement the stronger variants if they make sense to the realm, otherwise default implementations are provided.