### PR TITLE
Ability to set the realm via xml

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -18,7 +18,11 @@
 
 package org.wildfly.security.auth.client;
 
-import static javax.xml.stream.XMLStreamConstants.*;
+import static javax.xml.stream.XMLStreamConstants.COMMENT;
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.PROCESSING_INSTRUCTION;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security._private.ElytronMessages.xmlLog;
 
@@ -53,9 +57,10 @@ import org.wildfly.client.config.ConfigurationXMLStreamReader;
 import org.wildfly.security.FixedSecurityFactory;
 import org.wildfly.security.OneTimeSecurityFactory;
 import org.wildfly.security.SecurityFactory;
-import org.wildfly.security.auth.util.ElytronAuthenticator;
 import org.wildfly.security.auth.server.NameRewriter;
+import org.wildfly.security.auth.util.ElytronAuthenticator;
 import org.wildfly.security.auth.util.RegexNameRewriter;
+import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.keystore.PasswordEntry;
 import org.wildfly.security.keystore.WrappingPasswordKeyStore;
 import org.wildfly.security.password.Password;
@@ -65,7 +70,6 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.ssl.CipherSuiteSelector;
 import org.wildfly.security.ssl.ProtocolSelector;
 import org.wildfly.security.util.ServiceLoaderSupplier;
-import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.x500.X500;
 
 /**
@@ -472,6 +476,13 @@ public final class ElytronXmlParser {
                         final SecurityFactory<AuthenticationConfiguration> parentConfig = configuration;
                         final Module module = parseModuleRefType(reader);
                         configuration = () -> parentConfig.create().useProviders(new ServiceLoaderSupplier<Provider>(Provider.class, module.getClassLoader()));
+                        break;
+                    }
+                    case "use-mechanism-realm": {
+                        gotConfig = true;
+                        final String realm = parseNameType(reader);
+                        final SecurityFactory<AuthenticationConfiguration> parentConfig = configuration;
+                        configuration = () -> parentConfig.create().useRealm(realm);
                         break;
                     }
                     default: throw reader.unexpectedElement();

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -124,6 +124,7 @@
                 <xsd:element name="ssl-protocol" type="names-list-type" minOccurs="1" maxOccurs="1"/>
                 <xsd:element name="use-system-providers" type="empty-type" minOccurs="1" maxOccurs="1"/>
                 <xsd:element name="use-module-providers" type="module-ref-type" minOccurs="1" maxOccurs="1"/>
+                <xsd:element name="use-mechanism-realm" type="name-type" minOccurs="1" maxOccurs="1"/>
             </xsd:choice>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" use="optional"/>

--- a/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -18,7 +18,8 @@
 
 package org.wildfly.security.auth.client;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -62,6 +63,7 @@ public class XmlConfigurationTest {
             "            <match-userinfo name=\"fred\"/>\n" +
             "            <set-host name=\"localhost\"/>\n" +
             "            <set-user-name name=\"jane\"/>\n" +
+            "            <use-mechanism-realm name=\"mainRealm\"/>\n" +
             "        </rule>\n" +
             "    </rules>\n" +
             "</authentication-client>\n").getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-367

This is needed to be able to create a client from xml config using DIGEST authentication which seems to need a realm as shown in https://github.com/jboss-remoting/jboss-remoting/pull/53.

I went with 'use-mechanism-realm' rather than 'use-realm' or 'set-realm' as per David's suggestion.