### PR TITLE
[ELY-521] And related changes following ServerAuthenticationContext Clean Up

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1181,6 +1181,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6005, value= "Attachments are not supported on this scope.")
     UnsupportedOperationException noAttachmentSupport();
 
+    @Message(id = 6006, value = "An authorization check for user '%s' failed using mechanism '%s'.")
+    String authorizationFailed(String username, String mechanismName);
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm")

--- a/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
@@ -38,6 +38,7 @@ import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpConstants;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.util.SecurityIdentityServerMechanismFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.DigestPassword;
 
@@ -54,7 +55,7 @@ public final class HttpAuthenticationFactory extends AbstractMechanismAuthentica
     }
 
     HttpServerAuthenticationMechanism doCreate(final String name, final CallbackHandler callbackHandler, final UnaryOperator<HttpServerAuthenticationMechanismFactory> factoryTransformation) throws HttpAuthenticationException {
-        return factoryTransformation.apply(getFactory()).createAuthenticationMechanism(name, Collections.emptyMap(), callbackHandler);
+        return new SecurityIdentityServerMechanismFactory(factoryTransformation.apply(getFactory())).createAuthenticationMechanism(name, Collections.emptyMap(), callbackHandler);
     }
 
     Collection<String> getAllSupportedMechNames() {

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -737,7 +737,7 @@ public final class ServerAuthenticationContext {
                                 final X500Principal principal = evidence.getPrincipal();
                                 if (principal != null) {
                                     setAuthenticationPrincipal(principal);
-                                    final boolean authorized = verifyEvidence(evidence);
+                                    final boolean authorized = verifyEvidence(evidence) && authorize();
                                     authorizationCallback.setAuthorized(authorized);
                                     if (authorized) {
                                         // cache identity

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -180,9 +180,9 @@ public class HttpAuthenticator {
         }
 
         @Override
-        public void authenticationComplete(SecurityIdentity securityIdentity, HttpServerMechanismsResponder responder) {
+        public void authenticationComplete(HttpServerMechanismsResponder responder) {
             authenticated = true;
-            httpExchangeSpi.authenticationComplete(securityIdentity, currentMechanism.getMechanismName());
+            httpExchangeSpi.authenticationComplete(currentMechanism.getMechanismName());
             successResponder = responder;
         }
 

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.http;
 
+import static org.wildfly.security.http.HttpConstants.SECURITY_IDENTITY;
+
 import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
 import static org.wildfly.security.http.HttpConstants.OK;
@@ -182,7 +184,9 @@ public class HttpAuthenticator {
         @Override
         public void authenticationComplete(HttpServerMechanismsResponder responder) {
             authenticated = true;
-            httpExchangeSpi.authenticationComplete(currentMechanism.getMechanismName());
+            httpExchangeSpi.authenticationComplete(
+                    currentMechanism.getNegotiationProperty(SECURITY_IDENTITY, SecurityIdentity.class),
+                    currentMechanism.getMechanismName());
             successResponder = responder;
         }
 

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -28,6 +28,15 @@ public class HttpConstants {
     }
 
     /*
+     * Negotiated Properties
+     */
+
+    /**
+     * The property which holds the negotiated security identity after a successful HTTP server-side authentication.
+     */
+    public static final String SECURITY_IDENTITY = "wildfly.http.security-identity";
+
+    /*
      * Header Fields
      */
 

--- a/src/main/java/org/wildfly/security/http/HttpServerAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerAuthenticationMechanism.java
@@ -44,6 +44,37 @@ public interface HttpServerAuthenticationMechanism {
     void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException;
 
     /**
+     * Get the property negotiated as a result of authentication.
+     *
+     * Mechanisms only make properties available after indicating a successful authentication has completed.
+     *
+     * @param propertyName the name of the property.
+     * @return the value of the property or {@code null} if the specified property is not available.
+     */
+    default Object getNegotiatedProperty(String propertyName) {
+        return null;
+    }
+
+    /**
+     * Get the strongly typed property negotiated as a result of authentication.
+     *
+     * Mechanisms only make properties available after indicating a successful authentication has completed.
+     *
+     * Note: This form of the mechanism will also return {@code null} if the property is set but is of a different type.
+     *
+     * @param propertyName the name of the property.
+     * @param type the expected type of the property.
+     * @return the value of the property or {@code null} if the specified property is not available or is of a different type..
+     */
+    default <T> T getNegotiationProperty(String propertyName, Class<T> type) {
+        Object property = getNegotiatedProperty(propertyName);
+        if (property != null && type.isInstance(property)) {
+            return type.cast(property);
+        }
+        return null;
+    }
+
+    /**
      * Dispose of any resources currently held by this authentication mechanism.
      */
     default void dispose() {

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -89,20 +89,25 @@ public interface HttpServerRequest extends HttpServerScopes {
     /**
      * Notification that authentication is now complete.
      *
-     * @param securityIdentity the {@link SecurityIdentity} established as a result of this authentication.
+     * After this point the framework will perform an authorization check for the authenticated user and if successful establish
+     * the identity of the request.
+     *
      * @param responder a {@link HttpServerMechanismsResponder} that can send a response.
      */
-    void authenticationComplete(SecurityIdentity securityIdentity, final HttpServerMechanismsResponder responder);
+    void authenticationComplete(final HttpServerMechanismsResponder responder);
 
     /**
      * Notification that authentication is now complete.
+     *
+     * After this point the framework will perform an authorization check for the authenticated user and if successful establish
+     * the identity of the request.
      *
      * If this form is called no response is expected from this mechanism.
      *
      * @param securityIdentity the {@link SecurityIdentity} established as a result of this authentication.
      */
-    default void authenticationComplete(SecurityIdentity securityIdentity) {
-        authenticationComplete(securityIdentity, null);
+    default void authenticationComplete() {
+        authenticationComplete(null);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
@@ -122,10 +122,9 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
                     try {
                         String username = usernameChars.toString();
                         if (authenticate(username, passwordChars.array())) {
-                            SecurityIdentityCallback securityIdentityCallback = new SecurityIdentityCallback();
-                            callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.SUCCEEDED, securityIdentityCallback });
+                            callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.SUCCEEDED });
 
-                            request.authenticationComplete(securityIdentityCallback.getSecurityIdentity());
+                            request.authenticationComplete();
                             return;
                         } else {
                             callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });

--- a/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
@@ -80,7 +80,7 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
 
         if (callback.isAuthorized()) try {
             MechanismUtil.handleCallbacks(CLIENT_CERT_NAME, callbackHandler, AuthenticationCompleteCallback.SUCCEEDED);
-            request.authenticationComplete(null);
+            request.authenticationComplete();
         } catch (AuthenticationMechanismException e) {
             throw e.toHttpAuthenticationException();
         } catch (UnsupportedCallbackException ignored) {

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -97,6 +97,17 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
         }
     }
 
+    @Override
+    public Object getNegotiatedProperty(String propertyName) {
+        return mechanism.getNegotiatedProperty(propertyName);
+    }
+
+    @Override
+    public <T> T getNegotiationProperty(String propertyName, Class<T> type) {
+        return mechanism.getNegotiationProperty(propertyName, type);
+    }
+
+
     private HttpServerMechanismsResponder wrap(final HttpServerMechanismsResponder toWrap) {
         return toWrap != null ? (HttpServerResponse r) -> AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             toWrap.sendResponse(r);

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -35,7 +35,6 @@ import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
-import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpScope;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
@@ -164,8 +163,8 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
         }
 
         @Override
-        public void authenticationComplete(SecurityIdentity securityIdentity, HttpServerMechanismsResponder responder) {
-            wrapped.authenticationComplete(securityIdentity, wrap(responder));
+        public void authenticationComplete(HttpServerMechanismsResponder responder) {
+            wrapped.authenticationComplete(wrap(responder));
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
@@ -45,7 +45,7 @@ public class SecurityIdentityServerMechanismFactory implements HttpServerAuthent
 
     private final HttpServerAuthenticationMechanismFactory delegate;
 
-    private SecurityIdentityServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate) {
+    public SecurityIdentityServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate) {
         this.delegate = checkNotNullParam("delegate", delegate);
     }
 

--- a/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.http.util;
+
+import static org.wildfly.security.http.HttpConstants.SECURITY_IDENTITY;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
+import org.wildfly.security.auth.callback.SecurityIdentityCallback;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.HttpServerRequest;
+
+/**
+ *
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SecurityIdentityServerMechanismFactory implements HttpServerAuthenticationMechanismFactory {
+
+    private final HttpServerAuthenticationMechanismFactory delegate;
+
+    private SecurityIdentityServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate) {
+        this.delegate = checkNotNullParam("delegate", delegate);
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanismFactory#getMechanismNames(java.util.Map)
+     */
+    @Override
+    public String[] getMechanismNames(Map<String, ?> properties) {
+        return delegate.getMechanismNames(properties);
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanismFactory#createAuthenticationMechanism(java.lang.String, java.util.Map, javax.security.auth.callback.CallbackHandler)
+     */
+    @Override
+    public HttpServerAuthenticationMechanism createAuthenticationMechanism(String mechanismName, Map<String, ?> properties, CallbackHandler callbackHandler) throws HttpAuthenticationException {
+        SecurityIdentityCallbackHandler securityIdentityCallbackHandler = new SecurityIdentityCallbackHandler(callbackHandler);
+        final HttpServerAuthenticationMechanism delegate = this.delegate.createAuthenticationMechanism(mechanismName, properties, securityIdentityCallbackHandler);
+        if (delegate != null) {
+            return new HttpServerAuthenticationMechanism() {
+
+                @Override
+                public String getMechanismName() {
+                    return delegate.getMechanismName();
+                }
+
+                @Override
+                public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+                    delegate.evaluateRequest(request);
+                }
+
+                @Override
+                public Object getNegotiatedProperty(String propertyName) {
+                    return SECURITY_IDENTITY.equals(propertyName) ? securityIdentityCallbackHandler.getSecurityIdentity()
+                            : delegate.getNegotiatedProperty(propertyName);
+                }
+
+            };
+        }
+        return null;
+    }
+
+    private static class SecurityIdentityCallbackHandler implements CallbackHandler {
+
+        private final CallbackHandler delegate;
+        private SecurityIdentity securityIdentity;
+
+        SecurityIdentityCallbackHandler(CallbackHandler delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            Callback[] theCallbacks = callbacks;
+            SecurityIdentityCallback securityIdentityCallback = null;
+            for (Callback current : callbacks) {
+                if (current instanceof AuthenticationCompleteCallback
+                        && ((AuthenticationCompleteCallback) current).succeeded()) {
+                    theCallbacks = new Callback[callbacks.length + 1];
+                    System.arraycopy(callbacks, 0, theCallbacks, 0, callbacks.length);
+                    theCallbacks[theCallbacks.length - 1] = (securityIdentityCallback = new SecurityIdentityCallback());
+                }
+            }
+
+            delegate.handle(theCallbacks);
+            if (securityIdentityCallback != null) {
+                securityIdentity = securityIdentityCallback.getSecurityIdentity();
+            }
+        }
+
+        SecurityIdentity getSecurityIdentity() {
+            return securityIdentity;
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
+++ b/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
@@ -95,9 +95,9 @@ public final class WildFlySasl {
     public static final String MECHANISM_QUERY_ALL = "wildfly.sasl.mechanism-query-all";
 
     /**
-     * The property which holds the negotiated realm identity after a successful SASL server-side authentication.
+     * The property which holds the negotiated security identity after a successful SASL server-side authentication.
      */
-    public static final String SECURITY_IDENTITY = "wildfly.sasl.realm-identity";
+    public static final String SECURITY_IDENTITY = "wildfly.sasl.security-identity";
 
     /**
      * The immutable empty names array.


### PR DESCRIPTION
This pull request predominantly pulls the ServerAuthenticationContext out of the HTTP mechanism API and also some related clean up following on from the ServerAuthenticationContext clean up.

Once this one is merged I have fixes for Elytron Web and the Subsystem to get both of those projects building and running again.

I then need to get the PermissionMapper support enhanced so we can make the WildFly integration usable again before I finish off the other HTTP changes we have discussed.