### PR TITLE
Principal name in Domain.mapPrincipal() by createRunAsIdentity()

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -138,9 +138,11 @@ public final class SecurityDomain {
             throw log.invalidName();
         }
         String realmName = mapRealmName(name, null, null);
-        SecurityRealm securityRealm = getRealm(realmName);
+        RealmInfo realmInfo = getRealmInfo(realmName);
+        SecurityRealm securityRealm = realmInfo.getSecurityRealm();
         assert securityRealm != null;
         name = this.postRealmRewriter.rewriteName(name);
+        name = realmInfo.getNameRewriter().rewriteName(name);
         if (name == null) {
             throw log.invalidName();
         }


### PR DESCRIPTION
For the consistency principal name used in `SecurityDomain.mapPrincipal()` should be identical with `SecurityIdentity.createRunAsIdentity()`.
Added realm-info NameRewriter into mapPrincipal().

Related test:
https://github.com/wildfly-security/elytron-subsystem/pull/171/files#diff-984fedede558a8dc0c583a22962db97bR59