### PR TITLE
LDAP realm - attributes modifiable

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -419,6 +419,19 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1099, value = "Ldap-backed realm is not configured to allow create new identities (new identity parent and attributes has to be set)")
     RealmUnavailableException ldapRealmNotConfiguredToSupportCreatingIdentities();
 
+    @Message(id = 1100, value = "Ldap-backed realm does not contain mapping to set Elytron attribute \"%s\" of identity \"%s\"")
+    RealmUnavailableException ldapRealmCannotSetAttributeWithoutMapping(String attribute, String identity);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1101, value = "Ldap-backed realm does not support setting of filtered attribute \"%s\" (identity \"%s\")")
+    void ldapRealmDoesNotSupportSettingFilteredAttribute(String attribute, String identity);
+
+    @Message(id = 1102, value = "Ldap-backed realm require exactly one value of attribute \"%s\" mapped to RDN (identity \"%s\")")
+    RealmUnavailableException ldapRealmRequireExactlyOneRdnAttribute(String attribute, String identity);
+
+    @Message(id = 1103, value = "Ldap-backed realm failed to set attributes of identity \"%s\"")
+    RealmUnavailableException ldapRealmAttributesSettingFailed(String identity, @Cause Throwable cause);
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
@@ -18,20 +18,24 @@
 
 package org.wildfly.security.ldap;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.wildfly.common.Assert;
+import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder;
 import org.wildfly.security.auth.server.ModifiableRealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.authz.MapAttributes;
 
 import javax.naming.InvalidNameException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.BasicAttribute;
 import javax.naming.directory.BasicAttributes;
 import javax.naming.ldap.LdapName;
+
+import java.util.Arrays;
 
 /**
  * Test case to test creating and removing identities in LDAP
@@ -47,7 +51,7 @@ public class ModifiabilityTest {
     @BeforeClass
     public static void createRealm() throws InvalidNameException {
 
-        Attributes attributes = new BasicAttributes(true);
+        Attributes attributes = new BasicAttributes(true); // ldap attributes of new identity
         BasicAttribute objectClass = new BasicAttribute("objectClass");
         objectClass.add("top");
         objectClass.add("inetOrgPerson");
@@ -56,12 +60,19 @@ public class ModifiabilityTest {
         attributes.put(objectClass);
         attributes.put(new BasicAttribute("sn", "aaa"));
         attributes.put(new BasicAttribute("cn", "bbb"));
+        attributes.put(new BasicAttribute("description", "new user"));
 
         realm = LdapSecurityRealmBuilder.builder()
             .setDirContextFactory(dirContextFactory.create())
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                 .setRdnIdentifier("uid")
+                .map(AttributeMapping.from("uid").to("userName"), // mapping ldap attributes to elytron attributes
+                     AttributeMapping.from("cn").to("firstName"),
+                     AttributeMapping.from("sn").to("lastName"),
+                     AttributeMapping.from("description").to("description"),
+                     AttributeMapping.from("telephoneNumber").to("phones"),
+                     AttributeMapping.fromFilter("ou=Finance,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea"))
                 .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
                 .setNewIdentityAttributes(attributes)
                 .build()
@@ -97,4 +108,59 @@ public class ModifiabilityTest {
         identity = (ModifiableRealmIdentity) realm.getRealmIdentity(horribleIdentityName);
         Assert.assertFalse(identity.exists());
     }
+
+    @Test
+    public void testAttributeSetting() throws Exception {
+        ModifiableRealmIdentity identity = (ModifiableRealmIdentity) realm.getRealmIdentity("myNewAttributesIdentity");
+        Assert.assertFalse(identity.exists());
+        identity.create();
+
+        MapAttributes newAttributes = new MapAttributes();
+        newAttributes.addFirst("userName", "JohnSmithsNewIdentity");
+        newAttributes.addFirst("firstName", "John");
+        newAttributes.addFirst("lastName", "Smith");
+        newAttributes.addAll("phones", Arrays.asList("123456", "654321"));
+        identity.setAttributes(newAttributes);
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity("myNewAttributesIdentity");
+        Assert.assertFalse(identity.exists());
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity("JohnSmithsNewIdentity");
+        Assert.assertTrue(identity.exists());
+
+        org.wildfly.security.authz.Attributes attributes = identity.getAuthorizationIdentity().getAttributes();
+        Assert.assertEquals("JohnSmithsNewIdentity", attributes.get("userName").get(0));
+        Assert.assertEquals("John", attributes.get("firstName").get(0));
+        Assert.assertEquals("Smith", attributes.get("lastName").get(0));
+        Assert.assertEquals(0, attributes.get("description").size());
+        Assert.assertEquals(2, attributes.get("phones").size());
+    }
+
+    @Test
+    public void testAttributeSettingEscaped() throws Exception {
+        ModifiableRealmIdentity identity = (ModifiableRealmIdentity) realm.getRealmIdentity(" myNewAttributesIdentity , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '");
+        Assert.assertFalse(identity.exists());
+        identity.create();
+
+        MapAttributes newAttributes = new MapAttributes();
+        newAttributes.addFirst("userName", " JohnSmithsNewIdentity , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '");
+        newAttributes.addFirst("firstName", "John");
+        newAttributes.addFirst("lastName", "Smith");
+        newAttributes.addAll("phones", Arrays.asList("123456", "654321"));
+        identity.setAttributes(newAttributes);
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity(" myNewAttributesIdentity , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '");
+        Assert.assertFalse(identity.exists());
+
+        identity = (ModifiableRealmIdentity) realm.getRealmIdentity(" JohnSmithsNewIdentity , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '");
+        Assert.assertTrue(identity.exists());
+
+        org.wildfly.security.authz.Attributes attributes = identity.getAuthorizationIdentity().getAttributes();
+        Assert.assertEquals(" JohnSmithsNewIdentity , \\ # + < > ; \" = / * ( ) . & - _ [ ] ` ~ | @ $ % ^ ? : { } ! '", attributes.get("userName").get(0));
+        Assert.assertEquals("John", attributes.get("firstName").get(0));
+        Assert.assertEquals("Smith", attributes.get("lastName").get(0));
+        Assert.assertEquals(0, attributes.get("description").size());
+        Assert.assertEquals(2, attributes.get("phones").size());
+    }
+
 }


### PR DESCRIPTION
* Setting attributes of identity in ldap realm
* Setting of RDN attribute (=renaming of node) supported
* Attributes defined in mapping by filter (loaded from other ldap node then user) ignored if enclosed

Just note, that if the username is in attribute mapping, it allow change it too, but it is not reflected by Identity object. (It cannot be updated, because "name" is final)