### PR TITLE
[ELY-394] Allow MechanismConfiguration and MechanismRealmConfiguration to override the RealmMapper

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/MechanismConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismConfiguration.java
@@ -44,15 +44,17 @@ public final class MechanismConfiguration {
     private final NameRewriter preRealmRewriter;
     private final NameRewriter postRealmRewriter;
     private final NameRewriter finalRewriter;
+    private final RealmMapper realmMapper;
     private final Map<String, MechanismRealmConfiguration> mechanismRealms;
     private final List<SecurityFactory<Credential>> serverCredentialFactories;
 
-    MechanismConfiguration(final NameRewriter preRealmRewriter, final NameRewriter postRealmRewriter, final NameRewriter finalRewriter, final Collection<MechanismRealmConfiguration> mechanismRealms, final List<SecurityFactory<Credential>> serverCredentialFactories) {
+    MechanismConfiguration(final NameRewriter preRealmRewriter, final NameRewriter postRealmRewriter, final NameRewriter finalRewriter, final RealmMapper realmMapper, final Collection<MechanismRealmConfiguration> mechanismRealms, final List<SecurityFactory<Credential>> serverCredentialFactories) {
         Assert.checkNotNullParam("mechanismRealms", mechanismRealms);
         Assert.checkNotNullParam("serverCredentials", serverCredentialFactories);
         this.preRealmRewriter = preRealmRewriter;
         this.postRealmRewriter = postRealmRewriter;
         this.finalRewriter = finalRewriter;
+        this.realmMapper = realmMapper;
         final Iterator<MechanismRealmConfiguration> iterator = mechanismRealms.iterator();
         if (! iterator.hasNext()) {
             // zero
@@ -104,6 +106,15 @@ public final class MechanismConfiguration {
     }
 
     /**
+     * Get the realm mapper.
+     *
+     * @return the realm mapper, or {@code null} to use the default
+     */
+    public RealmMapper getRealmMapper() {
+        return realmMapper;
+    }
+
+    /**
      * Get the collection of mechanism realm names, in order.  If no realms are configured, the collection will be
      * empty.
      *
@@ -151,6 +162,7 @@ public final class MechanismConfiguration {
         private NameRewriter preRealmRewriter;
         private NameRewriter postRealmRewriter;
         private NameRewriter finalRewriter;
+        private RealmMapper realmMapper;
         private List<MechanismRealmConfiguration> mechanismRealms;
         private List<SecurityFactory<Credential>> serverCredentials;
 
@@ -172,6 +184,11 @@ public final class MechanismConfiguration {
 
         public Builder setFinalRewriter(final NameRewriter finalRewriter) {
             this.finalRewriter = finalRewriter;
+            return this;
+        }
+
+        public Builder setRealmMapper(final RealmMapper realmMapper) {
+            this.realmMapper = realmMapper;
             return this;
         }
 
@@ -235,12 +252,12 @@ public final class MechanismConfiguration {
             } else {
                 serverCredentials = unmodifiableList(asList(serverCredentials.toArray(NO_CREDENTIALS)));
             }
-            return new MechanismConfiguration(preRealmRewriter, postRealmRewriter, finalRewriter, mechanismRealms, serverCredentials);
+            return new MechanismConfiguration(preRealmRewriter, postRealmRewriter, finalRewriter, realmMapper, mechanismRealms, serverCredentials);
         }
     }
 
     /**
      * An empty mechanism configuration..
      */
-    public static final MechanismConfiguration EMPTY = new MechanismConfiguration(null, null, null, emptyList(), emptyList());
+    public static final MechanismConfiguration EMPTY = new MechanismConfiguration(null, null, null, null, emptyList(), emptyList());
 }

--- a/src/main/java/org/wildfly/security/auth/server/MechanismRealmConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismRealmConfiguration.java
@@ -30,6 +30,7 @@ public final class MechanismRealmConfiguration {
     private final NameRewriter preRealmRewriter;
     private final NameRewriter postRealmRewriter;
     private final NameRewriter finalRewriter;
+    private final RealmMapper realmMapper;
 
     /**
      * Construct a new instance.
@@ -38,12 +39,14 @@ public final class MechanismRealmConfiguration {
      * @param preRealmRewriter the pre-realm rewriter to apply (may not be {@code null})
      * @param postRealmRewriter the post-realm rewriter to apply (may not be {@code null})
      * @param finalRewriter the final rewriter to apply (may not be {@code null})
+     * @param realmMapper the realm mapper to use
      */
-    MechanismRealmConfiguration(final String realmName, final NameRewriter preRealmRewriter, final NameRewriter postRealmRewriter, final NameRewriter finalRewriter) {
+    MechanismRealmConfiguration(final String realmName, final NameRewriter preRealmRewriter, final NameRewriter postRealmRewriter, final NameRewriter finalRewriter, final RealmMapper realmMapper) {
         this.realmName = realmName;
         this.preRealmRewriter = preRealmRewriter;
         this.postRealmRewriter = postRealmRewriter;
         this.finalRewriter = finalRewriter;
+        this.realmMapper = realmMapper;
     }
 
     /**
@@ -83,9 +86,18 @@ public final class MechanismRealmConfiguration {
     }
 
     /**
+     * Get the realm mapper for this mechanism realm.
+     *
+     * @return the realm mapper for this mechanism realm, or {@code null} to use the default
+     */
+    public RealmMapper getRealmMapper() {
+        return realmMapper;
+    }
+
+    /**
      * A realm configuration for no particular realm, which does no additional rewriting.
      */
-    public static final MechanismRealmConfiguration NO_REALM = new MechanismRealmConfiguration("none", null, null, null);
+    public static final MechanismRealmConfiguration NO_REALM = new MechanismRealmConfiguration("none", null, null, null, null);
 
     /**
      * Obtain a new {@link Builder} capable of building a {@link MechanismRealmConfiguration}.
@@ -101,6 +113,7 @@ public final class MechanismRealmConfiguration {
         private NameRewriter preRealmRewriter;
         private NameRewriter postRealmRewriter;
         private NameRewriter finalRewriter;
+        private RealmMapper realmMapper;
 
         /**
          * Construct a new instance.
@@ -132,9 +145,14 @@ public final class MechanismRealmConfiguration {
             return this;
         }
 
+        public Builder setRealmMapper(final RealmMapper realmMapper) {
+            this.realmMapper = realmMapper;
+            return this;
+        }
+
         public MechanismRealmConfiguration build() {
             Assert.checkNotNullParam("realmName", realmName);
-            return new MechanismRealmConfiguration(realmName, preRealmRewriter, postRealmRewriter, finalRewriter);
+            return new MechanismRealmConfiguration(realmName, preRealmRewriter, postRealmRewriter, finalRewriter, realmMapper);
         }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -345,6 +345,14 @@ public final class SecurityDomain {
         return realm != null ? realm : defaultRealmName;
     }
 
+    String getDefaultRealmName() {
+        return defaultRealmName;
+    }
+
+    RealmMapper getRealmMapper() {
+        return realmMapper;
+    }
+
     NameRewriter getPostRealmRewriter() {
         return postRealmRewriter;
     }

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -150,7 +150,8 @@ public final class ServerAuthenticationContext {
         // principal *must* be captured at this point
         final NamePrincipal principal = new NamePrincipal(name);
         name = rewriteAll(name, mechanismRealmConfiguration.getPostRealmRewriter(), mechanismConfiguration.getPostRealmRewriter(), domain.getPostRealmRewriter());
-        final RealmInfo realmInfo = domain.getRealmInfo(domain.mapRealmName(name));
+        String realmName = mapAll(name, mechanismRealmConfiguration.getRealmMapper(), mechanismConfiguration.getRealmMapper(), domain.getRealmMapper(), domain.getDefaultRealmName());
+        final RealmInfo realmInfo = domain.getRealmInfo(realmName);
         name = rewriteAll(name, mechanismRealmConfiguration.getFinalRewriter(), mechanismConfiguration.getFinalRewriter(), realmInfo.getNameRewriter());
         // name should remain
         if (oldState.getId() == ASSIGNED_ID) {
@@ -228,7 +229,7 @@ public final class ServerAuthenticationContext {
             }
         }
         name = rewriteAll(name, mechanismRealmConfiguration.getPreRealmRewriter(), mechanismConfiguration.getPreRealmRewriter(), domain.getPreRealmRewriter());
-        String realmName = domain.mapRealmName(name);
+        String realmName = mapAll(name, mechanismRealmConfiguration.getRealmMapper(), mechanismConfiguration.getRealmMapper(), domain.getRealmMapper(), domain.getDefaultRealmName());
         RealmInfo realmInfo = domain.getRealmInfo(realmName);
         name = rewriteAll(name, mechanismRealmConfiguration.getPostRealmRewriter(), mechanismConfiguration.getPostRealmRewriter(), domain.getPostRealmRewriter());
         name = rewriteAll(name, mechanismRealmConfiguration.getFinalRewriter(), mechanismConfiguration.getFinalRewriter(), realmInfo.getNameRewriter());
@@ -399,7 +400,8 @@ public final class ServerAuthenticationContext {
 
             // continue rewriting to locate the new authorization identity
             name = rewriteAll(name, mechanismRealmConfiguration.getPostRealmRewriter(), mechanismConfiguration.getPostRealmRewriter(), domain.getPostRealmRewriter());
-            final RealmInfo realmInfo = domain.getRealmInfo(domain.mapRealmName(name));
+            String realmName = mapAll(name, mechanismRealmConfiguration.getRealmMapper(), mechanismConfiguration.getRealmMapper(), domain.getRealmMapper(), domain.getDefaultRealmName());
+            final RealmInfo realmInfo = domain.getRealmInfo(realmName);
             name = rewriteAll(name, mechanismRealmConfiguration.getFinalRewriter(), mechanismConfiguration.getFinalRewriter(), realmInfo.getNameRewriter());
 
             // now construct the new identity
@@ -818,6 +820,24 @@ public final class ServerAuthenticationContext {
             return validatedRewrite(name, r3);
         }
         return name;
+    }
+
+    static String mapAll(String name, RealmMapper r1, RealmMapper r2, RealmMapper r3, String defaultRealmName) {
+        if (r1 != null) {
+            return mapRealmName(name, r1, defaultRealmName);
+        }
+        if (r2 != null) {
+            return mapRealmName(name, r2, defaultRealmName);
+        }
+        if (r3 != null) {
+            return mapRealmName(name, r3, defaultRealmName);
+        }
+        return defaultRealmName;
+    }
+
+    private static String mapRealmName(String name, RealmMapper realmMapper, String defaultRealmName) {
+        String realmName = realmMapper.getRealmMapping(name);
+        return realmName != null ? realmName : defaultRealmName;
     }
 
     private static final int INITIAL_ID = 0;


### PR DESCRIPTION
Also created https://github.com/wildfly-security/elytron-subsystem/pull/136 for the corresponding Elytron subsystem changes.