### PR TITLE
[ELY-380] Reduce visibility of LdapSecurityRealm.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/provider/ldap/AttributeMapping.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/AttributeMapping.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.provider.ldap;
+
+import org.wildfly.common.Assert;
+
+/**
+ * Definition of a mapping from LDAP to an Elytron attribute.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class AttributeMapping {
+
+    private final String ldapName;
+    private final String searchDn;
+    private final String filter;
+    private String name;
+    private String rdn;
+
+    /**
+     * Create an attribute mapping based on the given attribute in LDAP.
+     *
+     * @param ldapName the name of the attribute in LDAP from where values are obtained
+     * @return this builder
+     */
+    public static AttributeMapping from(String ldapName) {
+        Assert.checkNotNullParam("ldapName", ldapName);
+        return new AttributeMapping(ldapName);
+    }
+
+    /**
+     * <p>Create an attribute mapping based on the results of the given {@code filter}.
+     *
+     * <p>The {@code filter} <em>may</em> have one and exactly one <em>{0}</em> string that will be used to replace with the distinguished
+     * name of the identity. In this case, the filter is specially useful when the values for this attribute should be obtained from a
+     * separated entry. For instance, retrieving roles from entries with a object class of <em>groupOfNames</em> where the identity's DN is
+     * a value of a <em>member</em> attribute.
+     *
+     * @param searchDn the name of the context to be used when executing the filter
+     * @param filter the filter that is going to be used to search for entries and obtain values for this attribute
+     * @param ldapName the name of the attribute in LDAP from where the values are obtained
+     * @return this builder
+     */
+    public static AttributeMapping fromFilter(String searchDn, String filter, String ldapName) {
+        Assert.checkNotNullParam("searchDn", searchDn);
+        Assert.checkNotNullParam("filter", filter);
+        Assert.checkNotNullParam("ldapName", ldapName);
+        return new AttributeMapping(searchDn, filter, ldapName);
+    }
+
+    /**
+     * <p>The behavior is exactly the same as {@link #fromFilter(String, String, String)}, except that it uses the
+     * same name of the context defined in {@link org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder.IdentityMappingBuilder#setSearchDn(String)}.
+     *
+     * @param filter the filter that is going to be used to search for entries and obtain values for this attribute
+     * @param ldapName the name of the attribute in LDAP from where the values are obtained
+     * @return this builder
+     */
+    public static AttributeMapping fromFilter(String filter, String ldapName) {
+        Assert.checkNotNullParam("filter", filter);
+        Assert.checkNotNullParam("ldapName", ldapName);
+        return new AttributeMapping(null, filter, ldapName);
+    }
+
+    AttributeMapping(String ldapName) {
+        this(null, null, ldapName);
+    }
+
+    AttributeMapping(String searchDn, String filter, String ldapName) {
+        Assert.checkNotNullParam("ldapName", ldapName);
+        this.searchDn = searchDn;
+        this.filter = filter;
+        this.ldapName = ldapName.toUpperCase();
+    }
+
+    public AttributeMapping asRdn(String rdn) {
+        Assert.checkNotNullParam("rdn", rdn);
+        this.rdn = rdn;
+        return this;
+    }
+
+    public AttributeMapping to(String name) {
+        Assert.checkNotNullParam("to", name);
+        this.name = name;
+        return this;
+    }
+
+    String getLdapName() {
+        return this.ldapName;
+    }
+
+    String getName() {
+        if (this.name == null) {
+            return this.ldapName;
+        }
+
+        return this.name;
+    }
+
+    String getSearchDn() {
+        return this.searchDn;
+    }
+
+    String getFilter() {
+        return this.filter;
+    }
+
+    String getRdn() {
+        return this.rdn;
+    }
+}

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.security.auth.provider.ldap;
 
-import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.Attribute;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.IdentityMapping;
 
 import static org.wildfly.security._private.ElytronMessages.log;
@@ -182,7 +181,7 @@ public class LdapSecurityRealmBuilder {
         private boolean searchRecursive = false;
         private String nameAttribute;
         private int searchTimeLimit = 10000;
-        private List<Attribute> attributes = new ArrayList<>();
+        private List<AttributeMapping> attributes = new ArrayList<>();
 
         /**
          * <p>Set the name of the context to be used when executing queries.
@@ -246,10 +245,10 @@ public class LdapSecurityRealmBuilder {
         /**
          * Define an attribute mapping configuration.
          *
-         * @param attributes one or more {@link Attribute} configuration
+         * @param attributes one or more {@link AttributeMapping} configuration
          * @return this builder
          */
-        public IdentityMappingBuilder map(Attribute... attributes) {
+        public IdentityMappingBuilder map(AttributeMapping... attributes) {
             assertNotBuilt();
 
             this.attributes.addAll(Arrays.asList(attributes));

--- a/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingTest.java
+++ b/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.ClassRule;
-import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.Attribute;
+import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
@@ -46,11 +46,11 @@ public abstract class AbstractAttributeMappingTest {
         }
     }
 
-    protected void assertAttributes(AssertResultHandler handler, Attribute... expectedAttributes) throws RealmUnavailableException {
+    protected void assertAttributes(AssertResultHandler handler, AttributeMapping... expectedAttributes) throws RealmUnavailableException {
         assertAttributes("plainUser", handler, expectedAttributes);
     }
 
-    protected void assertAttributes(String principalName, AssertResultHandler handler, Attribute... expectedAttributes) throws RealmUnavailableException {
+    protected void assertAttributes(String principalName, AssertResultHandler handler, AttributeMapping... expectedAttributes) throws RealmUnavailableException {
         SecurityDomain.Builder builder = SecurityDomain.builder();
 
         builder.setDefaultRealmName("default")

--- a/src/test/java/org/wildfly/security/ldap/AttributeMappingTest.java
+++ b/src/test/java/org/wildfly/security/ldap/AttributeMappingTest.java
@@ -21,7 +21,7 @@ package org.wildfly.security.ldap;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.Attribute;
+import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -33,7 +33,7 @@ public class AttributeMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("firstName"), "My First Name");
-        }, Attribute.from("cn").to("firstName"));
+        }, AttributeMapping.from("cn").to("firstName"));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class AttributeMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name");
-        }, Attribute.from("cn"));
+        }, AttributeMapping.from("cn"));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class AttributeMappingTest extends AbstractAttributeMappingTest {
             assertEquals("Expected two attributes.", 2, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name");
             assertAttributeValue(attributes.get("lastName"), "My Last Name");
-        }, Attribute.from("cn"), Attribute.from("sn").to("lastName"));
+        }, AttributeMapping.from("cn"), AttributeMapping.from("sn").to("lastName"));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class AttributeMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected two attributes.", 1, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name", "My Last Name");
-        }, Attribute.from("cn"), Attribute.from("sn").to("CN"));
+        }, AttributeMapping.from("cn"), AttributeMapping.from("sn").to("CN"));
     }
 
     @Test
@@ -66,7 +66,7 @@ public class AttributeMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithRdnAttribute", attributes -> {
             assertEquals("Expected two attributes.", 1, attributes.size());
             assertAttributeValue(attributes.get("businessArea"), "Finance", "Sales");
-        }, Attribute.fromFilter("ou=Finance,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea")
-         , Attribute.fromFilter("ou=Sales,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea"));
+        }, AttributeMapping.fromFilter("ou=Finance,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea")
+         , AttributeMapping.fromFilter("ou=Sales,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea"));
     }
 }

--- a/src/test/java/org/wildfly/security/ldap/GroupMappingTest.java
+++ b/src/test/java/org/wildfly/security/ldap/GroupMappingTest.java
@@ -21,7 +21,7 @@ package org.wildfly.security.ldap;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.Attribute;
+import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -33,6 +33,6 @@ public class GroupMappingTest extends AbstractAttributeMappingTest {
         assertAttributes(attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree");
-        }, Attribute.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))", "CN").to("Groups"));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))", "CN").to("Groups"));
     }
 }

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingTest.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingTest.java
@@ -21,7 +21,7 @@ package org.wildfly.security.ldap;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-import org.wildfly.security.auth.provider.ldap.LdapSecurityRealm.Attribute;
+import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 import org.wildfly.security.authz.RoleDecoder;
 
 /**
@@ -34,7 +34,7 @@ public class RoleMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithMemberOfRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, Attribute.from("memberOf").asRdn("CN").to(RoleDecoder.KEY_ROLES)) ;
+        }, AttributeMapping.from("memberOf").asRdn("CN").to(RoleDecoder.KEY_ROLES)) ;
     }
 
     @Test
@@ -42,7 +42,7 @@ public class RoleMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu");
-        }, Attribute.fromFilter("ou=Roles,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES)) ;
+        }, AttributeMapping.fromFilter("ou=Roles,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES)) ;
     }
 
     @Test
@@ -50,7 +50,7 @@ public class RoleMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu", "RoleFromBaseDN");
-        }, Attribute.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
     }
 
     @Test
@@ -58,6 +58,6 @@ public class RoleMappingTest extends AbstractAttributeMappingTest {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, Attribute.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
     }
 }


### PR DESCRIPTION
The class was only public as it contained a configuration class that is used elsewhere.