### PR TITLE
LDAP security realm - create + delete identity

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -411,6 +411,15 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1096, value = "No such identity")
     RealmUnavailableException noSuchIdentity();
 
+    @Message(id = 1097, value = "Ldap-backed realm failed to delete identity from server")
+    RealmUnavailableException ldapRealmFailedDeleteIdentityFromServer(@Cause Throwable cause);
+
+    @Message(id = 1098, value = "Ldap-backed realm failed to create identity on server")
+    RealmUnavailableException ldapRealmFailedCreateIdentityOnServer(@Cause Throwable cause);
+
+    @Message(id = 1099, value = "Ldap-backed realm is not configured to allow create new identities (new identity parent and attributes has to be set)")
+    RealmUnavailableException ldapRealmNotConfiguredToSupportCreatingIdentities();
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
@@ -25,6 +25,8 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import org.wildfly.common.Assert;
 import org.wildfly.security.auth.server.NameRewriter;
 
+import javax.naming.directory.Attributes;
+import javax.naming.ldap.LdapName;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -182,6 +184,8 @@ public class LdapSecurityRealmBuilder {
         private String nameAttribute;
         private int searchTimeLimit = 10000;
         private List<AttributeMapping> attributes = new ArrayList<>();
+        private LdapName newIdentityParent = null;
+        private Attributes newIdentityAttributes = null;
 
         /**
          * <p>Set the name of the context to be used when executing queries.
@@ -242,6 +246,20 @@ public class LdapSecurityRealmBuilder {
             return this;
         }
 
+        public IdentityMappingBuilder setNewIdentityParent(LdapName newIdentityParent) {
+            assertNotBuilt();
+
+            this.newIdentityParent = newIdentityParent;
+            return this;
+        }
+
+        public IdentityMappingBuilder setNewIdentityAttributes(Attributes newIdentityAttributes) {
+            assertNotBuilt();
+
+            this.newIdentityAttributes = newIdentityAttributes;
+            return this;
+        }
+
         /**
          * Define an attribute mapping configuration.
          *
@@ -260,7 +278,7 @@ public class LdapSecurityRealmBuilder {
             built = true;
 
             return LdapSecurityRealmBuilder.this.setIdentityMapping(new IdentityMapping(
-                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes));
+                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes, newIdentityParent, newIdentityAttributes));
         }
 
         private void assertNotBuilt() {

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ldap;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder;
+import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+
+import javax.naming.InvalidNameException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.ldap.LdapName;
+
+/**
+ * Test case to test creating and removing identities in LDAP
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class ModifiabilityTest {
+
+    @ClassRule
+    public static DirContextFactoryRule dirContextFactory = new DirContextFactoryRule();
+    private static SecurityRealm realm;
+
+    @BeforeClass
+    public static void createRealm() throws InvalidNameException {
+
+        Attributes attributes = new BasicAttributes(true);
+        BasicAttribute objectClass = new BasicAttribute("objectClass");
+        objectClass.add("top");
+        objectClass.add("inetOrgPerson");
+        objectClass.add("person");
+        objectClass.add("organizationalPerson");
+        attributes.put(objectClass);
+        attributes.put(new BasicAttribute("sn", "aaa"));
+        attributes.put(new BasicAttribute("cn", "bbb"));
+
+        realm = LdapSecurityRealmBuilder.builder()
+            .setDirContextFactory(dirContextFactory.create())
+            .identityMapping()
+                .setSearchDn("dc=elytron,dc=wildfly,dc=org")
+                .setRdnIdentifier("uid")
+                .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
+                .setNewIdentityAttributes(attributes)
+                .build()
+            .build();
+    }
+
+    @Test
+    public void testCreateDelete() throws RealmUnavailableException, InterruptedException {
+        ModifiableRealmIdentity identity = (ModifiableRealmIdentity) realm.getRealmIdentity("myNewIdentity");
+        Assert.assertFalse(identity.exists());
+        identity.create();
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity("myNewIdentity");
+        Assert.assertTrue(identity.exists());
+        identity.delete();
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity("myNewIdentity");
+        Assert.assertFalse(identity.exists());
+    }
+
+    @Test
+    public void testCreateDeleteEscaped() throws RealmUnavailableException, InterruptedException {
+        String horribleIdentityName = " escape testing identity name , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! ' ";
+
+        ModifiableRealmIdentity identity = (ModifiableRealmIdentity) realm.getRealmIdentity(horribleIdentityName);
+        Assert.assertFalse(identity.exists());
+        identity.create();
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity(horribleIdentityName);
+        Assert.assertTrue(identity.exists());
+        identity.delete();
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity(horribleIdentityName);
+        Assert.assertFalse(identity.exists());
+    }
+}

--- a/src/test/java/org/wildfly/security/ldap/TestEnvironmentTest.java
+++ b/src/test/java/org/wildfly/security/ldap/TestEnvironmentTest.java
@@ -32,8 +32,6 @@ import static org.junit.Assert.fail;
 /**
  * Test case to test connectivity to the server, also verifies that the user accounts in use are all correctly registered.
  *
- * As a test case it is indented this is only executed as part of the {@link LdapTestSuite} so that the required LDAP server is running.
- *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class TestEnvironmentTest {


### PR DESCRIPTION
* Creating and removing identity in Ldap realm. (Usernames escaping in DN should be safe)
* Parent node and attributes (include objectClass) of new identities has to be set as part of IdentityMapping (Do you agree this a good place for this configuration?)