### PR TITLE
[ELY-511] Use Collections instead of arrays for information accessible from the request object.

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -208,12 +208,12 @@ public class HttpAuthenticator {
         }
 
         @Override
-        public Map<String, String[]> getParameters() {
+        public Map<String, List<String>> getParameters() {
             return httpExchangeSpi.getRequestParameters();
         }
 
         @Override
-        public HttpServerCookie[] getCookies() {
+        public List<HttpServerCookie> getCookies() {
             return httpExchangeSpi.getCookies();
         }
 

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -160,14 +160,14 @@ public interface HttpExchangeSpi {
      *
      * @return the query parameters
      */
-    Map<String,String[]> getRequestParameters();
+    Map<String, List<String>> getRequestParameters();
 
     /**
      * Returns an array containing all of the {@link HttpServerCookie} objects the client sent with this request. This method returns <code>null</code> if no cookies were sent.
      *
      * @return an array of all the cookies included with this request, or <code>null</code> if the request has no cookies
      */
-    HttpServerCookie[] getCookies();
+    List<HttpServerCookie> getCookies();
 
     /**
      * Returns the request input stream.

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -110,14 +110,14 @@ public interface HttpServerRequest extends HttpServerScopes {
      *
      * @return the query parameters
      */
-    Map<String, String[]> getParameters();
+    Map<String, List<String>> getParameters();
 
     /**
      * Returns an array containing all of the {@link HttpServerCookie} objects the client sent with this request. This method returns <code>null</code> if no cookies were sent.
      *
      * @return an array of all the cookies included with this request, or <code>null</code> if the request has no cookies
      */
-    HttpServerCookie[] getCookies();
+    List<HttpServerCookie> getCookies();
 
     /**
      * Returns the request input stream.

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -163,12 +163,12 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
         }
 
         @Override
-        public Map<String, String[]> getParameters() {
+        public Map<String, List<String>> getParameters() {
             return wrapped.getParameters();
         }
 
         @Override
-        public HttpServerCookie[] getCookies() {
+        public List<HttpServerCookie> getCookies() {
             return wrapped.getCookies();
         }
 


### PR DESCRIPTION
:warning: This PR will break some changes in the integration project but I think better to get it in and then I will follow up getting those repos back up and running.
