### PR TITLE
LDAP security realm - iterability with pagination

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -352,8 +352,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1077, value = "Invalid alias \"%s\" for missing mechanism database entry \"%s\"")
     void warnInvalidAliasForMissingMechanismDatabaseEntry(String value, String name);
 
-    @Message(id = 1078, value = "Ldap-backed realm failed to obtain identity from server")
-    RuntimeException ldapRealmFailedObtainIdentityFromServer(@Cause Throwable cause);
+    @Message(id = 1078, value = "Ldap-backed realm failed to obtain identity \"%s\" from server")
+    RuntimeException ldapRealmFailedObtainIdentityFromServer(String identity, @Cause Throwable cause);
 
     @Message(id = 1079, value = "Ldap-backed realm failed to obtain attributes for entry [%s]")
     RuntimeException ldapRealmFailedObtainAttributes(String dn, @Cause Throwable cause);
@@ -444,6 +444,12 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1107, value = "OAuth2-based realm requires a HostnameVerifier when the token introspection endpoint [%s] is using SSL/TLS.")
     IllegalStateException oauth2RealmHostnameVerifierNotSpecified(URL tokenIntrospectionUrl);
+
+    @Message(id = 1108, value = "Ldap-backed realm identity search failed")
+    RuntimeException ldapRealmIdentitySearchFailed(@Cause Throwable cause);
+
+    @Message(id = 1109, value = "Ldap-backed realm is not configured to allow iterate over identities (iterator filter has to be set)")
+    RealmUnavailableException ldapRealmNotConfiguredToSupportIteratingOverIdentities();
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/DirContextFactory.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/DirContextFactory.java
@@ -58,6 +58,7 @@ public interface DirContextFactory {
     /**
      * Return the {@link DirContext} once it is no longer required. The returned DirContext is not necessarily an
      * {@link InitialDirContext} and as a result we can not assume it is closeable.
+     * Should only be called if a context was successfully obtained.
      *
      * @param context the {@link DirContext} to return
      */

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealm.java
@@ -125,7 +125,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
 
         try {
             context = dirContextFactory.obtainDirContext(null);
-
+        } catch (NamingException e) {
+            throw log.ldapRealmIdentitySearchFailed(e);
+        }
+        try {
             NamingEnumeration<SearchResult> result = context.search(identityMapping.searchDn, identityMapping.iteratorFilter,
                     identityMapping.iteratorFilterArgs, createSearchControls(identityMapping.rdnIdentifier));
 
@@ -138,7 +141,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             } finally {
                 result.close();
             }
-
         } catch (NamingException e) {
             throw log.ldapRealmIdentitySearchFailed(e);
         } finally {
@@ -397,7 +399,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
 
             try {
                 context = dirContextFactory.obtainDirContext(null);
-
+            } catch (NamingException e) {
+                throw log.ldapRealmFailedObtainIdentityFromServer(this.name, e);
+            }
+            try {
                 String searchDn = identityMapping.searchDn;
                 String name = this.name;
 
@@ -607,10 +612,12 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             DirContext context = null;
             try {
                 context = dirContextFactory.obtainDirContext(null);
-
+            } catch (NamingException e) {
+                throw log.ldapRealmFailedDeleteIdentityFromServer(e);
+            }
+            try {
                 log.debugf("Removing identity [%s] with DN [%s] from LDAP", name, identity.getDistinguishedName());
                 context.destroySubcontext(new LdapName(identity.getDistinguishedName()));
-
             } catch (NamingException e) {
                 throw log.ldapRealmFailedDeleteIdentityFromServer(e);
             } finally {
@@ -626,7 +633,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             DirContext context = null;
             try {
                 context = dirContextFactory.obtainDirContext(null);
-
+            } catch (NamingException e) {
+                throw log.ldapRealmFailedCreateIdentityOnServer(e);
+            }
+            try {
                 LdapName distinguishName = (LdapName) identityMapping.newIdentityParent.clone();
                 distinguishName.add(new Rdn(identityMapping.rdnIdentifier, name));
 
@@ -654,6 +664,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             DirContext context = null;
             try {
                 context = dirContextFactory.obtainDirContext(null);
+            } catch (Exception e) {
+                throw log.ldapRealmAttributesSettingFailed(this.name, e);
+            }
+            try {
                 List<ModificationItem> modItems = new LinkedList<>();
                 LdapName identityLdapName = new LdapName(identity.getDistinguishedName());
                 String renameTo = null;

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
@@ -49,10 +49,12 @@ public class LdapSecurityRealmBuilder {
     private boolean built = false;
     private DirContextFactory dirContextFactory;
     private NameRewriter nameRewriter = NameRewriter.IDENTITY_REWRITER;
+    private IdentityMapping identityMapping;
+    private int pageSize = 50;
+
     private List<CredentialLoader> credentialLoaders = new ArrayList<>();
     private List<CredentialPersister> credentialPersisters = new ArrayList<>();
     private List<EvidenceVerifier> evidenceVerifiers = new ArrayList<>();
-    private IdentityMapping identityMapping;
 
     private LdapSecurityRealmBuilder() {
     }
@@ -91,6 +93,18 @@ public class LdapSecurityRealmBuilder {
         assertNotBuilt();
 
         this.nameRewriter = nameRewriter;
+
+        return this;
+    }
+
+    /**
+     * Set size of page for realm iterating
+     *
+     * @param pageSize size of page
+     * @return this builder
+     */
+    public LdapSecurityRealmBuilder setPageSize(final int pageSize) {
+        this.pageSize = pageSize;
 
         return this;
     }
@@ -163,7 +177,7 @@ public class LdapSecurityRealmBuilder {
         }
 
         built = true;
-        return new LdapSecurityRealm(dirContextFactory, nameRewriter, identityMapping, credentialLoaders, credentialPersisters, evidenceVerifiers);
+        return new LdapSecurityRealm(dirContextFactory, nameRewriter, identityMapping, credentialLoaders, credentialPersisters, evidenceVerifiers, pageSize);
     }
 
     private void assertNotBuilt() {

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/LdapSecurityRealmBuilder.java
@@ -186,6 +186,8 @@ public class LdapSecurityRealmBuilder {
         private List<AttributeMapping> attributes = new ArrayList<>();
         private LdapName newIdentityParent = null;
         private Attributes newIdentityAttributes = null;
+        private String iteratorFilter;
+        private Object[] iteratorFilterArgs;
 
         /**
          * <p>Set the name of the context to be used when executing queries.
@@ -260,6 +262,20 @@ public class LdapSecurityRealmBuilder {
             return this;
         }
 
+        public IdentityMappingBuilder setIteratorFilter(String iteratorFilter) {
+            assertNotBuilt();
+
+            this.iteratorFilter = iteratorFilter;
+            return this;
+        }
+
+        public IdentityMappingBuilder setIteratorFilterArgs(Object[] iteratorFilterArgs) {
+            assertNotBuilt();
+
+            this.iteratorFilterArgs = iteratorFilterArgs;
+            return this;
+        }
+
         /**
          * Define an attribute mapping configuration.
          *
@@ -278,7 +294,8 @@ public class LdapSecurityRealmBuilder {
             built = true;
 
             return LdapSecurityRealmBuilder.this.setIdentityMapping(new IdentityMapping(
-                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes, newIdentityParent, newIdentityAttributes));
+                    searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes,
+                    newIdentityParent, newIdentityAttributes, iteratorFilter, iteratorFilterArgs));
         }
 
         private void assertNotBuilt() {

--- a/src/main/java/org/wildfly/security/auth/provider/ldap/SimpleDirContextFactoryBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/provider/ldap/SimpleDirContextFactoryBuilder.java
@@ -23,6 +23,7 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -219,12 +220,12 @@ public class SimpleDirContextFactoryBuilder {
                 });
             }
 
-            InitialDirContext context;
+            InitialLdapContext context;
 
             try {
-                context = new InitialDirContext(env);
+                context = new InitialLdapContext(env, null);
             } catch (NamingException ne) {
-                log.debugf(ne, "Could not create [%s]. Failed to connect to LDAP server.", InitialDirContext.class);
+                log.debugf(ne, "Could not create [%s]. Failed to connect to LDAP server.", InitialLdapContext.class);
                 throw ne;
             }
 

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
@@ -65,6 +65,7 @@ public class ModifiabilityTest {
 
         realm = LdapSecurityRealmBuilder.builder()
             .setDirContextFactory(dirContextFactory.create())
+            .setPageSize(3)
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                 .setRdnIdentifier("uid")
@@ -175,8 +176,7 @@ public class ModifiabilityTest {
             Assert.assertTrue(identity.exists());
             count++;
         }
-        Assert.assertNotEquals(0, count);
-
+        Assert.assertTrue(count > 10);
     }
 
 }

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilityTest.java
@@ -25,8 +25,8 @@ import org.junit.Test;
 import org.wildfly.security.auth.provider.ldap.AttributeMapping;
 import org.wildfly.security.auth.provider.ldap.LdapSecurityRealmBuilder;
 import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.RealmUnavailableException;
-import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.authz.MapAttributes;
 
 import javax.naming.InvalidNameException;
@@ -36,6 +36,7 @@ import javax.naming.directory.BasicAttributes;
 import javax.naming.ldap.LdapName;
 
 import java.util.Arrays;
+import java.util.Iterator;
 
 /**
  * Test case to test creating and removing identities in LDAP
@@ -46,7 +47,7 @@ public class ModifiabilityTest {
 
     @ClassRule
     public static DirContextFactoryRule dirContextFactory = new DirContextFactoryRule();
-    private static SecurityRealm realm;
+    private static ModifiableSecurityRealm realm;
 
     @BeforeClass
     public static void createRealm() throws InvalidNameException {
@@ -75,6 +76,7 @@ public class ModifiabilityTest {
                      AttributeMapping.fromFilter("ou=Finance,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea"))
                 .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
                 .setNewIdentityAttributes(attributes)
+                .setIteratorFilter("(uid=*)")
                 .build()
             .build();
     }
@@ -161,6 +163,20 @@ public class ModifiabilityTest {
         Assert.assertEquals("Smith", attributes.get("lastName").get(0));
         Assert.assertEquals(0, attributes.get("description").size());
         Assert.assertEquals(2, attributes.get("phones").size());
+    }
+
+    @Test
+    public void testIterating() throws Exception {
+        Iterator<ModifiableRealmIdentity> iterator = realm.getRealmIdentityIterator();
+
+        int count = 0;
+        while(iterator.hasNext()){
+            ModifiableRealmIdentity identity = iterator.next();
+            Assert.assertTrue(identity.exists());
+            count++;
+        }
+        Assert.assertNotEquals(0, count);
+
     }
 
 }


### PR DESCRIPTION
This is exteded #361 with pagination.
Pagination require InitialLdapContext instead of InitialDirContext, because which was added standalone SimpleLdapContextFactoryBuilder, which is not ideal - should be discussed if make SimpleDirContextFactoryBuilder less private and allow subclassing.