### PR TITLE
[ELY-495] Only convert to an X500Principal if the Principal is already an X500Principal or X500Name.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ConfigurationKeyManager.java
+++ b/src/main/java/org/wildfly/security/auth/client/ConfigurationKeyManager.java
@@ -50,9 +50,11 @@ final class ConfigurationKeyManager extends X509ExtendedKeyManager {
             if (issuers != null) {
                 for (Principal issuer : issuers) {
                     X500Principal x500Principal = X500PrincipalUtil.asX500Principal(issuer);
-                    final String alias = aliasesByIssuer.get(x500Principal);
-                    if (alias != null) {
-                        return alias;
+                    if (x500Principal != null) {
+                        final String alias = aliasesByIssuer.get(x500Principal);
+                        if (alias != null) {
+                            return alias;
+                        }
                     }
                 }
             } else {
@@ -72,10 +74,12 @@ final class ConfigurationKeyManager extends X509ExtendedKeyManager {
             if (issuers != null) {
                 for (Principal issuer : issuers) {
                     X500Principal x500Principal = X500PrincipalUtil.asX500Principal(issuer);
-                    final String alias = aliasesByIssuer.get(x500Principal);
-                    if (alias != null) {
-                        if (aliases == null) aliases = new LinkedHashSet<>(3);
-                        aliases.add(alias);
+                    if (x500Principal != null) {
+                        final String alias = aliasesByIssuer.get(x500Principal);
+                        if (alias != null) {
+                            if (aliases == null) aliases = new LinkedHashSet<>(3);
+                            aliases.add(alias);
+                        }
                     }
                 }
             } else {

--- a/src/main/java/org/wildfly/security/x500/X500PrincipalUtil.java
+++ b/src/main/java/org/wildfly/security/x500/X500PrincipalUtil.java
@@ -115,7 +115,7 @@ public final class X500PrincipalUtil {
      * Attempt to convert the given principal to an X.500 principal.
      *
      * @param principal the original principal
-     * @return the X.500 principal
+     * @return the X.500 principal or {@code null} if the principal can not be converted.
      */
     public static X500Principal asX500Principal(Principal principal) {
         if (principal instanceof X500Principal) {
@@ -124,7 +124,7 @@ public final class X500PrincipalUtil {
         if (HAS_X500_NAME && principal instanceof X500Name) {
             return ((X500Name) principal).asX500Principal();
         }
-        // if all else fails...
-        return new X500Principal(principal.getName());
+
+        return null;
     }
 }


### PR DESCRIPTION
The end result of this is that it can now be aggregated with different implementations so if this implementation does not support the Principal type another may be used.