### PR TITLE
[ELY-360] External credential gathering for Credential Store SPI implementors

### DIFF
--- a/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -18,6 +18,11 @@
 
 package org.wildfly.security;
 
+import static org.wildfly.security.credential.external.ExternalCredential.EXTERNAL_CREDENTIAL_PROVIDER_TYPE;
+import static org.wildfly.security.credential.external.impl.ExternalCredentialProviderName.CLASS;
+import static org.wildfly.security.credential.external.impl.ExternalCredentialProviderName.CMD;
+import static org.wildfly.security.credential.external.impl.ExternalCredentialProviderName.EXT;
+import static org.wildfly.security.credential.external.impl.ExternalCredentialProviderName.MASKED;
 import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
 import static org.wildfly.security.password.interfaces.BCryptPassword.ALGORITHM_BCRYPT;
 import static org.wildfly.security.password.interfaces.BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES;
@@ -90,6 +95,9 @@ public class WildFlyElytronProvider extends Provider {
 
     private static final String PASSWORD_FACTORY_TYPE = PasswordFactory.class.getSimpleName();
 
+    /**
+     * Default constructor for this security provider.
+     */
     public WildFlyElytronProvider() {
         super("WildFlyElytron", 1.0, "WildFly Elytron Provider");
 
@@ -97,6 +105,7 @@ public class WildFlyElytronProvider extends Provider {
         putKeyStoreImplementations();
         putPasswordImplementations();
         putSaslMechanismImplementations();
+        putExternalCredentialProviderImplementations();
     }
 
     private void putKeyStoreImplementations() {
@@ -193,6 +202,16 @@ public class WildFlyElytronProvider extends Provider {
                 putService(new Service(this, SASL_SERVER_FACTORY_TYPE, name, className, noAliases, noProperties));
             }
         } catch (ServiceConfigurationError | RuntimeException ignored) {}
+    }
+
+    private void putExternalCredentialProviderImplementations() {
+        final List<String> emptyList = Collections.emptyList();
+        final Map<String, String> emptyMap = Collections.emptyMap();
+
+        putService(new Service(this, EXTERNAL_CREDENTIAL_PROVIDER_TYPE, CLASS.way(), CLASS.get(), emptyList, emptyMap));
+        putService(new Service(this, EXTERNAL_CREDENTIAL_PROVIDER_TYPE, EXT.way(), EXT.get(), emptyList, emptyMap));
+        putService(new Service(this, EXTERNAL_CREDENTIAL_PROVIDER_TYPE, CMD.way(), CMD.get(), emptyList, emptyMap));
+        putService(new Service(this, EXTERNAL_CREDENTIAL_PROVIDER_TYPE, MASKED.way(), MASKED.get(), emptyList, emptyMap));
     }
 
 }

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -60,6 +60,7 @@ import org.wildfly.security.auth.permission.RunAsPrincipalPermission;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.authz.AuthorizationCheckException;
 import org.wildfly.security.authz.AuthorizationFailureException;
+import org.wildfly.security.credential.external.ExternalCredentialException;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.mechanism.AuthenticationMechanismException;
 import org.wildfly.security.mechanism.scram.ScramServerErrorCode;
@@ -1251,4 +1252,32 @@ public interface ElytronMessages extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 8038, value = "Could not obtain authorized identity.")
     void authzCouldNotObtainSecurityIdentity(@Cause Throwable cause);
+
+    /* credential.store. package */
+
+    @Message(id = 9500, value = "Problem to instantiate password class")
+    ExternalCredentialException passwordClassProblem(@Cause Exception cause);
+
+    @Message(id = 9501, value = "Specified class is not an instance of %s")
+    ExternalCredentialException wrongPasswordClass(String className);
+
+    @Message(id = 9502, value = "Password class not specified")
+    ExternalCredentialException passwordClassNotSpecified();
+
+    @LogMessage
+    @Message(id = 9503, value = "Wrong Base64 encoded string used. Falling back to \"%s\"")
+    void warnWrongBase64EncodedString(String base64);
+
+    @Message(id = 9504, value = "Problem executing external password command \"%s\"")
+    ExternalCredentialException passwordCommandExecutionProblem(String command, @Cause Exception cause);
+
+    @Message(id = 9505, value = "External password command not specified")
+    ExternalCredentialException passwordCommandNotSpecified();
+
+    @Message(id = 9506, value = "Password cache for external commands not supported")
+    ExternalCredentialException cacheForExternalCommandsNotSupported();
+
+    @Message(id = 9507, value = "Execution type not supported \"%s\"")
+    ExternalCredentialException executionTypeNotSupported(String executionType);
+
 }

--- a/src/main/java/org/wildfly/security/credential/external/ExternalCredential.java
+++ b/src/main/java/org/wildfly/security/credential/external/ExternalCredential.java
@@ -1,0 +1,181 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.credential.Credential;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * External credential.
+ * It is source for credentials obtained from external source.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class ExternalCredential {
+
+    /**
+     * JCA service type for a external credential provider.
+     */
+    public static final String EXTERNAL_CREDENTIAL_PROVIDER_TYPE = "ExternalCredential";
+
+    private final Provider provider;
+    private final String type;
+    private final ExternalCredentialSpi spi;
+
+    /**
+     * Constructor of ExternalCredential.
+     *
+     * @param provider JCA provider
+     * @param spi Service Provider Interface implementation
+     * @param type of Service Provider
+     */
+    private ExternalCredential(Provider provider, ExternalCredentialSpi spi, String type) {
+        Assert.assertNotNull(provider);
+        Assert.assertNotNull(spi);
+        Assert.assertNotNull(type);
+        this.provider = provider;
+        this.type = type;
+        this.spi = spi;
+    }
+
+    /**
+     * Get a {@code ExternalCredential} instance. The returned CredentialStore object will implement the given way
+     * of getting credential.
+     *
+     * @param way the name of the way to get the credential
+     * @return a {@code CredentialStore} instance
+     * @throws NoSuchAlgorithmException if the given way has no available implementations
+     */
+    public static ExternalCredential getInstance(String way) throws NoSuchAlgorithmException {
+        return getInstance(way, null);
+    }
+
+    /**
+     * Get a {@code ExternalCredential} instance. The returned CredentialStore object will implement the given way
+     * of getting credential.
+     *
+     * @param way the name of the way to get the credential
+     * @param nameSpace a base on which instance parameter names will be used (could be {@code null})
+     * @return a {@code CredentialStore} instance
+     * @throws NoSuchAlgorithmException if the given way has no available implementations
+     */
+    public static ExternalCredential getInstance(String way, String nameSpace) throws NoSuchAlgorithmException {
+        for (Provider provider : Security.getProviders()) {
+            final Provider.Service service = provider.getService(EXTERNAL_CREDENTIAL_PROVIDER_TYPE, way);
+            if (service != null) {
+                return new ExternalCredential(provider, (ExternalCredentialSpi) service.newInstance(nameSpace), way);
+            }
+        }
+        throw new NoSuchAlgorithmException();
+    }
+
+    /**
+     * Get a {@code ExternalCredential} instance.  The returned CredentialStore object will implement the given way
+     * of getting credential.
+     *
+     * @param way the name of the way to get the credential
+     * @param nameSpace a base on which instance parameter names will be used (could be {@code null})
+     * @param providerName the name of the provider to use
+     * @return a {@code CredentialStore} instance
+     * @throws NoSuchAlgorithmException if the given way has no available implementations
+     * @throws NoSuchProviderException if given provider name cannot match any registered {@link Provider}
+     */
+    public static ExternalCredential getInstance(String way, String nameSpace, String providerName) throws NoSuchAlgorithmException, NoSuchProviderException {
+        final Provider provider = Security.getProvider(providerName);
+        if (provider == null) throw new NoSuchProviderException(providerName);
+        return getInstance(way, nameSpace, provider);
+    }
+
+    /**
+     * Get a {@code ExternalCredential} instance.  The returned CredentialStore object will implement the given way
+     * of getting credential.
+     *
+     * @param way the name of the way to get the credential
+     * @param nameSpace a base on which instance parameter names will be used (could be {@code null})
+     * @param provider the provider to use
+     * @return a {@code CredentialStore} instance
+     * @throws NoSuchAlgorithmException if the given way has no available implementations
+     */
+    public static ExternalCredential getInstance(String way, String nameSpace, Provider provider) throws NoSuchAlgorithmException {
+        final Provider.Service service = provider.getService(EXTERNAL_CREDENTIAL_PROVIDER_TYPE, way);
+        if (service == null) throw new NoSuchAlgorithmException(way);
+        return new ExternalCredential(provider, (ExternalCredentialSpi) service.newInstance(nameSpace), way);
+    }
+
+    /**
+     * Returns {@link Provider} which provides {@link ExternalCredentialSpi} for this instance.
+     * @return {@link Provider} of this {@link ExternalCredentialSpi}
+     */
+    public Provider getProvider() {
+        return provider;
+    }
+
+    /**
+     * Returns JCA service type of {@link ExternalCredentialSpi} for this instance.
+     * @return type of service of this {@link ExternalCredentialSpi}
+     */
+    public String getType() {
+        return type;
+    }
+
+
+    /**
+     * Resolve credential from external source using specified parameters.
+     * @param parameters to obtain external password
+     * @param credentialType type of {@link Credential} to get back form this method
+     * @param <C> type parameter of {@link Credential}
+     * @return {@link Credential} from service provider
+     * @throws ExternalCredentialException if anything goes wrong while resolving the credential
+     */
+    public <C extends Credential> C resolveCredential(Map<String, String> parameters, Class<C> credentialType)
+            throws ExternalCredentialException {
+        return spi.resolveCredential(parameters, credentialType);
+    }
+
+    /**
+     * Resolve credential from external source using password command.
+     * @param passwordCommand to obtain external password
+     * @param credentialType type of {@link Credential} to get back form this method
+     * @param <C> type parameter of {@link Credential}
+     * @return {@link Credential} from service provider
+     * @throws ExternalCredentialException if anything goes wrong while resolving the credential
+     */
+    public <C extends Credential> C resolveCredential(String passwordCommand, Class<C> credentialType)
+            throws ExternalCredentialException {
+        return spi.resolveCredential(passwordCommand, credentialType);
+    }
+
+    /**
+     * This method provides parameters supported by external credential provider. The {@code Set} can be used
+     * to filter parameters supplied {@link #resolveCredential(Map, Class)} or {@link #resolveCredential(String, Class)}
+     * methods.
+     *
+     * @return {@code Set<String>} of supported parameters
+     */
+    public Set<String> supportedParameters() {
+        return spi.supportedParameters();
+    }
+
+}

--- a/src/main/java/org/wildfly/security/credential/external/ExternalCredentialException.java
+++ b/src/main/java/org/wildfly/security/credential/external/ExternalCredentialException.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external;
+
+/**
+ * An exception indicating that operation on {@link ExternalCredential} has failed.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class ExternalCredentialException extends Exception {
+
+    private static final long serialVersionUID = 4305059234628246695L;
+
+    /**
+     * Constructs a new exception with {@code null} as its detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     */
+    public ExternalCredentialException() {
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message.  The
+     * cause is not initialized, and may subsequently be initialized by
+     * a call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     *                later retrieval by the {@link #getMessage()} method.
+     */
+    public ExternalCredentialException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A <tt>null</tt> value is
+     *                permitted, and indicates that the cause is nonexistent or
+     *                unknown.)
+     * @since 1.4
+     */
+    public ExternalCredentialException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified cause and a detail
+     * message of <tt>(cause==null ? null : cause.toString())</tt> (which
+     * typically contains the class and detail message of <tt>cause</tt>).
+     * This constructor is useful for exceptions that are little more than
+     * wrappers for other throwables (for example, {@code
+     * PrivilegedActionException}).
+     *
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method).  (A <tt>null</tt> value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     * @since 1.4
+     */
+    public ExternalCredentialException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message,
+     * cause, suppression enabled or disabled, and writable stack
+     * trace enabled or disabled.
+     *
+     * @param message            the detail message.
+     * @param cause              the cause.  (A {@code null} value is permitted,
+     *                           and indicates that the cause is nonexistent or unknown.)
+     * @param enableSuppression  whether or not suppression is enabled
+     *                           or disabled
+     * @param writableStackTrace whether or not the stack trace should
+     *                           be writable
+     * @since 1.7
+     */
+    public ExternalCredentialException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/org/wildfly/security/credential/external/ExternalCredentialSpi.java
+++ b/src/main/java/org/wildfly/security/credential/external/ExternalCredentialSpi.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.wildfly.security.credential.Credential;
+
+/**
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public abstract class ExternalCredentialSpi {
+
+    /**
+     * Resolve credential from external source using specified parameters.
+     * @param parameters to obtain external password
+     * @param credentialType type of {@link Credential} to get back form this method
+     * @param <C> type parameter of {@link Credential}
+     * @return {@link Credential} from service provider
+     * @throws ExternalCredentialException if anything goes wrong while resolving the credential
+     */
+    public abstract <C extends Credential> C resolveCredential(Map<String, String> parameters, Class<C> credentialType)
+            throws ExternalCredentialException;
+
+    /**
+     * Resolve credential from external source using password command.
+     * @param passwordCommand to obtain external password
+     * @param credentialType type of {@link Credential} to get back form this method
+     * @param <C> type parameter of {@link Credential}
+     * @return {@link Credential} from service provider
+     * @throws ExternalCredentialException if anything goes wrong while resolving the credential
+     */
+    public abstract <C extends Credential> C resolveCredential(String passwordCommand, Class<C> credentialType)
+            throws ExternalCredentialException;
+
+    /**
+     * This method provides parameters supported by external credential provider. The {@code Set} can be used
+     * to filter parameters supplied {@link #resolveCredential(Map, Class)} or {@link #resolveCredential(String, Class)}
+     * methods.
+     *
+     * @return {@code Set<String>} of supported parameters
+     */
+    public abstract Set<String> supportedParameters();
+}

--- a/src/main/java/org/wildfly/security/credential/external/PasswordClass.java
+++ b/src/main/java/org/wildfly/security/credential/external/PasswordClass.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external;
+
+import javax.security.auth.Destroyable;
+
+/**
+ * Password Class interface for classes used as external password resolvers of type 'CLASS'.
+ *
+ * Each password class specified used in {@link org.wildfly.security.credential.external.impl.ClassCredentialProvider}
+ * has to implement this interface.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+public interface PasswordClass extends Destroyable {
+    /**
+     * Method to return the password back to {@code CallbackHandler}.
+     * @return password
+     */
+    char[] getPassword();
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/ClassCredentialProvider.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/ClassCredentialProvider.java
@@ -1,0 +1,215 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.external.ExternalCredentialException;
+import org.wildfly.security.credential.external.PasswordClass;
+import org.wildfly.security.credential.store.CredentialStorePermission;
+
+/**
+ * {@link org.wildfly.security.credential.external.ExternalCredentialSpi} implementation which supports getting
+ * credentials from {@link PasswordClass}.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class ClassCredentialProvider extends ExternalCredentialProvider {
+
+    /**
+     * Parameter name which denotes class name
+     */
+    public static final String CLASS_NAME = "className";
+    /**
+     * Parameter name which denotes module name (JBoss Modules)
+     */
+    public static final String MODULE = "module";
+
+    /**
+     * Separator character between 'CLASS' and module
+     */
+    public static final String SEPARATOR = "@";
+
+    static final Set<String> SUPPORTED_PARAMETERS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(CLASS_NAME, MODULE)));
+    private static final String[] EMPTY_ARGUMENTS = new String[]{};
+
+    @Override
+    public <C extends Credential> C resolveCredential(Map<String, String> parameters, Class<C> credentialType)
+            throws ExternalCredentialException {
+        try {
+            return credentialType.cast(createCredentialFromPassword(
+                    invokePasswordClass(new ClassModuleSpec(parameters.get(CLASS_NAME), parameters.get(MODULE)),
+                            parameters, null)));
+        } catch (Exception e) {
+            throw new ExternalCredentialException(e);
+        }
+    }
+
+    @Override
+    public <C extends Credential> C resolveCredential(String passwordCommand, Class<C> credentialType)
+            throws ExternalCredentialException {
+
+        String passwordCmdType = null;
+        String passwordCmdLine = null;
+
+        // Look for a {...} prefix indicating a password command
+        if (passwordCommand.startsWith("{CLASS")) {
+            StringTokenizer tokenizer = new StringTokenizer(passwordCommand, "{}");
+            passwordCmdType = tokenizer.nextToken();
+            passwordCmdLine = tokenizer.nextToken();
+        } else {
+            throw log.passwordClassNotSpecified();
+        }
+
+        String module = null;
+        if (passwordCmdType.contains(SEPARATOR)) {
+            module = passwordCmdType.split(SEPARATOR)[1];
+        }
+        // Check for a ctor argument delimited by ':'
+        String className;
+        String constructorArguments = null;
+        String[] arguments;
+        int colon = passwordCmdLine.indexOf(':');
+        if (colon > 0) {
+            className = passwordCmdLine.substring(0, colon);
+            constructorArguments = passwordCmdLine.substring(colon + 1);
+            arguments = constructorArguments.split(",", 100);
+        } else {
+            className = passwordCmdLine;
+            arguments = EMPTY_ARGUMENTS;
+        }
+
+        try {
+            return credentialType.cast(createCredentialFromPassword(
+                    invokePasswordClass(new ClassModuleSpec(className, module),
+                            null, arguments)));
+        } catch (Exception e) {
+            throw new ExternalCredentialException(e);
+        }
+    }
+
+    /**
+     * This method provides parameters supported by external credential provider. The {@code Set} can be used
+     * to filter parameters supplied {@link #resolveCredential(Map, Class)} or {@link #resolveCredential(String, Class)}
+     * methods.
+     *
+     * @return {@code Set<String>} of supported parameters
+     */
+    @Override
+    public Set<String> supportedParameters() {
+        return SUPPORTED_PARAMETERS;
+    }
+
+
+    private static char[] invokePasswordClass(final ClassModuleSpec passwordClassSpec, final Map<String, String> passwordClassParameters, final Object[] passwordClassArguments)
+            throws ExternalCredentialException {
+
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(CredentialStorePermission.LOAD_EXTERNAL_STORE_PASSWORD);
+        }
+
+        Class<?> c;
+        try {
+            c = loadPasswordClass(passwordClassSpec);
+        } catch (Exception e) {
+            throw new ExternalCredentialException(e);
+        }
+
+        Object instance = null;
+        try {
+            if (passwordClassParameters != null && passwordClassParameters.size() > 0) {
+                Class<?>[] sig = {Map.class};
+                try {
+                    Constructor<?> ctor = c.getConstructor(sig);
+                    instance = ctor.newInstance(passwordClassParameters);
+                } catch (NoSuchMethodException e) {
+                    throw log.passwordClassProblem(e);
+                }
+            } else if (passwordClassArguments != null && passwordClassArguments.length > 0) {
+                Class<?>[] sig = null;
+                sig = new Class[passwordClassArguments.length];
+                for (int i = 0; i < passwordClassArguments.length; i++) {
+                    sig[i] = passwordClassArguments[i].getClass();
+                }
+                try {
+                    Constructor<?> ctor = c.getConstructor(sig);
+                    instance = ctor.newInstance(passwordClassArguments);
+                } catch (NoSuchMethodException e) {
+                    throw log.passwordClassProblem(e);
+                }
+            } else {
+                // Use the default constructor
+                instance = c.newInstance();
+            }
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            throw log.passwordClassProblem(e);
+        }
+
+        if (!(instance instanceof PasswordClass)) {
+            throw log.wrongPasswordClass(PasswordClass.class.getName());
+        }
+
+        char[] password;
+        try {
+            PasswordClass passwordClass = (PasswordClass)instance;
+            password = passwordClass.getPassword();
+            passwordClass.destroy();
+        } catch (Throwable e) {
+            throw new ExternalCredentialException(e);
+        }
+        return password != null ? password.clone() : null;
+    }
+
+    private static Class<?> loadPasswordClass(final ClassModuleSpec passwordClassSpec) throws Exception {
+        try {
+            return AccessController.doPrivileged((PrivilegedExceptionAction<Class<?>>) () -> {
+                if (passwordClassSpec.getClassName() == null || passwordClassSpec.getClassName().isEmpty()) {
+                    throw log.passwordClassNotSpecified();
+                } else if (passwordClassSpec.getModule() == null) {
+                    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+                    return cl.loadClass(passwordClassSpec.getClassName());
+                } else {
+                    ModuleLoader loader = Module.getCallerModuleLoader();
+                    final Module pwdClassModule = loader.loadModule(ModuleIdentifier.fromString(passwordClassSpec.getModule()));
+                    return pwdClassModule.getClassLoader().loadClass(passwordClassSpec.getClassName());
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            throw e.getException();
+        }
+    }
+
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/ClassModuleSpec.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/ClassModuleSpec.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+/**
+ * Class for helping with parsing and composing class names including module in Credential Store configurations.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+final class ClassModuleSpec {
+
+    private final String className;
+    private final String module;
+
+    private static final String SEPARATOR = ClassCredentialProvider.SEPARATOR;
+
+    /**
+     * Constructor to create new {@code ClassModuleSpec}
+     * @param className class name
+     * @param module JBoss Module name
+     */
+    ClassModuleSpec(String className, String module) {
+        this.className = className;
+        this.module = module;
+    }
+
+    /**
+     * Method to create {@code ClassModuleSpec} from {@code String} representation.
+     *
+     * @param classModuleSpec {@code String} representation of {@code ClassModuleSpec} (className [@moduleName])
+     * @return {@code ClassModuleSpec}
+     */
+    static ClassModuleSpec parse(final String classModuleSpec) {
+        if (classModuleSpec == null) {
+            throw new IllegalArgumentException("classModuleSpec==null");
+        }
+        int at = classModuleSpec.indexOf(SEPARATOR);
+        return new ClassModuleSpec(at != -1 ? classModuleSpec.substring(0, at) : classModuleSpec,
+            at != -1 ? classModuleSpec.substring(at + 1) : null);
+    }
+
+    /**
+     * Helper method to create proper {@code ClassModuleSpec} {@code String}.
+     * @param className class name
+     * @param module JBoss Module name (can be {@code null})
+     * @return {@code String} representing {@code ClassModuleSpec}
+     */
+    public static String specString(final String className, final String module) {
+        if (module == null) {
+            return className;
+        } else {
+            return className + SEPARATOR + module;
+        }
+    }
+
+    /**
+     * Returns proper {@code ClassModuleSpec} {@code String}
+     * @return {@code ClassModuleSpec} {@code String}
+     */
+    public String specString() {
+        return specString(className, module);
+    }
+
+    /**
+     * Returns class name part
+     * @return class name part
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * Returns module name part
+     * @return module name part
+     */
+    public String getModule() {
+        return module;
+    }
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/CmdCredentialProvider.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/CmdCredentialProvider.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.external.ExternalCredentialException;
+import org.wildfly.security.credential.store.CredentialStorePermission;
+
+/**
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class CmdCredentialProvider extends ExecCredentialProvider {
+
+    /**
+     * Default constructor
+     */
+    public CmdCredentialProvider() {
+        SUPPORTED_CMD_TYPE = "CMD";
+    }
+
+    /**
+     * Executes command in operating system. In case of Java Security Manager active uses
+     * doPrivileged to start the command.
+     * @param cmd command as operating system accepts
+     * @return {@link Credential} transformed using {@link ExternalCredentialProvider#createCredentialFromPassword(char[])}
+     * @throws ExternalCredentialException when something goes wrong
+     */
+    Credential execute(String cmd) throws ExternalCredentialException {
+
+        final SecurityManager sm = System.getSecurityManager();
+        CmdRuntimeActions action;
+        if (sm != null) {
+            sm.checkPermission(CredentialStorePermission.LOAD_EXTERNAL_STORE_PASSWORD);
+            action = CmdRuntimeActions.PRIVILEGED;
+        } else {
+            action = CmdRuntimeActions.NON_PRIVILEGED;
+        }
+
+        try {
+            return createCredentialFromPassword(action.execCmd(cmd));
+        } catch (Exception e) {
+            throw log.passwordCommandExecutionProblem(
+                    log.isInfoEnabled() ? cmd : "not shown", e);
+        }
+    }
+
+    private interface CmdRuntimeActions {
+
+        CmdRuntimeActions NON_PRIVILEGED = new CmdRuntimeActions() {
+            public char[] execCmd(final String command) throws Exception {
+                final ProcessBuilder builder = new ProcessBuilder(parseCommand(command));
+                final Process process = builder.start();
+                final String line;
+                BufferedReader reader = null;
+                try {
+                    reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                    line = reader.readLine();
+                } finally {
+                    if (reader != null)
+                        reader.close();
+                }
+
+                int exitCode = process.waitFor();
+                if (log.isTraceEnabled())
+                    log.tracef("Exit code from password command = %d", Integer.valueOf(exitCode));
+                return line != null ? line.toCharArray() : null;
+            }
+
+            protected String[] parseCommand(String command) {
+                // comma can be back slashed
+                final String[] parsedCommand = command.split("(?<!\\\\),");
+                for (int k = 0; k < parsedCommand.length; k++) {
+                    if (parsedCommand[k].indexOf('\\') != -1)
+                        parsedCommand[k] = parsedCommand[k].replaceAll("\\\\,", ",");
+                }
+                return parsedCommand;
+            }
+
+        };
+
+        CmdRuntimeActions PRIVILEGED = command -> {
+            try {
+                char[] password = AccessController.doPrivileged((PrivilegedExceptionAction<char[]>) () -> NON_PRIVILEGED.execCmd(command));
+                return password;
+            } catch (PrivilegedActionException e) {
+                throw e.getException();
+            }
+        };
+
+        char[] execCmd(String cmd) throws Exception;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/ExecCredentialProvider.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/ExecCredentialProvider.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.external.ExternalCredentialException;
+import org.wildfly.security.credential.store.CredentialStorePermission;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+/**
+ * {@link org.wildfly.security.credential.external.ExternalCredentialSpi} implementation which supports getting
+ * credentials using {@code Runtime#exec} method.
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class ExecCredentialProvider extends ExternalCredentialProvider {
+
+    /**
+     * Parameter name which denotes command line
+     */
+    public static final String COMMAND_LINE = "exec.command";
+    /**
+     * Parameter name which denotes execution type
+     */
+    public static final String EXEC_TYPE = "exec.type";
+
+    String SUPPORTED_CMD_TYPE = "EXT";
+
+    static final Set<String> SUPPORTED_PARAMETERS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(EXEC_TYPE, COMMAND_LINE)));
+
+    @Override
+    public <C extends Credential> C resolveCredential(Map<String, String> parameters, Class<C> credentialType) throws ExternalCredentialException {
+        String passwordCommand = parameters.get(COMMAND_LINE);
+        String execType = parameters.get(EXEC_TYPE);
+
+        if (execType != null && !execType.equals(SUPPORTED_CMD_TYPE)) {
+            throw log.executionTypeNotSupported(execType);
+        }
+
+        if (passwordCommand != null) {
+            return credentialType.cast(execute(passwordCommand));
+        } else {
+            throw log.passwordCommandNotSpecified();
+        }
+    }
+
+    @Override
+    public <C extends Credential> C resolveCredential(String passwordCommand, Class<C> credentialType) throws ExternalCredentialException {
+
+        String passwordCmdType;
+        String passwordCmdLine;
+
+        // Look for a {...} prefix indicating a password command
+        if (passwordCommand.trim().startsWith("{" + SUPPORTED_CMD_TYPE)) {
+            StringTokenizer tokenizer = new StringTokenizer(passwordCommand, "{}");
+            passwordCmdType = tokenizer.nextToken();
+            passwordCmdLine = tokenizer.nextToken();
+        } else {
+            passwordCmdType = SUPPORTED_CMD_TYPE;
+            passwordCmdLine = passwordCommand;
+        }
+
+        if (!passwordCmdType.equals(SUPPORTED_CMD_TYPE)) {
+            throw log.cacheForExternalCommandsNotSupported();
+        }
+
+        return credentialType.cast(execute(passwordCmdLine));
+    }
+
+    /**
+     * This method provides parameters supported by external credential provider. The {@code Set} can be used
+     * to filter parameters supplied {@link #resolveCredential(Map, Class)} or {@link #resolveCredential(String, Class)}
+     * methods.
+     *
+     * @return {@code Set<String>} of supported parameters
+     */
+    @Override
+    public Set<String> supportedParameters() {
+        return SUPPORTED_PARAMETERS;
+    }
+
+
+    /**
+     * Executes command in operating system. In case of Java Security Manager active uses
+     * doPrivileged to start the command.
+     * @param cmd command as operating system accepts
+     * @return {@link Credential} transformed using {@link ExternalCredentialProvider#createCredentialFromPassword(char[])}
+     * @throws ExternalCredentialException when something goes wrong
+     */
+    Credential execute(String cmd) throws ExternalCredentialException {
+
+        final SecurityManager sm = System.getSecurityManager();
+        ExecRuntimeActions action;
+        if (sm != null) {
+            sm.checkPermission(CredentialStorePermission.LOAD_EXTERNAL_STORE_PASSWORD);
+            action = ExecRuntimeActions.PRIVILEGED;
+        } else {
+            action = ExecRuntimeActions.NON_PRIVILEGED;
+        }
+
+        try {
+            return createCredentialFromPassword(action.execCmd(cmd));
+        } catch (Exception e) {
+            throw log.passwordCommandExecutionProblem(
+                    log.isInfoEnabled() ? cmd : "not shown", e);
+        }
+    }
+
+
+    private interface ExecRuntimeActions {
+
+        ExecRuntimeActions NON_PRIVILEGED = cmd -> {
+            Runtime rt = Runtime.getRuntime();
+            Process p = rt.exec(cmd);
+            InputStream stdin = null;
+            String line;
+            BufferedReader reader = null;
+            try {
+                stdin = p.getInputStream();
+                reader = new BufferedReader(new InputStreamReader(stdin));
+                line = reader.readLine();
+            } finally {
+                if (reader != null)
+                    reader.close();
+                if (stdin != null)
+                    stdin.close();
+            }
+
+            int exitCode = p.waitFor();
+            if (log.isTraceEnabled())
+                log.tracef("Exit code from password command = %d", Integer.valueOf(exitCode));
+            return line != null ? line.toCharArray() : null;
+        };
+
+        ExecRuntimeActions PRIVILEGED = cmd -> {
+            try {
+                return AccessController.doPrivileged((PrivilegedExceptionAction<char[]>) () -> NON_PRIVILEGED.execCmd(cmd));
+            } catch (PrivilegedActionException e) {
+                throw e.getException();
+            }
+        };
+
+        char[] execCmd(String cmd) throws Exception;
+    }
+
+
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/ExternalCredentialProvider.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/ExternalCredentialProvider.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.external.ExternalCredentialSpi;
+import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+
+/**
+ * Base class of all external credential providers.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+abstract class ExternalCredentialProvider extends ExternalCredentialSpi {
+
+    protected Credential createCredentialFromPassword(char[] password) throws UnsupportedCredentialTypeException {
+        try {
+            PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+            return new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec(password)));
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new UnsupportedCredentialTypeException(e);
+        }
+    }
+
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/ExternalCredentialProviderName.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/ExternalCredentialProviderName.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+/**
+ * Short names for {@link org.wildfly.security.credential.external.ExternalCredentialSpi} implementations.
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+public enum ExternalCredentialProviderName {
+
+    /**
+     * ExternalCredentialProvider short name for using {EXT} type of call as known from older Vault implementations.
+     */
+    EXT("EXT", ExecCredentialProvider.class.getName()),
+
+    /**
+     * ExternalCredentialProvider short name for using {CMD} type of call as known from older Vault implementations.
+     */
+    CMD("CMD", CmdCredentialProvider.class.getName()),
+
+    /**
+     * ExternalCredentialProvider short name for using {CLASS} type of call as known from older Vault implementations.
+     */
+    CLASS("CLASS", ClassCredentialProvider.class.getName()),
+
+    /**
+     * ExternalCredentialProvider short name for MASKED callback used to decrypt PBE masked passwords.
+     */
+    MASKED("MASKED", MaskedPasswordCredentialProvider.class.getName())
+    ;
+
+    private final String way;
+    private final String className;
+
+    ExternalCredentialProviderName(final String way, final String className) {
+        this.way = way;
+        this.className = className;
+    }
+
+    /**
+     * Get class name behind the shorten name.
+     * @return className of this short name
+     */
+    public final String get() {
+        return className;
+    }
+
+    /**
+     * Get a way constant of obtaining credential
+     * @return way string
+     */
+    public String way() {
+        return way;
+    }
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/MaskedPasswordCredentialProvider.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/MaskedPasswordCredentialProvider.java
@@ -1,0 +1,213 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.external.impl;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.external.ExternalCredentialException;
+import org.wildfly.security.util.Alphabet;
+import org.wildfly.security.util.ByteIterator;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wildfly.security._private.ElytronMessages.log;
+
+/**
+ * Provider handling password decoding from masked string using PBE algorithms.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class MaskedPasswordCredentialProvider extends ExternalCredentialProvider {
+
+    private final String nameSpace;
+
+    /**
+     * Parameter name which denotes masked password string
+     */
+    public static final String PASSWORD = "password";
+    /**
+     * Parameter name which denotes salt
+     */
+    public static final String SALT = "salt";
+    /**
+     * Parameter name which denotes iteration count
+     */
+    public static final String ITERATION_COUNT = "iteration";
+    /**
+     * Parameter name which denotes PBE algorithm
+     */
+    public static final String PBE_ALGORITHM = "algorithm";
+    /**
+     * Parameter name which denotes initial key for PBE algorithm
+     */
+    public static final String INITIAL_KEY = "initialKey";
+
+    private final Set<String> supportedParameters;
+
+    /**
+     * Prefix to used when masked password needs to be detected.
+     */
+    public static String PASS_MASK_PREFIX = "MASK-";
+
+    private static final char[] DEFAULT_PBE_KEY = "somearbitrarycrazystringthatdoesnotmatter".toCharArray();
+    static final String DEFAULT_PBE_ALGORITHM = "PBEwithMD5andDES";
+
+
+    /**
+     * Constructor of {@code MaskedPasswordCredentialProvider} using namespace to distinguish among more
+     * masked passwords in the same set of parameters.
+     * @param nameSpace a base on which parameter names will be used
+     */
+    public MaskedPasswordCredentialProvider(String nameSpace) {
+        Assert.assertNotNull(nameSpace);
+        this.nameSpace = nameSpace;
+        supportedParameters = Collections.unmodifiableSet(new HashSet<>(
+                Arrays.asList(this.nameSpace + "." + SALT,
+                        this.nameSpace + "." + ITERATION_COUNT,
+                        this.nameSpace + "." + PBE_ALGORITHM,
+                        this.nameSpace + "." + INITIAL_KEY)));
+    }
+
+    @Override
+    public <C extends Credential> C resolveCredential(Map<String, String> parameters, Class<C> credentialType) throws ExternalCredentialException {
+        try {
+            return credentialType.cast(
+                    createCredentialFromPassword(
+                            decode(getPassword(parameters),
+                                    getSalt(parameters),
+                                    getIterationCount(parameters),
+                                    getPbeAlgorithm(parameters),
+                                    getInitialKey(parameters))));
+        } catch (Exception e) {
+            throw new ExternalCredentialException(e);
+        }
+    }
+
+    /**
+     * Method is not supported in this provider.
+     * @param passwordCommand to obtain external password
+     * @param credentialType type of {@link Credential} to get back form this method
+     * @param <C> type parameter of {@link Credential}
+     * @return {@link Credential} from service provider
+     * @throws ExternalCredentialException if anything goes wrong while resolving the credential
+     */
+    @Override
+    public <C extends Credential> C resolveCredential(String passwordCommand, Class<C> credentialType) throws ExternalCredentialException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This method provides parameters supported by external credential provider. The {@code Set} can be used
+     * to filter parameters supplied {@link #resolveCredential(Map, Class)} or {@link #resolveCredential(String, Class)}
+     * methods.
+     *
+     * @return {@code Set<String>} of supported parameters
+     */
+    @Override
+    public Set<String> supportedParameters() {
+        return supportedParameters;
+    }
+
+    /**
+     * This decodes password encoded using {@code PBEUtils} class of PicketBox.
+     *
+     * Method ported from PicketBox to maintain backward compatibility.
+     *
+     * @param maskedString masked password string including (masked) prefix
+     * @param salt salt
+     * @param iterationCount iteration count
+     * @param pbeAlgorithm PBE algorithm. {@code null} for default value.
+     * @param initialKey initial key. {@code null} for default value.
+     * @return returns clear text password
+     * @throws Exception when anything goes wrong
+     */
+    static char[] decode(final String maskedString, final String salt, final int iterationCount,
+                                final String pbeAlgorithm, final String initialKey) throws Exception {
+
+        String algorithm = pbeAlgorithm != null ? pbeAlgorithm : DEFAULT_PBE_ALGORITHM;
+        String encryptedBase64EncodedSecret = maskedString.startsWith(PASS_MASK_PREFIX) ? maskedString.substring(PASS_MASK_PREFIX.length()) : maskedString;
+        // Create the PBE secret key
+        SecretKeyFactory factory = SecretKeyFactory.getInstance(algorithm);
+
+        char[] initialKeyMaterial = initialKey != null ? initialKey.toCharArray() : DEFAULT_PBE_KEY;
+        PBEParameterSpec cipherSpec = new PBEParameterSpec(salt.getBytes(StandardCharsets.UTF_8), iterationCount);
+        PBEKeySpec keySpec = new PBEKeySpec(initialKeyMaterial);
+        SecretKey cipherKey = factory.generateSecret(keySpec);
+
+        return decode64(encryptedBase64EncodedSecret, algorithm, cipherKey, cipherSpec).toCharArray();
+    }
+
+    private static String decode64(String secret, String cipherAlgorithm, SecretKey cipherKey, PBEParameterSpec cipherSpec)
+            throws Exception {
+        byte[] encoding;
+        try {
+            encoding = ByteIterator.ofBytes(secret.getBytes(StandardCharsets.UTF_8)).base64Decode(Alphabet.Base64Alphabet.PICKETBOX_BASE_64).drain();
+        } catch (IllegalArgumentException e) {
+            // fallback when original string is was created with faulty version of Base64
+            String fallBack = "0" + secret;
+            encoding = ByteIterator.ofBytes((fallBack).getBytes(StandardCharsets.UTF_8)).base64Decode().drain();
+            log.warnWrongBase64EncodedString(fallBack);
+        }
+        byte[] decoded = decode(encoding, cipherAlgorithm, cipherKey, cipherSpec);
+
+        return new String(decoded, StandardCharsets.UTF_8);
+    }
+
+    private static byte[] decode(byte[] secret, String cipherAlgorithm, SecretKey cipherKey, PBEParameterSpec cipherSpec)
+            throws Exception {
+        Cipher cipher = Cipher.getInstance(cipherAlgorithm);
+        cipher.init(Cipher.DECRYPT_MODE, cipherKey, cipherSpec);
+        byte[] decode = cipher.doFinal(secret);
+        return decode;
+    }
+
+    String getSalt(final Map<String, String> parameters) {
+        return parameters.get(nameSpace + "." + SALT);
+    }
+
+    int getIterationCount(final Map<String, String> parameters) {
+        String iterationCount = parameters.get(nameSpace + "." + ITERATION_COUNT);
+        if (iterationCount != null) {
+            return Integer.parseInt(iterationCount);
+        } else {
+            throw new IllegalArgumentException(nameSpace + "." + ITERATION_COUNT);
+        }
+    }
+
+    String getPbeAlgorithm(final Map<String, String> parameters) {
+        return parameters.get(nameSpace + "." + PBE_ALGORITHM);
+    }
+
+    String getInitialKey(final Map<String, String> parameters) {
+        return parameters.get(nameSpace + "." + INITIAL_KEY);
+    }
+
+    String getPassword(final Map<String, String> parameters) {
+        return parameters.get(nameSpace + "." + PASSWORD);
+    }
+}

--- a/src/main/java/org/wildfly/security/credential/external/impl/package-info.java
+++ b/src/main/java/org/wildfly/security/credential/external/impl/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package to hold provider implementations for credential gathering from external sources like operating
+ * system key rings.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+package org.wildfly.security.credential.external.impl;

--- a/src/main/java/org/wildfly/security/credential/external/package-info.java
+++ b/src/main/java/org/wildfly/security/credential/external/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package for external credential API/SPI classes and interfaces.
+ * They are used to gather credentials from external sources like operating system
+ * facilities for storing secrets.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+package org.wildfly.security.credential.external;

--- a/src/main/java/org/wildfly/security/credential/store/CredentialStorePermission.java
+++ b/src/main/java/org/wildfly/security/credential/store/CredentialStorePermission.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.credential.store;
+
+import java.security.BasicPermission;
+
+/**
+ * Credential Store API specific permission. It can have following target names:
+ * <ul>
+ *  <li>{@code loadCredentialStore}</li>
+ *  <li>{@code loadExternalStorePassword}</li>
+ *  <li>{@code retrieveCredential}</li>
+ *  <li>{@code modifyCredentialStore}</li>
+ * </ul>
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+public class CredentialStorePermission extends BasicPermission {
+
+    private static final long serialVersionUID = 6248622485149435793L;
+
+    enum Name {
+        loadCredentialStore,
+        loadExternalStorePassword,
+        retrieveCredential,
+        modifyCredentialStore
+        ;
+
+        private final CredentialStorePermission permission;
+
+        Name() {
+            permission = new CredentialStorePermission(this);
+        }
+
+        CredentialStorePermission getPermission() {
+            return permission;
+        }
+
+        public static Name of(final String name) {
+            try {
+                return valueOf(name);
+            } catch (IllegalArgumentException ignored) {
+                throw new IllegalArgumentException(name.toString());
+            }
+        }
+
+    }
+
+    /**
+     * Load credential store permission.
+     */
+    public static final CredentialStorePermission LOAD_CREDENTIAL_STORE = Name.loadCredentialStore.getPermission();
+    /**
+     * Load external store password permission.
+     */
+    public static final CredentialStorePermission LOAD_EXTERNAL_STORE_PASSWORD = Name.loadExternalStorePassword.getPermission();
+    /**
+     * Retrieve credential (password) permission (from credential store).
+     */
+    public static final CredentialStorePermission RETRIEVE_CREDENTIAL = Name.retrieveCredential.getPermission();
+    /**
+     * Store or delete credential (password) permission (from credential store).
+     */
+    public static final CredentialStorePermission MODIFY_CREDENTIAL_STORE = Name.modifyCredentialStore.getPermission();
+
+
+    /**
+     * Creates new {@code CredentialStorePermission} using {@link CredentialStorePermission.Name}
+     * @param name of new {@code CredentialStorePermission}
+     */
+    public CredentialStorePermission(final Name name) {
+        super(name.toString());
+    }
+
+
+    /**
+     * Creates new {@code CredentialStorePermission}
+     * @param name of new {@code CredentialStorePermission}
+     */
+    public CredentialStorePermission(final String name) {
+        this(Name.of(name));
+    }
+
+    /**
+     * Creates new {@code CredentialStorePermission}
+     * @param name of new {@code CredentialStorePermission}
+     * @param actions have to be {@code null}
+     */
+    public CredentialStorePermission(final String name, final String actions) {
+        this(name);
+        if (actions != null || !actions.isEmpty()) {
+            throw new IllegalArgumentException("Actions cannot be specified (use null)");
+        }
+    }
+
+}

--- a/src/main/java/org/wildfly/security/util/Alphabet.java
+++ b/src/main/java/org/wildfly/security/util/Alphabet.java
@@ -269,4 +269,41 @@ public abstract class Alphabet {
             }
         };
     }
+
+    /**
+     * The alphabet used by PicketBox project base 64 encoding.
+     * {@code 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz./}
+     */
+    public static final Base64Alphabet PICKETBOX_BASE_64 = new Base64Alphabet(false) {
+        public int encode(int val) {
+            if (val <= 9) {
+                return '0' + val;
+            } else if (val <= 35) {
+                return 'A' + val - 10;
+            } else if (val <= 61) {
+                return 'a' + val - 36;
+            } else if (val == 62) {
+                return '.';
+            } else {
+                assert val == 63;
+                return '/';
+            }
+        }
+
+        public int decode(int codePoint) {
+            if ('0' <= codePoint && codePoint <= '9') {
+                return codePoint - '0';
+            } else if ('A' <= codePoint && codePoint <= 'Z') {
+                return codePoint - 'A' + 10;
+            } else if ('a' <= codePoint && codePoint <= 'z') {
+                return codePoint - 'a' + 36;
+            } else if (codePoint == '.') {
+                return 62;
+            } else if (codePoint == '/') {
+                return 63;
+            } else {
+                return -1;
+            }
+        }
+    };
 }


### PR DESCRIPTION
Instead of using different callback handlers and callbacks external credential gathering is switched to JCA style providers.
PR contains SPI implementations which ensures compatibility with PicketBox vault methods for external password gathering. 
This approach allow users to contribute they own providers in an easy way.