### PR TITLE
[ELY-178] Provide the ability to propagate an established security identity from one domain to another

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -57,7 +57,9 @@ import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.security.asn1.ASN1Exception;
+import org.wildfly.security.auth.AuthenticationException;
 import org.wildfly.security.auth.callback.FastUnsupportedCallbackException;
+import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.security.auth.permission.RunAsPrincipalPermission;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.authz.AuthorizationCheckException;
@@ -458,6 +460,15 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1109, value = "Ldap-backed realm is not configured to allow iterate over identities (iterator filter has to be set)")
     RealmUnavailableException ldapRealmNotConfiguredToSupportIteratingOverIdentities();
+
+    @Message(id = 1110, value = "Unable to inflow established security identity for principal %s; authorization check failed (permission denied)")
+    AuthorizationCheckException inflowedIdentityNotAuthorized(Principal establishedPrincipal, @Param Principal inflowedPrincipal, @Param LoginPermission permission);
+
+    @Message(id = 1111, value = "Established security identity is not trusted for principal %s")
+    AuthenticationException establishedIdentityNotTrusted(Principal principal);
+
+    @Message(id = 1112, value = "Established security identity is not trusted due to realm failure for principal %s")
+    AuthenticationException establishedIdentityNotTrustedRealmProblem(@Cause RealmUnavailableException e, Principal principal);
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/realm/AggregateSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/AggregateSecurityRealm.java
@@ -139,5 +139,9 @@ public final class AggregateSecurityRealm implements SecurityRealm {
             authenticationIdentity.dispose();
             authorizationIdentity.dispose();
         }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return authenticationIdentity.createdBySecurityRealm(securityRealm);
+        }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -63,6 +63,7 @@ import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.NameRewriter;
 import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.server.SupportLevel;
 import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.authz.AuthorizationIdentity;
@@ -564,6 +565,10 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm {
         public AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {
             final LoadedIdentity loadedIdentity = loadIdentity(true, false);
             return loadedIdentity == null ? AuthorizationIdentity.EMPTY : AuthorizationIdentity.basicIdentity(loadedIdentity.getAttributes());
+        }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return FileSystemSecurityRealm.this == securityRealm;
         }
 
         private LoadedIdentity loadIdentity(final boolean skipCredentials, final boolean skipAttributes) throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/realm/JaasSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/JaasSecurityRealm.java
@@ -202,6 +202,10 @@ public class JaasSecurityRealm implements SecurityRealm {
         public AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {
             return new JaasAuthorizationIdentity(this.principal, this.subject);
         }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return JaasSecurityRealm.this == securityRealm;
+        }
     }
 
     private class DefaultCallbackHandler implements CallbackHandler {

--- a/src/main/java/org/wildfly/security/auth/realm/KeyStoreBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/KeyStoreBackedSecurityRealm.java
@@ -157,5 +157,9 @@ public class KeyStoreBackedSecurityRealm implements SecurityRealm {
         public boolean exists() throws RealmUnavailableException {
             return getEntry(name) != null;
         }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return KeyStoreBackedSecurityRealm.this == securityRealm;
+        }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealm.java
@@ -196,6 +196,9 @@ public class LegacyPropertiesSecurityRealm implements SecurityRealm {
                 return AuthorizationIdentity.basicIdentity(new MapAttributes(Collections.singletonMap(groupsAttribute, accountEntry.getGroups())));
             }
 
+            public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+                return LegacyPropertiesSecurityRealm.this == securityRealm;
+            }
         };
     }
 

--- a/src/main/java/org/wildfly/security/auth/realm/SimpleMapBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/SimpleMapBackedSecurityRealm.java
@@ -211,5 +211,9 @@ public class SimpleMapBackedSecurityRealm implements SecurityRealm {
         public boolean exists() throws RealmUnavailableException {
             return map.containsKey(name);
         }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return SimpleMapBackedSecurityRealm.this == securityRealm;
+        }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/realm/jdbc/JdbcSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/jdbc/JdbcSecurityRealm.java
@@ -197,6 +197,10 @@ public class JdbcSecurityRealm implements SecurityRealm {
             return AuthorizationIdentity.basicIdentity(this.identity.attributes);
         }
 
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return JdbcSecurityRealm.this == securityRealm;
+        }
+
         private JdbcIdentity getIdentity() {
             if (this.identity == null) {
                 JdbcSecurityRealm.this.queryConfiguration.stream().map(queryConfiguration -> executePrincipalQuery(queryConfiguration, resultSet -> {

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -62,6 +62,7 @@ import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.NameRewriter;
 import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.server.SupportLevel;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.authz.MapAttributes;
@@ -472,6 +473,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             }
 
             return exists;
+        }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return LdapSecurityRealm.this == securityRealm;
         }
 
         private LdapIdentity getIdentity() throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/realm/oauth2/OAuth2SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/oauth2/OAuth2SecurityRealm.java
@@ -163,6 +163,10 @@ public class OAuth2SecurityRealm implements SecurityRealm {
             return null;
         }
 
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return OAuth2SecurityRealm.this == securityRealm;
+        }
+
         @Override
         public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException {
             return SupportLevel.UNSUPPORTED;

--- a/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/ModifiableRealmIdentity.java
@@ -94,6 +94,10 @@ public interface ModifiableRealmIdentity extends RealmIdentity {
             return false;
         }
 
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return false;
+        }
+
         public void delete() throws RealmUnavailableException {
             // no operation
         }

--- a/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
@@ -148,6 +148,14 @@ public interface RealmIdentity {
     }
 
     /**
+     * Determine if this realm identity was created by the given security realm.
+     *
+     * @param securityRealm the security realm to check
+     * @return {@code true} if this realm identity was created by the given security realm, {@code false} otherwise
+     */
+    boolean createdBySecurityRealm(SecurityRealm securityRealm);
+
+    /**
      * The anonymous realm identity.
      */
     RealmIdentity ANONYMOUS = new RealmIdentity() {
@@ -178,6 +186,10 @@ public interface RealmIdentity {
         public boolean exists() throws RealmUnavailableException {
             return true;
         }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
+            return SecurityRealm.EMPTY_REALM == securityRealm;
+        }
     };
 
     /**
@@ -205,6 +217,10 @@ public interface RealmIdentity {
         }
 
         public boolean exists() throws RealmUnavailableException {
+            return false;
+        }
+
+        public boolean createdBySecurityRealm(final SecurityRealm securityRealm) {
             return false;
         }
     };

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -32,7 +32,10 @@ import java.util.function.Function;
 
 import org.wildfly.common.Assert;
 import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.auth.AuthenticationException;
+import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.security.auth.principal.AnonymousPrincipal;
+import org.wildfly.security.authz.AuthorizationException;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.authz.PermissionMapper;
 import org.wildfly.security.authz.RoleDecoder;
@@ -40,6 +43,7 @@ import org.wildfly.security.authz.RoleMapper;
 import org.wildfly.security.authz.Roles;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.SecurityIdentityEvidence;
 import org.wildfly.security.permission.ElytronPermission;
 import org.wildfly.security.permission.PermissionVerifier;
 
@@ -293,6 +297,66 @@ public final class SecurityDomain {
      */
     public SecurityIdentity getAnonymousSecurityIdentity() {
         return anonymousIdentity;
+    }
+
+    /**
+     * Attempt to inflow an established security identity to this domain.
+     *
+     * @param securityIdentity the established security identity to inflow
+     * @return the new security identity after inflowing the given security identity to this domain
+     * @throws AuthenticationException if the established security identity is not trusted by this domain
+     * @throws AuthorizationException if the inflowed identity is not authorized to complete an authentication
+     */
+    public SecurityIdentity inflowFromSecurityIdentity(final SecurityIdentity securityIdentity)
+            throws AuthenticationException, AuthorizationException {
+        return inflowFromSecurityIdentity(securityIdentity, MechanismConfiguration.EMPTY);
+    }
+
+    /**
+     * Attempt to inflow an established security identity to this domain.
+     *
+     * @param securityIdentity the established security identity to inflow
+     * @param mechanismConfiguration the mechanism configuration to use
+     * @return the new security identity after inflowing the given security identity to this domain
+     * @throws AuthenticationException if the established security identity is not trusted by this domain
+     * @throws AuthorizationException if the inflowed identity is not authorized to complete an authentication
+     */
+    public SecurityIdentity inflowFromSecurityIdentity(final SecurityIdentity securityIdentity,
+                                                       final MechanismConfiguration mechanismConfiguration)
+            throws AuthenticationException, AuthorizationException {
+        Assert.checkNotNullParam("securityIdentity", securityIdentity);
+        if (this == securityIdentity.getSecurityDomain()) {
+            // Same domain, just return the identity as is
+            return securityIdentity;
+        }
+        final SecurityIdentityEvidence securityIdentityEvidence = new SecurityIdentityEvidence(securityIdentity);
+        final Principal evidencePrincipal = securityIdentityEvidence.getPrincipal();
+        if (evidencePrincipal instanceof AnonymousPrincipal) {
+            // Return the anonymous identity for this domain
+            return getAnonymousSecurityIdentity();
+        }
+        final ServerAuthenticationContext serverAuthenticationContext = createNewAuthenticationContext(mechanismConfiguration);
+        boolean ok = false;
+        try {
+            // If the identity can be trusted, propagate it to this domain and return the propagated identity
+            final SupportLevel evidenceSupport = serverAuthenticationContext.getEvidenceVerifySupport(SecurityIdentityEvidence.class, null);
+            if (evidenceSupport.mayBeSupported() && (serverAuthenticationContext.verifyEvidence(securityIdentityEvidence))) {
+                if (! serverAuthenticationContext.authorize()) {
+                    throw ElytronMessages.log.inflowedIdentityNotAuthorized(evidencePrincipal,
+                            serverAuthenticationContext.getAuthenticationPrincipal(), new LoginPermission());
+                }
+                serverAuthenticationContext.succeed();
+                ok = true;
+                return serverAuthenticationContext.getAuthorizedIdentity();
+            }
+            throw ElytronMessages.log.establishedIdentityNotTrusted(evidencePrincipal);
+        } catch (RealmUnavailableException e) {
+            throw ElytronMessages.log.establishedIdentityNotTrustedRealmProblem(e, evidencePrincipal);
+        } finally {
+            if (! ok) {
+                serverAuthenticationContext.fail();
+            }
+        }
     }
 
     SecurityIdentity getAndSetCurrentSecurityIdentity(SecurityIdentity newIdentity) {

--- a/src/main/java/org/wildfly/security/evidence/SecurityIdentityEvidence.java
+++ b/src/main/java/org/wildfly/security/evidence/SecurityIdentityEvidence.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.evidence;
+
+import java.security.Principal;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A piece of evidence that is comprised of a security identity.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public final class SecurityIdentityEvidence implements Evidence {
+
+    private final SecurityIdentity securityIdentity;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param securityIdentity the security identity to use (must not be {@code null})
+     */
+    public SecurityIdentityEvidence(final SecurityIdentity securityIdentity) {
+        Assert.checkNotNullParam("securityIdentity", securityIdentity);
+        this.securityIdentity = securityIdentity;
+    }
+
+    /**
+     * Get the security identity.
+     *
+     * @return the security identity (not {@code null})
+     */
+    public SecurityIdentity getSecurityIdentity() {
+        return securityIdentity;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return getSecurityIdentity().getPrincipal();
+    }
+}

--- a/src/test/java/org/wildfly/security/auth/server/IdentityPropagationTest.java
+++ b/src/test/java/org/wildfly/security/auth/server/IdentityPropagationTest.java
@@ -1,0 +1,161 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.wildfly.common.Assert.assertTrue;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.AuthenticationException;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.realm.SimpleRealmEntry;
+import org.wildfly.security.authz.AuthorizationException;
+import org.wildfly.security.authz.MapAttributes;
+import org.wildfly.security.authz.RoleDecoder;
+import org.wildfly.security.authz.Roles;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+
+/**
+ * Simple tests for propagating an identity from one domain to another.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class IdentityPropagationTest {
+
+    private static final Provider provider = new WildFlyElytronProvider();
+    private static SecurityDomain domain1;
+    private static SecurityDomain domain2;
+
+    @BeforeClass
+    public static void setupSecurityDomains() throws Exception {
+        Security.addProvider(provider);
+
+        // Create some realms
+        SimpleMapBackedSecurityRealm realm1 = new SimpleMapBackedSecurityRealm();
+        Map<String, SimpleRealmEntry> users = new HashMap<>();
+        addUser(users, "joe", "User");
+        addUser(users, "bob", "User");
+        realm1.setPasswordMap(users);
+
+        SimpleMapBackedSecurityRealm realm2 = new SimpleMapBackedSecurityRealm();
+        users = new HashMap<>();
+        addUser(users, "sam", "Manager");
+        realm2.setPasswordMap(users);
+
+        // domain1 contains both realms
+        SecurityDomain.Builder builder = SecurityDomain.builder();
+        builder.addRealm("users", realm1).build();
+        builder.addRealm("managers", realm2).build();
+        builder.setDefaultRealmName("users");
+        builder.setPermissionMapper((principal, roles) -> PermissionVerifier.from(new LoginPermission()));
+        domain1 = builder.build();
+
+        // domain2 contains one of the realms
+        builder = SecurityDomain.builder();
+        builder.addRealm("usersRealm", realm1).setRoleMapper(rolesToMap -> Roles.of("UserRole")).build();
+        builder.setDefaultRealmName("usersRealm");
+        builder.setPermissionMapper((principal, roles) -> {
+            if (principal.getName().equals("joe")) {
+                return PermissionVerifier.from(new LoginPermission());
+            }
+            return PermissionVerifier.NONE;
+        });
+        domain2 = builder.build();
+    }
+
+    @Test
+    public void testInflowFromTrustedIdentity() throws Exception {
+        SecurityIdentity establishedIdentity = getIdentityFromDomain(domain1, "joe");
+        SecurityIdentity inflowedIdentity = domain2.inflowFromSecurityIdentity(establishedIdentity);
+        assertEquals("joe", inflowedIdentity.getPrincipal().getName());
+        assertEquals(domain2, inflowedIdentity.getSecurityDomain());
+        assertTrue(inflowedIdentity.getRoles().contains("UserRole"));
+    }
+
+    @Test
+    public void testInflowFromUntrustedIdentity() throws Exception {
+        SecurityIdentity establishedIdentity = getIdentityFromDomain(domain1, "sam");
+        try {
+            SecurityIdentity inflowedIdentity = domain2.inflowFromSecurityIdentity(establishedIdentity);
+            fail("Expected AuthenticationException not thrown");
+        } catch (AuthenticationException expected) {
+        }
+    }
+
+    @Test
+    public void testUnauthorizedInflowedIdentity() throws Exception {
+        SecurityIdentity establishedIdentity = getIdentityFromDomain(domain1, "bob");
+        try {
+            SecurityIdentity inflowedIdentity = domain2.inflowFromSecurityIdentity(establishedIdentity);
+            fail("Expected AuthorizationException not thrown");
+        } catch (AuthorizationException expected) {
+        }
+    }
+
+    @Test
+    public void testInflowFromAnonymousIdentity() throws Exception {
+        SecurityIdentity inflowedIdentity = domain2.inflowFromSecurityIdentity(domain1.getCurrentSecurityIdentity());
+        assertEquals(domain2.getAnonymousSecurityIdentity(), inflowedIdentity);
+    }
+
+    @Test
+    public void testInflowFromSameDomain() throws Exception {
+        SecurityIdentity establishedIdentity = getIdentityFromDomain(domain2, "joe");
+        SecurityIdentity inflowedIdentity = domain2.inflowFromSecurityIdentity(establishedIdentity);
+        assertEquals(establishedIdentity, inflowedIdentity);
+    }
+
+    private static void addUser(Map<String, SimpleRealmEntry> securityRealm, String userName, String roles) {
+        List<Credential> credentials;
+        try {
+            credentials = Collections.singletonList(
+                    new PasswordCredential(
+                            PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(
+                                    new ClearPasswordSpec("password".toCharArray()))));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        MapAttributes attributes = new MapAttributes();
+        attributes.addAll(RoleDecoder.KEY_ROLES, Collections.singletonList(roles));
+        securityRealm.put(userName, new SimpleRealmEntry(credentials, attributes));
+    }
+
+    private SecurityIdentity getIdentityFromDomain(final SecurityDomain securityDomain, final String userName) throws Exception {
+        final ServerAuthenticationContext authenticationContext = securityDomain.createNewAuthenticationContext();
+        authenticationContext.setAuthenticationName(userName);
+        authenticationContext.succeed();
+        return authenticationContext.getAuthorizedIdentity();
+    }
+}
+


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-178