### PR TITLE
[ELY-431] - Changes to the Elytron HTTP API/SPI to support a broader range of authentication mechanisms

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1153,6 +1153,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6003, value = "An authentication attempt failed validation using mechanism '%s'.")
     String authenticationFailed(String mechanismName);
 
+    @Message(id = 6004, value = "Session management not supported. This is probably because no HttpSessionSpi was implemented for the underlying container.")
+    IllegalStateException httpSessionNotSupported();
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm")

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -22,8 +22,13 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
 import static org.wildfly.security.http.HttpConstants.OK;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSession;
@@ -44,12 +49,14 @@ public class HttpAuthenticator {
     private final HttpExchangeSpi httpExchangeSpi;
     private final boolean required;
     private final boolean ignoreOptionalFailures;
+    private final HttpSessionSpi httpSessionSpi;
     private volatile boolean authenticated = false;
 
     private HttpAuthenticator(final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier, final HttpExchangeSpi httpExchangeSpi,
-            final boolean required, final boolean ignoreOptionalFailures) {
+                              HttpSessionSpi httpSessionSpi, final boolean required, final boolean ignoreOptionalFailures) {
         this.mechanismSupplier = mechanismSupplier;
         this.httpExchangeSpi = httpExchangeSpi;
+        this.httpSessionSpi = httpSessionSpi;
         this.required = required;
         this.ignoreOptionalFailures = ignoreOptionalFailures;
     }
@@ -179,6 +186,36 @@ public class HttpAuthenticator {
         }
 
         @Override
+        public String getRequestMethod() {
+            return httpExchangeSpi.getRequestMethod();
+        }
+
+        @Override
+        public String getRequestURI() {
+            return httpExchangeSpi.getRequestURI();
+        }
+
+        @Override
+        public Map<String, String[]> getParameters() {
+            return httpExchangeSpi.getRequestParameters();
+        }
+
+        @Override
+        public HttpServerCookie[] getCookies() {
+            return httpExchangeSpi.getCookies();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return httpExchangeSpi.getRequestInputStream();
+        }
+
+        @Override
+        public InetSocketAddress getSourceAddress() {
+            return httpExchangeSpi.getSourceAddress();
+        }
+
+        @Override
         public void addResponseHeader(String headerName, String headerValue) {
             httpExchangeSpi.addResponseHeader(headerName, headerValue);
         }
@@ -197,13 +234,37 @@ public class HttpAuthenticator {
             }
         }
 
+        @Override
+        public OutputStream getOutputStream() {
+            return httpExchangeSpi.getResponseOutputStream();
+        }
 
+        @Override
+        public void setResponseCookie(HttpServerCookie cookie) {
+            httpExchangeSpi.setResponseCookie(cookie);
+        }
+
+        @Override
+        public HttpServerSession getSession(boolean create) {
+            return httpSessionSpi.getSession(create);
+        }
+
+        @Override
+        public HttpServerSession getSession(String id) {
+            return httpSessionSpi.getSession(id);
+        }
+
+        @Override
+        public Set<String> getSessions() {
+            return httpSessionSpi.getSessions();
+        }
     }
 
     public static class Builder {
 
         private Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
         private HttpExchangeSpi httpExchangeSpi;
+        private HttpSessionSpi httpSessionSpi = HttpSessionSpi.NOT_SUPPORTED;
         private boolean required;
         private boolean ignoreOptionalFailures;
 
@@ -231,6 +292,19 @@ public class HttpAuthenticator {
          */
         public Builder setHttpExchangeSpi(final HttpExchangeSpi httpExchangeSpi) {
             this.httpExchangeSpi = httpExchangeSpi;
+
+            return this;
+        }
+
+        /**
+         * Set the {@link HttpSessionSpi} instance for the current request to allow integration with the session management capabilities
+         * provided by the underlying web container..
+         *
+         * @param httpSessionSpi the {@link HttpSessionSpi} instance for the current request
+         * @return the {@link Builder} to allow method call chaining.
+         */
+        public Builder setHttpSessionSpi(final HttpSessionSpi httpSessionSpi) {
+            this.httpSessionSpi = httpSessionSpi;
 
             return this;
         }
@@ -265,7 +339,7 @@ public class HttpAuthenticator {
         }
 
         public HttpAuthenticator build() {
-            return new HttpAuthenticator(mechanismSupplier, httpExchangeSpi, required, ignoreOptionalFailures);
+            return new HttpAuthenticator(mechanismSupplier, httpExchangeSpi, httpSessionSpi, required, ignoreOptionalFailures);
         }
 
     }

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -17,7 +17,11 @@
  */
 package org.wildfly.security.http;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.SSLSession;
 
@@ -99,5 +103,60 @@ public interface HttpExchangeSpi {
      */
     void badRequest(final HttpAuthenticationException error, final String mechanismName);
 
+    /**
+     * Returns the name of the HTTP method with which this request was made, for example, GET, POST, or PUT.
+     *
+     * @return a <code>String</code> specifying the name of the method with which this request was made
+     */
+    String getRequestMethod();
 
+    /**
+     * Reconstructs the URL the client used to make the request. The returned URL contains a protocol, server name, port
+     * number, and server path, but it does not include query string parameters.
+     *
+     * @return a <code>String</code> containing the part of the URL from the protocol name up to the query string
+     */
+    String getRequestURI();
+
+    /**
+     * Returns the  query parameters.
+     *
+     * @return the query parameters
+     */
+    Map<String,String[]> getRequestParameters();
+
+    /**
+     * Returns an array containing all of the {@link HttpServerCookie} objects the client sent with this request. This method returns <code>null</code> if no cookies were sent.
+     *
+     * @return an array of all the cookies included with this request, or <code>null</code> if the request has no cookies
+     */
+    HttpServerCookie[] getCookies();
+
+    /**
+     * Returns the request input stream.
+     *
+     * @return the input stream
+     */
+    InputStream getRequestInputStream();
+
+    /**
+     * Get the source address of the HTTP request.
+     *
+     * @return the source address of the HTTP request
+     */
+    InetSocketAddress getSourceAddress();
+
+    /**
+     * Sets a response cookie.
+     *
+     * @param cookie the cookie
+     */
+    void setResponseCookie(HttpServerCookie cookie);
+
+    /**
+     * Returns the response output stream.
+     *
+     * @return the output stream
+     */
+    OutputStream getResponseOutputStream();
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerCookie.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerCookie.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http;
+
+/**
+ * Server side representation of a HTTP Cookie.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface HttpServerCookie {
+
+    /**
+     * Returns the name of the cookie.
+     *
+     * @return the name of the cookie
+     */
+    String getName();
+
+    /**
+     * Returns the current value of this cookie.
+     *
+     * @return the current value of this cookie
+     */
+    String getValue();
+
+    /**
+     * Gets the domain name of this cookie.
+     *
+     * @return the domain name of this cookie
+     */
+    String getDomain();
+
+    /**
+     * Gets the maximum age in seconds of this Cookie.
+     *
+     * @return an integer specifying the maximum age of the cookie in seconds
+     */
+    int getMaxAge();
+
+    /**
+     * Returns the path on the server to which the browser returns this cookie.
+     *
+     * @return a <code>String</code> specifying a path on the server
+     */
+    String getPath();
+
+    /**
+     * Returns <code>true</code> if the browser is sending cookies only over a secure protocol, or <code>false</code> if the
+     * browser can send cookies using any protocol.
+     *
+     * @return <code>true</code> if the browser uses a secure protocol, <code>false</code> otherwise
+     */
+    boolean isSecure();
+
+    /**
+     * Returns the version of the protocol this cookie complies with.
+     *
+     * @return the version of the protocol this cookie complies with.
+     */
+    int getVersion();
+
+    /**
+     * Checks whether this cookie has been marked as <i>HttpOnly</i>.
+     *
+     * @return true if this cookie has been marked as <i>HttpOnly</i>, false otherwise
+     */
+    boolean isHttpOnly();
+}

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -24,6 +24,11 @@ import javax.net.ssl.SSLSession;
 
 import org.wildfly.security.auth.server.SecurityIdentity;
 
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Set;
+
 /**
  * Server side representation of a HTTP request.
  *
@@ -87,4 +92,73 @@ public interface HttpServerRequest {
         badRequest(failure, null);
     }
 
+    /**
+     * Returns the name of the HTTP method with which this request was made, for example, GET, POST, or PUT.
+     *
+     * @return a <code>String</code> specifying the name of the method with which this request was made
+     */
+    String getRequestMethod();
+
+    /**
+     * Reconstructs the URL the client used to make the request. The returned URL contains a protocol, server name, port
+     * number, and server path, but it does not include query string parameters.
+     *
+     * @return a <code>String</code> containing the part of the URL from the protocol name up to the query string
+     */
+    String getRequestURI();
+
+    /**
+     * Returns the query parameters.
+     *
+     * @return the query parameters
+     */
+    Map<String, String[]> getParameters();
+
+    /**
+     * Returns an array containing all of the {@link HttpServerCookie} objects the client sent with this request. This method returns <code>null</code> if no cookies were sent.
+     *
+     * @return an array of all the cookies included with this request, or <code>null</code> if the request has no cookies
+     */
+    HttpServerCookie[] getCookies();
+
+    /**
+     * Returns the request input stream.
+     *
+     * @return the input stream
+     */
+    InputStream getInputStream();
+
+    /**
+     * Get the source address of the HTTP request.
+     *
+     * @return the source address of the HTTP request
+     */
+    InetSocketAddress getSourceAddress();
+
+    /**
+     * Returns the current {@link HttpServerSession} associated with this request or, if there is no
+     * current session and <code>create</code> is true, returns a new session.
+     *
+     * <p>If <code>create</code> is <code>false</code> and the request has no valid {@link HttpServerSession},
+     * this method returns <code>null</code>.
+     *
+     * @param create <code>true</code> to create a new session for this request if necessary; <code>false</code> to return <code>null</code> if there's no current session
+     * @return the {@link HttpServerSession} associated with this request or <code>null</code> if code>create</code> is <code>false</code> and the request has no valid session
+     */
+    HttpServerSession getSession(boolean create);
+
+    /**
+     * Retrieves a session with the given session id.
+     *
+     * @param id the session ID
+     * @return the session, or null if it does not exist
+     */
+    HttpServerSession getSession(String id);
+
+    /**
+     * Returns the identifiers of all sessions, including both active and passive.
+     *
+     * @return the identifiers of all sessions, including both active and passive
+     */
+    Set<String> getSessions();
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerResponse.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerResponse.java
@@ -17,6 +17,8 @@
  */
 package org.wildfly.security.http;
 
+import java.io.OutputStream;
+
 /**
  * Server side representation of a HTTP response.
  *
@@ -41,6 +43,17 @@ public interface HttpServerResponse {
      */
     void setResponseCode(final int responseCode);
 
+    /**
+     * Sets a response cookie
+     *
+     * @param cookie the cookie
+     */
+    void setResponseCookie(final HttpServerCookie cookie);
 
-
+    /**
+     * Returns the output stream.
+     *
+     * @return the output stream
+     */
+    OutputStream getOutputStream();
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerSession.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerSession.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http;
+
+/**
+ * Represents a HTTP session.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface HttpServerSession {
+
+    /**
+     * Returns a string containing the unique identifier assigned to this session. The identifier is assigned
+     * by the underlying web container and is implementation dependent.
+     *
+     * @return a string specifying the identifier assigned to this session
+     */
+    String getId();
+
+    /**
+     * Returns the object bound with the specified name in this session, or <code>null</code> if no object is bound under the name.
+     *
+     * @param name a string specifying the name of the object
+     * @return the object with the specified name
+     */
+    <R> R getAttribute(String name);
+
+    /**
+     * Binds an object to this session, using the name specified. If an object of the same name is already bound to the session,
+     * the object is replaced.
+     *
+     * @param name  the name to which the object is bound
+     * @param value the object to be bound
+     */
+    void setAttribute(String name, Object value);
+
+    /**
+     * Removes the object bound with the specified name from this session. If the session does not have an object bound with the specified name,
+     * this method does nothing.
+     *
+     * @param name the name of the object to remove from this session
+     */
+    <R> R removeAttribute(String name);
+
+    /**
+     * Invalidates this session then unbinds any objects bound to it.
+     */
+    void invalidate();
+}

--- a/src/main/java/org/wildfly/security/http/HttpSessionSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpSessionSpi.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http;
+
+import org.wildfly.security._private.ElytronMessages;
+
+import java.util.Set;
+
+/**
+ * The SPI to be implemented to bridge the Elytron APIs with the session management capabilities provided by the underlying server.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public interface HttpSessionSpi {
+
+    /**
+     * Bare minimum implementation to indicate that session management is not supported.
+     */
+    HttpSessionSpi NOT_SUPPORTED = new HttpSessionSpi() {
+        @Override
+        public HttpServerSession getSession(boolean create) {
+            throw ElytronMessages.log.httpSessionNotSupported();
+        }
+
+        @Override
+        public HttpServerSession getSession(String id) {
+            throw ElytronMessages.log.httpSessionNotSupported();
+        }
+
+        @Override
+        public Set<String> getSessions() {
+            throw ElytronMessages.log.httpSessionNotSupported();
+        }
+    };
+
+    /**
+     * Returns the current {@link HttpServerSession} associated with this request or, if there is no
+     * current session and <code>create</code> is true, returns a new session.
+     *
+     * <p>If <code>create</code> is <code>false</code> and the request has no valid {@link HttpServerSession},
+     * this method returns <code>null</code>.
+     *
+     * @param create <code>true</code> to create a new session for this request if necessary; <code>false</code> to return <code>null</code> if there's no current session
+     * @return the {@link HttpServerSession} associated with this request or <code>null</code> if code>create</code> is <code>false</code> and the request has no valid session
+     */
+    HttpServerSession getSession(boolean create);
+
+    /**
+     * Retrieves a session with the given session id
+     *
+     * @param id the session ID
+     * @return the session, or null if it does not exist
+     */
+    HttpServerSession getSession(String id);
+
+    /**
+     * Returns the identifiers of all sessions, including both active and passive
+     *
+     * @return the identifiers of all sessions, including both active and passive
+     */
+    Set<String> getSessions();
+}

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -19,22 +19,28 @@ package org.wildfly.security.http.util;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
 
+import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.net.InetSocketAddress;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
 import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.http.HttpServerCookie;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerMechanismsResponder;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
+import org.wildfly.security.http.HttpServerSession;
 
 /**
  * A {@link HttpServerAuthenticationMechanism} with a stored {@link AccessControlContext} that is used for all request
@@ -130,6 +136,50 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
             wrapped.badRequest(failure, wrap(responder));
         }
 
+        @Override
+        public String getRequestMethod() {
+            return wrapped.getRequestMethod();
+        }
+
+        @Override
+        public String getRequestURI() {
+            return wrapped.getRequestURI();
+        }
+
+        @Override
+        public Map<String, String[]> getParameters() {
+            return wrapped.getParameters();
+        }
+
+        @Override
+        public HttpServerCookie[] getCookies() {
+            return wrapped.getCookies();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return wrapped.getInputStream();
+        }
+
+        @Override
+        public InetSocketAddress getSourceAddress() {
+            return wrapped.getSourceAddress();
+        }
+
+        @Override
+        public HttpServerSession getSession(boolean create) {
+            return wrapped.getSession(create);
+        }
+
+        @Override
+        public HttpServerSession getSession(String id) {
+            return wrapped.getSession(id);
+        }
+
+        @Override
+        public Set<String> getSessions() {
+            return wrapped.getSessions();
+        }
     }
 
 }


### PR DESCRIPTION
### Overview

* Added a SPI for Session Management
* Added new methods to ```HttpExchangeSpi``` to support things like cookies, request parameters, etc.