### PR TITLE
[ELY-503] Add a PeerIdentitiesAssignedState to the ServerAuthenticationContext state machine

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -459,6 +459,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1109, value = "Ldap-backed realm is not configured to allow iterate over identities (iterator filter has to be set)")
     RealmUnavailableException ldapRealmNotConfiguredToSupportIteratingOverIdentities();
 
+    @Message(id = 1110, value = "Peer identities were already set on this context")
+    IllegalStateException peerIdentitiesAlreadySet();
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
@@ -73,12 +73,16 @@ public final class SecurityIdentity implements PermissionVerifier {
     private final PermissionVerifier verifier;
 
     SecurityIdentity(final SecurityDomain securityDomain, final Principal principal, final RealmInfo realmInfo, final AuthorizationIdentity authorizationIdentity, final Map<String, RoleMapper> roleMappers) {
+        this(securityDomain, principal, realmInfo, authorizationIdentity, roleMappers, NO_PEER_IDENTITIES);
+    }
+
+    SecurityIdentity(final SecurityDomain securityDomain, final Principal principal, final RealmInfo realmInfo, final AuthorizationIdentity authorizationIdentity, final Map<String, RoleMapper> roleMappers, final PeerIdentity[] peerIdentities) {
         this.securityDomain = securityDomain;
         this.principal = principal;
         this.realmInfo = realmInfo;
         this.authorizationIdentity = authorizationIdentity;
         this.roleMappers = roleMappers;
-        this.peerIdentities = NO_PEER_IDENTITIES;
+        this.peerIdentities = peerIdentities;
         this.creationTime = Instant.now();
         this.verifier = securityDomain.mapPermissions(this);
     }
@@ -126,6 +130,10 @@ public final class SecurityIdentity implements PermissionVerifier {
 
     AuthorizationIdentity getAuthorizationIdentity() {
         return authorizationIdentity;
+    }
+
+    PeerIdentity[] getPeerIdentities() {
+        return peerIdentities;
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
@@ -493,7 +493,7 @@ public final class SecurityIdentity implements PermissionVerifier {
             final AuthorizationIdentity newAuthorizationIdentity = realmIdentity.getAuthorizationIdentity();
             SecurityRealm.safeHandleRealmEvent(securityRealm, new RealmIdentitySuccessfulAuthorizationEvent(this.authorizationIdentity, this.principal, principal));
             try {
-                return securityDomain.transform(new SecurityIdentity(domain, principal, realmInfo, newAuthorizationIdentity, roleMappers));
+                return securityDomain.transform(new SecurityIdentity(domain, principal, realmInfo, newAuthorizationIdentity, roleMappers, this.getPeerIdentities()));
             } finally {
                 realmIdentity.dispose();
             }


### PR DESCRIPTION
This will allow us to ensure that when propagating a security identity from one domain to another, any peer identities associated with the security identity also get propagated.

https://issues.jboss.org/browse/ELY-503