### PR TITLE
[ELY-468] Support registration of a Consumer to be called when a scope is being destroyed.

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpScope.java
+++ b/src/main/java/org/wildfly/security/http/HttpScope.java
@@ -20,6 +20,7 @@ package org.wildfly.security.http;
 import static org.wildfly.security._private.ElytronMessages.log;
 
 import java.io.InputStream;
+import java.util.function.Consumer;
 
 /**
  * An attachment scope for use by an authentication mechanism, different scopes may be available to share Objects e.g.
@@ -106,6 +107,24 @@ public interface HttpScope {
      */
     default InputStream getResource(final String path) {
         return null;
+    }
+
+    /**
+     * Does this scope support registration to receive destruction notifications?
+     *
+     * @return {@code true} if this scope supports registration for destruction notifications, {@code false} otherwise.
+     */
+    default boolean supportsNotifications() {
+        return false;
+    }
+
+    /**
+     * Register a {@link Consumer<HttpServerScopes>} to receive a notification when this scope is destroyed.
+     *
+     * @param notificationConsumer the {@link Consumer<HttpServerScopes>} to receive a notification when this scope is
+     *        destroyed.
+     */
+    default void registerForNotification(Consumer<HttpServerScopes> notificationConsumer) {
     }
 
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -20,7 +20,6 @@ package org.wildfly.security.http;
 
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -33,7 +32,7 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public interface HttpServerRequest {
+public interface HttpServerRequest extends HttpServerScopes {
 
     /**
      * Get a list of all of the values set for the specified header within the HTTP request.
@@ -133,30 +132,5 @@ public interface HttpServerRequest {
      * @return the source address of the HTTP request
      */
     InetSocketAddress getSourceAddress();
-
-    /**
-     * Get the specified {@link HttpScope} if available.
-     *
-     * @param scope the type of the scope required.
-     * @return the scope specified or {@code null} if not supported.
-     */
-    HttpScope getScope(Scope scope);
-
-    /**
-     * Get the IDs available for the scope specified.
-     *
-     * @param scope the scope the IDs are required for.
-     * @return The IDs available for the scope specified or {@code null} if the scope specified does not support obtaining scopes by ID.
-     */
-     Collection<String> getScopeIds(Scope scope);
-
-    /**
-     * Get the specified {@link HttpScope} with the specified ID.
-     *
-     * @param scope the type of the scope required.
-     * @param id the id of the scope instance required.
-     * @return the scope specified or {@code null} if not supported or if the scope with that ID does not exist.
-     */
-    HttpScope getScope(Scope scope, String id);
 
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerScopes.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerScopes.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.http;
+
+import java.util.Collection;
+
+/**
+ * Interface providing access to context specific {@link HttpScope} instances.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface HttpServerScopes {
+
+    /**
+     * Get the specified {@link HttpScope} if available.
+     *
+     * @param scope the type of the scope required.
+     * @return the scope specified or {@code null} if not supported.
+     */
+    HttpScope getScope(Scope scope);
+
+    /**
+     * Get the IDs available for the scope specified.
+     *
+     * @param scope the scope the IDs are required for.
+     * @return The IDs available for the scope specified or {@code null} if the scope specified does not support obtaining scopes by ID.
+     */
+     Collection<String> getScopeIds(Scope scope);
+
+    /**
+     * Get the specified {@link HttpScope} with the specified ID.
+     *
+     * @param scope the type of the scope required.
+     * @param id the id of the scope instance required.
+     * @return the scope specified or {@code null} if not supported or if the scope with that ID does not exist.
+     */
+    HttpScope getScope(Scope scope, String id);
+
+}


### PR DESCRIPTION
Again a very tiny change in Elytron to add this API, most of the work being in the integration projects.