### PR TITLE
[ELY-311] JMockit upgrade (for JDK9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,7 @@
         <version.org.jboss.spec.jboss-json-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.jboss-json-api_1.0_spec>
         <version.org.kohsuke.metainf-services.metainf-services>1.7</version.org.kohsuke.metainf-services.metainf-services>
         <version.junit.junit>4.11</version.junit.junit>
-        <!-- to make testsuite work on JDK9 newer version of jmockit is required but that one doesn't work properly with mocking AbstractDigestMechanism -->
-        <version.jmockit>1.10</version.jmockit>
+        <version.jmockit>1.22</version.jmockit>
         <version.hsqldb>2.3.1</version.hsqldb>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -65,7 +65,7 @@ public class CompatibilityClientTest extends BaseTestCase {
     private SaslClient client;
 
     private void mockNonce(final String nonce){
-        new MockUp<AbstractDigestMechanism>(){
+        new MockUp<DigestSaslClient>(){
             @Mock
             byte[] generateNonce(){
                 return nonce.getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -57,7 +57,7 @@ public class CompatibilityServerTest extends BaseTestCase {
     protected static final String QOP_PROPERTY = "javax.security.sasl.qop";
 
     private void mockNonce(final String nonce){
-        new MockUp<AbstractDigestMechanism>(){
+        new MockUp<DigestSaslServer>(){
             @Mock
             byte[] generateNonce(){
                 return nonce.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-311