### PR TITLE
[ELY-385] Handle aliases of aliases in mechanism database.

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/MechanismDatabase.java
+++ b/src/main/java/org/wildfly/security/ssl/MechanismDatabase.java
@@ -155,8 +155,14 @@ class MechanismDatabase {
         }
 
         for (Map.Entry<String, String> entry : aliases.entrySet()) {
-            String name = entry.getKey();
+            final String name = entry.getKey();
             String value = entry.getValue();
+
+            while (aliases.containsKey(value)) {
+                // Just skip to the end, intermediate aliases will get their own turn in the for loop.
+                value = aliases.get(value);
+            }
+
             if (entriesByStdName.containsKey(name)) {
                 log.warnInvalidDuplicateMechanismDatabaseEntry(name);
             } else if (! entriesByStdName.containsKey(value)) {


### PR DESCRIPTION
The scenario that was causing the WARN to be logged was: -
    TLS_RSA_FIPS_WITH_DES_CBC_SHA           = alias:TLS_RSA_WITH_DES_CBC_SHA
    TLS_RSA_WITH_DES_CBC_SHA                = alias:SSL_RSA_WITH_DES_CBC_SHA
    SSL_RSA_WITH_DES_CBC_SHA                = DES-CBC-SHA,RSA,RSA,DES,SHA1,SSLv3,false,LOW,false,56,56

I did consider if we should just update the database and avoid the alias of an alias but if we need this in future I think safer to ensure the code can handle it.

Secondly at some point I think we should review the logging in this initialisation, this properties file is effectively part of our code - I am wondering if we should just fail to load on errors either using an exception or an assertion.  That way errors in the file can be easily detected in our testsuite instead of waiting all the way till a connection is being established to see a WARN message.
