### PR TITLE
[ELY-221] X.500 principal mapper improvements

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/PrincipalDecoder.java
+++ b/src/main/java/org/wildfly/security/auth/server/PrincipalDecoder.java
@@ -99,6 +99,16 @@ public interface PrincipalDecoder {
     }
 
     /**
+     * Create a principal decoder which always returns the same name.
+     *
+     * @param name the name to return
+     * @return the constant decoder
+     */
+    static PrincipalDecoder constant(String name) {
+        return principal -> name;
+    }
+
+    /**
      * The default decoder, which just calls {@link Principal#getName()}.
      */
     PrincipalDecoder DEFAULT = Principal::getName;

--- a/src/main/java/org/wildfly/security/auth/server/PrincipalDecoder.java
+++ b/src/main/java/org/wildfly/security/auth/server/PrincipalDecoder.java
@@ -19,6 +19,7 @@
 package org.wildfly.security.auth.server;
 
 import java.security.Principal;
+import java.util.StringJoiner;
 
 import org.wildfly.common.Assert;
 
@@ -95,6 +96,31 @@ public interface PrincipalDecoder {
             } else {
                 return formerName + joinString + latterName;
             }
+        };
+    }
+
+    /**
+     * Create a principal decoder that concatenates the results of the given principal decoders in the order in which
+     * they're given. If any decoder is not able to decode the principal, then {@code null} is returned.
+     *
+     * @param joinString the string to use to join the results
+     * @param decoders the principal decoders (must not be {@code null}, cannot have {@code null} elements)
+     * @return the concatenating decoder
+     */
+    static PrincipalDecoder concatenating(final String joinString, final PrincipalDecoder... decoders) {
+        Assert.checkNotNullParam("joinString", joinString);
+        Assert.checkNotNullParam("decoders", decoders);
+        return principal -> {
+            final StringJoiner concatenatedResult = new StringJoiner(joinString);
+            String result;
+            for (PrincipalDecoder decoder : decoders) {
+                result = decoder.getName(principal);
+                if (result == null) {
+                    return null;
+                }
+                concatenatedResult.add(result);
+            }
+            return concatenatedResult.toString();
         };
     }
 

--- a/src/main/java/org/wildfly/security/x500/X500AttributePrincipalDecoder.java
+++ b/src/main/java/org/wildfly/security/x500/X500AttributePrincipalDecoder.java
@@ -35,6 +35,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
     private final String oid;
     private final String joiner;
     private final int maximumSegments;
+    private final boolean reverse;
 
     /**
      * Construct a new instance.  A joining string of "." is assumed.
@@ -42,7 +43,17 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param oid the OID of the attribute to map
      */
     public X500AttributePrincipalDecoder(final String oid) {
-        this(oid, ".", Integer.MAX_VALUE);
+        this(oid, false);
+    }
+
+    /**
+     * Construct a new instance.  A joining string of "." is assumed.
+     *
+     * @param oid the OID of the attribute to map
+     * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
+     */
+    public X500AttributePrincipalDecoder(final String oid, final boolean reverse) {
+        this(oid, ".", Integer.MAX_VALUE, reverse);
     }
 
     /**
@@ -52,7 +63,18 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param maximumSegments the maximum number of occurrences of the attribute to map
      */
     public X500AttributePrincipalDecoder(final String oid, final int maximumSegments) {
-        this(oid, ".", maximumSegments);
+        this(oid, maximumSegments, false);
+    }
+
+    /**
+     * Construct a new instance.  A joining string of "." is assumed.
+     *
+     * @param oid the OID of the attribute to map
+     * @param maximumSegments the maximum number of occurrences of the attribute to map
+     * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
+     */
+    public X500AttributePrincipalDecoder(final String oid, final int maximumSegments, final boolean reverse) {
+        this(oid, ".", maximumSegments, reverse);
     }
 
     /**
@@ -62,7 +84,18 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param joiner the joining string
      */
     public X500AttributePrincipalDecoder(final String oid, final String joiner) {
-        this(oid, joiner, Integer.MAX_VALUE);
+        this(oid, joiner, false);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param oid the OID of the attribute to map
+     * @param joiner the joining string
+     * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
+     */
+    public X500AttributePrincipalDecoder(final String oid, final String joiner, final boolean reverse) {
+        this(oid, joiner, Integer.MAX_VALUE, reverse);
     }
 
     /**
@@ -73,9 +106,22 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param maximumSegments the maximum number of occurrences of the attribute to map
      */
     public X500AttributePrincipalDecoder(final String oid, final String joiner, final int maximumSegments) {
+        this(oid, joiner, maximumSegments, false);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param oid the OID of the attribute to map
+     * @param joiner the joining string
+     * @param maximumSegments the maximum number of occurrences of the attribute to map
+     * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
+     */
+    public X500AttributePrincipalDecoder(final String oid, final String joiner, final int maximumSegments, final boolean reverse) {
         this.oid = oid;
         this.joiner = joiner;
         this.maximumSegments = maximumSegments;
+        this.reverse = reverse;
     }
 
     public String getName(final Principal principal) {
@@ -83,7 +129,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
         if (x500Principal == null) {
             return null;
         }
-        final String[] values = X500PrincipalUtil.getAttributeValues(x500Principal, oid);
+        final String[] values = X500PrincipalUtil.getAttributeValues(x500Principal, oid, reverse);
         if (values.length == 0) {
             return null;
         } else {

--- a/src/main/java/org/wildfly/security/x500/X500AttributePrincipalDecoder.java
+++ b/src/main/java/org/wildfly/security/x500/X500AttributePrincipalDecoder.java
@@ -34,6 +34,7 @@ import org.wildfly.security.auth.server.PrincipalDecoder;
 public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
     private final String oid;
     private final String joiner;
+    private final int startSegment;
     private final int maximumSegments;
     private final boolean reverse;
 
@@ -53,7 +54,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
      */
     public X500AttributePrincipalDecoder(final String oid, final boolean reverse) {
-        this(oid, ".", Integer.MAX_VALUE, reverse);
+        this(oid, ".", 0, Integer.MAX_VALUE, reverse);
     }
 
     /**
@@ -74,7 +75,30 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
      */
     public X500AttributePrincipalDecoder(final String oid, final int maximumSegments, final boolean reverse) {
-        this(oid, ".", maximumSegments, reverse);
+        this(oid, ".", 0, maximumSegments, reverse);
+    }
+
+    /**
+     * Construct a new instance.  A joining string of "." is assumed.
+     *
+     * @param oid the OID of the attribute to map
+     * @param startSegment the 0-based starting occurrence of the attribute to map
+     * @param maximumSegments the maximum number of occurrences of the attribute to map
+     */
+    public X500AttributePrincipalDecoder(final String oid, final int startSegment, final int maximumSegments) {
+        this(oid, startSegment, maximumSegments, false);
+    }
+
+    /**
+     * Construct a new instance.  A joining string of "." is assumed.
+     *
+     * @param oid the OID of the attribute to map
+     * @param startSegment the 0-based starting occurrence of the attribute to map
+     * @param maximumSegments the maximum number of occurrences of the attribute to map
+     * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
+     */
+    public X500AttributePrincipalDecoder(final String oid, final int startSegment, final int maximumSegments, final boolean reverse) {
+        this(oid, ".", startSegment, maximumSegments, reverse);
     }
 
     /**
@@ -95,7 +119,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
      */
     public X500AttributePrincipalDecoder(final String oid, final String joiner, final boolean reverse) {
-        this(oid, joiner, Integer.MAX_VALUE, reverse);
+        this(oid, joiner, 0, Integer.MAX_VALUE, reverse);
     }
 
     /**
@@ -106,7 +130,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      * @param maximumSegments the maximum number of occurrences of the attribute to map
      */
     public X500AttributePrincipalDecoder(final String oid, final String joiner, final int maximumSegments) {
-        this(oid, joiner, maximumSegments, false);
+        this(oid, joiner, 0, maximumSegments, false);
     }
 
     /**
@@ -114,12 +138,14 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
      *
      * @param oid the OID of the attribute to map
      * @param joiner the joining string
+     * @param startSegment the 0-based starting occurrence of the attribute to map
      * @param maximumSegments the maximum number of occurrences of the attribute to map
      * @param reverse {@code true} if the attribute values should be processed and returned in reverse order
      */
-    public X500AttributePrincipalDecoder(final String oid, final String joiner, final int maximumSegments, final boolean reverse) {
+    public X500AttributePrincipalDecoder(final String oid, final String joiner, final int startSegment, final int maximumSegments, final boolean reverse) {
         this.oid = oid;
         this.joiner = joiner;
+        this.startSegment = startSegment;
         this.maximumSegments = maximumSegments;
         this.reverse = reverse;
     }
@@ -133,7 +159,7 @@ public final class X500AttributePrincipalDecoder implements PrincipalDecoder {
         if (values.length == 0) {
             return null;
         } else {
-            return Arrays.stream(values).limit(maximumSegments).collect(Collectors.joining(joiner));
+            return Arrays.stream(values).skip(startSegment).limit(maximumSegments).collect(Collectors.joining(joiner));
         }
     }
 }

--- a/src/main/java/org/wildfly/security/x500/X500PrincipalUtil.java
+++ b/src/main/java/org/wildfly/security/x500/X500PrincipalUtil.java
@@ -61,6 +61,19 @@ public final class X500PrincipalUtil {
      * @return the list of values associated with the OID
      */
     public static String[] getAttributeValues(X500Principal principal, String oid) {
+        return getAttributeValues(principal, oid, false);
+    }
+
+    /**
+     * Get all the values of the attribute with the given OID in the given principal.  This includes occurrences within
+     * multi-valued RDNs.
+     *
+     * @param principal the principal to examine
+     * @param oid the OID whose values are to be returned
+     * @param reverse {@code true} if the values in the returned list should be in reverse order
+     * @return the list of values associated with the OID
+     */
+    public static String[] getAttributeValues(X500Principal principal, String oid, boolean reverse) {
         final ASN1Decoder decoder = new DERDecoder(principal.getEncoded());
         String[] strings = NO_STRINGS;
         int len = 0;
@@ -105,8 +118,16 @@ public final class X500PrincipalUtil {
             throw log.unexpectedTrailingGarbageInX500principal();
         }
         String[] result = len == 0 ? NO_STRINGS : new String[len];
-        for (int i = 0; i < len; i ++) {
-            result[len - i - 1] = strings[i];
+        if (! reverse) {
+            // The attribute values will be in the same order they appear in the string representation of the X.500 principal
+            for (int i = 0; i < len; i++) {
+                result[len - i - 1] = strings[i];
+            }
+        } else {
+            // The attribute values will be in reverse order
+            for (int i = 0; i < len; i++) {
+                result[i] = strings[i];
+            }
         }
         return result;
     }

--- a/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
+++ b/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
@@ -41,4 +41,20 @@ public class X500AttributePrincipalDecoderTest {
         decoder = new X500AttributePrincipalDecoder(X500.OID_DC, 1, true);
         assertEquals("example", decoder.getName(principal)); // single attribute value
     }
+
+    @Test
+    public void testDecodeAttributeWithSubrange() {
+        X500Principal principal;
+        X500AttributePrincipalDecoder decoder;
+        principal = new X500Principal("cn=bob.smith,dc=example,dc=redhat,dc=com");
+        decoder = new X500AttributePrincipalDecoder(X500.OID_DC, 1, 1); // single attribute value
+        assertEquals("redhat", decoder.getName(principal));
+
+        decoder = new X500AttributePrincipalDecoder(X500.OID_DC, 1, 2);
+        assertEquals("redhat.com", decoder.getName(principal));
+
+        principal = new X500Principal("dc=com,dc=redhat,dc=jboss,dc=example,ou=people,cn=bob.smith");
+        decoder = new X500AttributePrincipalDecoder(X500.OID_DC, 1, 3, true); // reverse order
+        assertEquals("jboss.redhat.com", decoder.getName(principal));
+    }
 }

--- a/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
+++ b/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.x500;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.junit.Test;
+
+/**
+ * Tests for the X500AttributePrincipalDecoder.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class X500AttributePrincipalDecoderTest {
+
+    @Test
+    public void testDecodeInReverse() {
+        X500Principal principal = new X500Principal("dc=com,dc=redhat,dc=example,ou=people,cn=bob.smith");
+        X500AttributePrincipalDecoder decoder;
+        decoder = new X500AttributePrincipalDecoder(X500.OID_DC, true);
+        assertEquals("example.redhat.com", decoder.getName(principal));
+
+        decoder = new X500AttributePrincipalDecoder(X500.OID_DC, 1, true);
+        assertEquals("example", decoder.getName(principal)); // single attribute value
+    }
+}

--- a/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
+++ b/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
@@ -78,4 +78,17 @@ public class X500AttributePrincipalDecoderTest {
         concatenatingDecoder = PrincipalDecoder.concatenating(",", dcDecoder1, dcDecoder, ouDecoder, cnDecoder);
         assertEquals("dc=redhat,dc=example,ou=people,cn=bob.smith", concatenatingDecoder.getName(principal));
     }
+
+    @Test
+    public void testDecodeWithRequiredAttributes() {
+        X500Principal principal;
+        // require the principal to have both CN and OU attributes
+        X500AttributePrincipalDecoder decoder = new X500AttributePrincipalDecoder(X500.OID_CN, ",", 0, 2, false, X500.OID_CN, X500.OID_OU);
+
+        principal = new X500Principal("cn=bob.smith,cn=bsmith,dc=example,dc=redhat,dc=com"); // missing an OU attribute
+        assertEquals(null, decoder.getName(principal));
+
+        principal = new X500Principal("cn=bob.smith,cn=bsmith,ou=people,dc=example,dc=redhat,dc=com");
+        assertEquals("bob.smith,bsmith", decoder.getName(principal));
+    }
 }

--- a/src/test/java/org/wildfly/security/x500/X500PrincipalUtilTest.java
+++ b/src/test/java/org/wildfly/security/x500/X500PrincipalUtilTest.java
@@ -56,5 +56,8 @@ public class X500PrincipalUtilTest {
         assertArrayEquals(new String[] { "peanut", "butter", "com", "faux" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_DC));
         assertArrayEquals(new String[] { "banana", "apple" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_CN));
         assertArrayEquals(new String[] { "faux", "com", "butter", "peanut" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_DC, true));
+        principal = new X500Principal("cn=Bob Smith+uid=bsmith,ou=people,dc=redhat,dc=com");
+        assertTrue(X500PrincipalUtil.containsAllAttributes(principal, X500.OID_CN, X500.OID_UID, X500.OID_DC));
+        assertFalse(X500PrincipalUtil.containsAllAttributes(principal, X500.OID_UID, X500.OID_L, X500.OID_DC));
     }
 }

--- a/src/test/java/org/wildfly/security/x500/X500PrincipalUtilTest.java
+++ b/src/test/java/org/wildfly/security/x500/X500PrincipalUtilTest.java
@@ -55,5 +55,6 @@ public class X500PrincipalUtilTest {
         System.out.println(principal.getName());
         assertArrayEquals(new String[] { "peanut", "butter", "com", "faux" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_DC));
         assertArrayEquals(new String[] { "banana", "apple" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_CN));
+        assertArrayEquals(new String[] { "faux", "com", "butter", "peanut" }, X500PrincipalUtil.getAttributeValues(principal, X500.OID_DC, true));
     }
 }


### PR DESCRIPTION
Made the following changes:

* Added the ability to decode attribute values in reverse order
* Added the ability to specify where to start decoding from
* Added a constant principal decoder
* Added a concatenating principal decoder that combines the results of two or more principal decoders
* Added the ability to specify a set of attributes that must be present in an X.500 principal

https://issues.jboss.org/browse/ELY-221