### PR TITLE
[ELY-470] Form authentication.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1211,6 +1211,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6006, value = "An authorization check for user '%s' failed using mechanism '%s'.")
     String authorizationFailed(String username, String mechanismName);
 
+    @Message(id = 6007, value = "Username or password missing from authentication attempt.")
+    String usernameOrPasswordMissing();
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm [%s]")

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -286,6 +286,18 @@ public class HttpAuthenticator {
             httpExchangeSpi.setResponseCookie(cookie);
         }
 
+        @Override
+        public boolean forward(String path) {
+            int statusCode = httpExchangeSpi.forward(path);
+            if (statusCode > 0) {
+                setStatusCode(statusCode);
+
+                return true;
+            }
+
+            return false;
+        }
+
     }
 
     /**

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -122,7 +122,9 @@ public class HttpAuthenticator {
                 if (required || (authenticationAttempted && ignoreOptionalFailures == false)) {
                     statusCodeAllowed = true;
                     if (responders.size() > 0) {
-                        responders.forEach((HttpServerMechanismsResponder r) -> r.sendResponse(this) );
+                        for (HttpServerMechanismsResponder responder : responders) {
+                            responder.sendResponse(this);
+                        }
                         if (statusCode > 0) {
                             httpExchangeSpi.setStatusCode(statusCode);
                         } else {

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -298,6 +298,16 @@ public class HttpAuthenticator {
             return false;
         }
 
+        @Override
+        public boolean suspendRequest() {
+            return httpExchangeSpi.suspendRequest();
+        }
+
+        @Override
+        public boolean resumeRequest() {
+            return httpExchangeSpi.resumeRequest();
+        }
+
     }
 
     /**

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -107,7 +107,12 @@ public class HttpAuthenticator {
 
                     if (isAuthenticated()) {
                         if (successResponder != null) {
+                            statusCodeAllowed = true;
                             successResponder.sendResponse(this);
+                            if (statusCode > 0) {
+                                httpExchangeSpi.setStatusCode(statusCode);
+                                return false;
+                            }
                         }
                         return true;
                     }

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -37,6 +37,17 @@ public class HttpConstants {
     public static final String SECURITY_IDENTITY = "wildfly.http.security-identity";
 
     /*
+     * Mechanism Configuration Properties
+     */
+
+    private static final String CONFIG_BASE = HttpConstants.class.getPackage().getName();
+    public static final String CONFIG_CONTEXT_PATH = CONFIG_BASE + ".context-path";
+    public static final String CONFIG_REALM = CONFIG_BASE + ".realm";
+    public static final String CONFIG_LOGIN_PAGE = CONFIG_BASE + ".login-page";
+    public static final String CONFIG_ERROR_PAGE = CONFIG_BASE + ".error-page";
+
+
+    /*
      * Header Fields
      */
 

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -43,9 +43,21 @@ public class HttpConstants {
     private static final String CONFIG_BASE = HttpConstants.class.getPackage().getName();
     public static final String CONFIG_CONTEXT_PATH = CONFIG_BASE + ".context-path";
     public static final String CONFIG_REALM = CONFIG_BASE + ".realm";
+
+    /**
+     * The context relative path of the login page.
+     */
     public static final String CONFIG_LOGIN_PAGE = CONFIG_BASE + ".login-page";
+
+    /**
+     * The context relative path of the error page.
+     */
     public static final String CONFIG_ERROR_PAGE = CONFIG_BASE + ".error-page";
 
+    /**
+     * This defines the location used by mechanisms dependent on the response to the challenge being sent in using 'POST'.
+     */
+    public static final String CONFIG_POST_LOCATION = CONFIG_BASE + ".post-location";
 
     /*
      * Header Fields
@@ -60,6 +72,7 @@ public class HttpConstants {
      */
 
     public static final String AUTHORIZATION = "Authorization";
+    public static final String LOCATION = "Location";
     public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 
     /*
@@ -68,13 +81,25 @@ public class HttpConstants {
 
     public static final String BASIC_NAME = "BASIC";
     public static final String CLIENT_CERT_NAME = "CLIENT_CERT";
+    public static final String FORM_NAME = "FORM";
 
     /*
      * Response Codes
      */
 
     public static final int OK = 200;
+    public static final int SEE_OTHER = 303;
+    public static final int TEMPORARY_REDIRECT = 307;
     public static final int UNAUTHORIZED = 401;
     public static final int FORBIDDEN = 403;
 
+    /*
+     * Methods
+     */
+
+    public static final String POST = "POST";
+
+
+
 }
+

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -251,4 +251,24 @@ public interface HttpExchangeSpi {
          return -1;
      }
 
+     /**
+      * Suspend the current request so that it can be subsequently resumed.
+      *
+      * The server may use any strategy it deems appropriate to suspend the current request and store the state ready for a subsequent request.
+      *
+      * @return {@code true} if suspension is supported, {@code false} otherwise.
+      */
+     default boolean suspendRequest() {
+         return false;
+     }
+
+     /**
+      * Resume a previously suspended request.
+      *
+      * @return {@code true} if resuming a request is supported, {@code false} otherwise.
+      */
+     default boolean resumeRequest() {
+         return false;
+     }
+
 }

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -241,4 +241,14 @@ public interface HttpExchangeSpi {
      * @return the output stream
      */
     OutputStream getResponseOutputStream();
+
+    /**
+     * Forward the current request to a different path.
+     *
+     * @return the desired status code from forwarding or {@code -1} if forwarding was not successful.
+     */
+     default int forward(String path) {
+         return -1;
+     }
+
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerMechanismsResponder.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerMechanismsResponder.java
@@ -31,6 +31,6 @@ public interface HttpServerMechanismsResponder {
      *
      * @param response the {@link HttpServerResponse} to use to set the response / challenge.
      */
-    void sendResponse(HttpServerResponse response);
+    void sendResponse(HttpServerResponse response) throws HttpAuthenticationException;
 
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -193,7 +193,7 @@ public interface HttpServerRequest extends HttpServerScopes {
      * Get the first value for the parameter specified.
      *
      * @param name the name of the parameter the first value is required for.
-     * @return the first value of the named parameter or {@code null} if the paramter is not available.
+     * @return the first value of the named parameter or {@code null} if the parameter is not available.
      */
     String getFirstParameterValue(String name);
 

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -218,4 +218,18 @@ public interface HttpServerRequest extends HttpServerScopes {
      */
     InetSocketAddress getSourceAddress();
 
+    /**
+     * Suspend the current request so that it can be subsequently resumed.
+     *
+     * @return {@code true} if suspending requests is supported, {@code false} otherwise.
+     */
+    boolean suspendRequest();
+
+    /**
+     * Resume any previously suspended request.
+     *
+     * @return {@code true} if resuming requests is supported, {@code false} otherwise.
+     */
+    boolean resumeRequest();
+
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerResponse.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerResponse.java
@@ -56,4 +56,12 @@ public interface HttpServerResponse {
      * @return the output stream
      */
     OutputStream getOutputStream();
+
+    /**
+     * Forward the current request to a different path.
+     *
+     * @return {@code true} if forwarding was supported and successful, {@code false} otherwise.
+     */
+     boolean forward(String path);
+
 }

--- a/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
@@ -36,18 +36,10 @@ import java.nio.CharBuffer;
 import java.util.List;
 import java.util.function.Supplier;
 
-import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.sasl.AuthorizeCallback;
-import javax.security.sasl.RealmCallback;
 
-import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
-import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
-import org.wildfly.security.evidence.PasswordGuessEvidence;
 import org.wildfly.security.http.HttpAuthenticationException;
-import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.util.ByteIterator;
@@ -57,16 +49,15 @@ import org.wildfly.security.util.ByteIterator;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism {
+class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationMechanism {
 
     // TODO - Undertow also has a silent mode for HTTP authentication.
 
     private static final String CHALLENGE_PREFIX = "Basic ";
     private static final int PREFIX_LENGTH = CHALLENGE_PREFIX.length();
 
-    private final CallbackHandler callbackHandler;
     private final boolean includeCharset;
-    private final String mechanismRealm;
+    final String mechanismRealm;
     private final String displayRealm;
 
     /**
@@ -78,9 +69,8 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
      * @param includeCharset should the charset be included in the challenge.
      */
     BasicAuthenticationMechanism(final CallbackHandler callbackHandler, final String mechanismRealm, final String displayRealm, final boolean includeCharset) {
-        checkNotNullParam("callbackHandler", callbackHandler);
+        super(checkNotNullParam("callbackHandler", callbackHandler), mechanismRealm);
 
-        this.callbackHandler = callbackHandler;
         this.includeCharset = includeCharset;
         this.mechanismRealm = mechanismRealm;
         this.displayRealm = displayRealm;
@@ -126,18 +116,20 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
                         String username = usernameChars.toString();
                         if (authenticate(username, passwordChars.array())) {
                             if (authorize(username)) {
-                                callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.SUCCEEDED });
+                                succeed();
 
                                 request.authenticationComplete();
                                 return;
                             } else {
-                                callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+                                fail();
+
                                 request.authenticationFailed(log.authorizationFailed(username, BASIC_NAME), response -> prepareResponse(() -> getHostName(request), response));
                                 return;
                             }
 
                         } else {
-                            callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+                            fail();
+
                             request.authenticationFailed(log.authenticationFailed(username, BASIC_NAME), response -> prepareResponse(() -> getHostName(request), response));
                             return;
                         }
@@ -154,47 +146,6 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
         }
 
         request.noAuthenticationInProgress(response -> prepareResponse(() -> getHostName(request), response));
-    }
-
-    private boolean authenticate(String username, char[] password) throws HttpAuthenticationException {
-        RealmCallback realmCallback = mechanismRealm != null ? new RealmCallback("User realm", mechanismRealm) : null;
-        NameCallback nameCallback = new NameCallback("Remote Authentication Name", username);
-        nameCallback.setName(username);
-        final PasswordGuessEvidence evidence = new PasswordGuessEvidence(password);
-        EvidenceVerifyCallback evidenceVerifyCallback = new EvidenceVerifyCallback(evidence);
-
-        try {
-            final Callback[] callbacks;
-            if (realmCallback != null) {
-                callbacks = new Callback[] { realmCallback, nameCallback, evidenceVerifyCallback };
-            } else {
-                callbacks = new Callback[] { nameCallback, evidenceVerifyCallback };
-            }
-
-            callbackHandler.handle(callbacks);
-
-            return evidenceVerifyCallback.isVerified();
-        } catch (UnsupportedCallbackException e) {
-            return false;
-        } catch (IOException e) {
-            throw new HttpAuthenticationException(e);
-        } finally {
-            evidence.destroy();
-        }
-    }
-
-    private boolean authorize(String username) throws HttpAuthenticationException {
-        AuthorizeCallback authorizeCallback = new AuthorizeCallback(username, username);
-
-        try {
-            callbackHandler.handle(new Callback[] {authorizeCallback});
-
-            return authorizeCallback.isAuthorized();
-        } catch (UnsupportedCallbackException e) {
-            return false;
-        } catch (IOException e) {
-            throw new HttpAuthenticationException(e);
-        }
     }
 
     private String getHostName(HttpServerRequest request) {

--- a/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
@@ -66,21 +66,24 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
 
     private final CallbackHandler callbackHandler;
     private final boolean includeCharset;
-    private final String realm;
+    private final String mechanismRealm;
+    private final String displayRealm;
 
     /**
      * Construct a new instance of {@code BasicAuthenticationMechanism}.
      *
      * @param callbackHandler the {@link CallbackHandler} to use to verify the supplied credentials and to notify to establish the current identity.
-     * @param realm the realm name to include in the challenge to the client.
-     * @param includeCharset should the charset be incuded in the challenge.
+     * @param mechanismRealm the name of the realm to be passed back in the callbacks for authentication.
+     * @param displayRealm the realm name that should be sent in the challenge to the client, if {@code null} the name of the host will be sent instead.
+     * @param includeCharset should the charset be included in the challenge.
      */
-    BasicAuthenticationMechanism(final CallbackHandler callbackHandler, final String realm, final boolean includeCharset) {
+    BasicAuthenticationMechanism(final CallbackHandler callbackHandler, final String mechanismRealm, final String displayRealm, final boolean includeCharset) {
         checkNotNullParam("callbackHandler", callbackHandler);
 
         this.callbackHandler = callbackHandler;
         this.includeCharset = includeCharset;
-        this.realm = realm;
+        this.mechanismRealm = mechanismRealm;
+        this.displayRealm = displayRealm;
     }
 
     /**
@@ -154,7 +157,7 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
     }
 
     private boolean authenticate(String username, char[] password) throws HttpAuthenticationException {
-        RealmCallback realmCallback = realm != null ? new RealmCallback("User realm", realm) : null;
+        RealmCallback realmCallback = mechanismRealm != null ? new RealmCallback("User realm", mechanismRealm) : null;
         NameCallback nameCallback = new NameCallback("Remote Authentication Name", username);
         nameCallback.setName(username);
         final PasswordGuessEvidence evidence = new PasswordGuessEvidence(password);
@@ -199,7 +202,7 @@ class BasicAuthenticationMechanism implements HttpServerAuthenticationMechanism 
     }
 
     private void prepareResponse(Supplier<String> hostnameSupplier, HttpServerResponse response) {
-        String realmName = realm != null ? realm : hostnameSupplier.get();
+        String realmName = displayRealm != null ? displayRealm : hostnameSupplier.get();
 
         StringBuilder sb = new StringBuilder(CHALLENGE_PREFIX);
         sb.append(REALM).append("=\"").append(realmName).append("\"");

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -194,6 +194,10 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
     }
 
     void sendPage(String page, HttpServerRequest request, HttpServerResponse response) throws HttpAuthenticationException {
+        if (response.forward(page)) {
+            return;
+        }
+
         // Work out how and send the login page.
         HttpScope application = request.getScope(Scope.APPLICATION);
         if (application != null && application.supportsResources()) {

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -102,7 +102,7 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
                     if (authenticate(username, password) && authorize(username)) {
                         succeed();
                         request.authenticationComplete();
-
+                        request.resumeRequest();
                         return;
                     } else {
                         identityCredentials.dispose();
@@ -188,6 +188,7 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
         HttpScope session = request.getScope(Scope.SESSION);
         if (session != null && session.supportsAttachments()) {
             session.setAttachment(LOCATION_KEY, request.getRequestURI().getPath());
+            request.suspendRequest();
         }
 
         sendPage(loginPage, request, response);
@@ -226,22 +227,6 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
         response.addResponseHeader(LOCATION, location);
         response.setStatusCode(SEE_OTHER);
     }
-
-    /*
-     * Suspend / Resume Options
-     *
-     * 1 - Cache URL only and redirect as GET request.
-     * 2 - Delegate suspend / resume to HTTP server - i.e. cache the whole request.
-     * 3 - Ignore address of security intercept and rederect to pre-defined location after auth.
-     */
-
-    /*
-     * Challenge Options
-     *
-     * 1 - Redirect to login page / error page.
-     * 2 - Access resource and serve directly.
-     * 3 - Internally forward request to page.
-     */
 
     final class FormIdentityCredentials {
         private final String username;

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.http.impl;
+
+import static java.util.Arrays.fill;
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.security.http.HttpConstants.CONFIG_CONTEXT_PATH;
+import static org.wildfly.security.http.HttpConstants.CONFIG_ERROR_PAGE;
+import static org.wildfly.security.http.HttpConstants.CONFIG_LOGIN_PAGE;
+import static org.wildfly.security.http.HttpConstants.CONFIG_POST_LOCATION;
+import static org.wildfly.security.http.HttpConstants.FORM_NAME;
+import static org.wildfly.security.http.HttpConstants.LOCATION;
+import static org.wildfly.security.http.HttpConstants.POST;
+import static org.wildfly.security.http.HttpConstants.SEE_OTHER;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpScope;
+import org.wildfly.security.http.HttpServerMechanismsResponder;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.http.HttpServerResponse;
+import org.wildfly.security.http.Scope;
+
+/**
+ * A generic FORM authentication mechanism which is usable in a number of different scenarios.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanism {
+
+    /*
+     * These two could also be made configurable but defer until proven demand.
+     */
+
+    private static final String USERNAME = "j_username";
+    private static final String PASSWORD = "j_password";
+
+    private static final String LOCATION_KEY = FormAuthenticationMechanism.class.getName() + ".Location";
+    private static final String IDENTITY_CREDENTIAL_KEY = FormAuthenticationMechanism.class.getName() + ".Identity-Credential";
+
+    private static final String DEFAULT_POST_LOCATION = "j_security_check";
+
+    private final String loginPage;
+    private final String errorPage;
+    private final String postLocation;
+
+    FormAuthenticationMechanism(final CallbackHandler callbackHandler, final Map<String, ?> properties) {
+        super(checkNotNullParam("callbackHandler", callbackHandler), null);
+        checkNotNullParam("properties", properties);
+
+        String postLocation = (String) properties.get(CONFIG_POST_LOCATION);
+        this.postLocation = postLocation != null ? postLocation : DEFAULT_POST_LOCATION;
+
+        loginPage = createPage(properties, CONFIG_LOGIN_PAGE);
+        errorPage = createPage(properties, CONFIG_ERROR_PAGE);
+    }
+
+    private String createPage(final Map<String, ?> properties, String pageConfig) {
+        String page = (String) properties.get(pageConfig);
+        if (page != null) {
+            String contextPath = (String) properties.get(CONFIG_CONTEXT_PATH);
+            return contextPath != null ? contextPath + page : page;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public String getMechanismName() {
+        return FORM_NAME;
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#evaluateRequest(org.wildfly.security.http.HttpServerRequest)
+     */
+    @Override
+    public void evaluateRequest(final HttpServerRequest request) throws HttpAuthenticationException {
+
+        // Do we have a cached identity?
+        HttpScope session = request.getScope(Scope.SESSION);
+        if (session != null) {
+            FormIdentityCredentials identityCredentials = session.getAttachment(IDENTITY_CREDENTIAL_KEY, FormIdentityCredentials.class);
+            if (identityCredentials != null) {
+                String username = identityCredentials.getUsername();
+                char[] password = identityCredentials.getPassword();
+                try {
+                    if (authenticate(username, password) && authorize(username)) {
+                        succeed();
+                        request.authenticationComplete();
+
+                        return;
+                    } else {
+                        identityCredentials.dispose();
+                        session.setAttachment(IDENTITY_CREDENTIAL_KEY, null);
+                    }
+                } catch (IOException | UnsupportedCallbackException e) {
+                    throw new HttpAuthenticationException(e);
+                } finally {
+                    fill(password, (char) 0x00);
+                }
+            }
+        }
+
+        // Is current request an authentication attempt?
+        if (POST.equals(request.getRequestMethod()) && request.getRequestURI().getPath().endsWith(postLocation)) {
+            attemptAuthentication(request);
+            return;
+        }
+
+        // Register challenger
+        if (loginPage != null) {
+            request.noAuthenticationInProgress((response) -> sendLoginByRedirect(request, response));
+        }
+    }
+
+    private void error(String message, HttpServerRequest request) {
+        request.authenticationFailed(message, this::sendErrorByRedirect);
+    }
+
+    private void attemptAuthentication(HttpServerRequest request) throws HttpAuthenticationException {
+        String username = request.getFirstParameterValue(USERNAME);
+        String password = request.getFirstParameterValue(PASSWORD);
+
+        if (username == null || password == null) {
+            error(log.usernameOrPasswordMissing(), request);
+            return;
+        }
+
+        char[] passwordChars = password.toCharArray();
+        try {
+            if (authenticate(username, passwordChars)) {
+                if (authorize(username)) {
+                    succeed();
+
+                    HttpScope session = request.getScope(Scope.SESSION);
+                    HttpServerMechanismsResponder responder = null;
+                    if (session != null) {
+                        session.setAttachment(IDENTITY_CREDENTIAL_KEY, new FormIdentityCredentials(username, password.toCharArray()));
+
+                        String originalPath = session.getAttachment(LOCATION_KEY, String.class);
+                        if (originalPath != null) {
+                            session.setAttachment(LOCATION_KEY, null);
+                            responder = (response) -> sendRedirect(response, originalPath);
+                        }
+                    }
+
+                    request.authenticationComplete(responder);
+
+                    return;
+                } else {
+                    fail();
+
+                    error(log.authorizationFailed(username, FORM_NAME), request);
+                    return;
+                }
+
+            } else {
+                fail();
+
+                error(log.authenticationFailed(username, FORM_NAME), request);
+                return;
+            }
+        } catch (IOException | UnsupportedCallbackException e) {
+            throw new HttpAuthenticationException(e);
+        } finally {
+            fill(passwordChars, (char) 0x00);
+        }
+    }
+
+    void sendLoginByRedirect(HttpServerRequest request, HttpServerResponse response) {
+        HttpScope session;
+        if ( (session = request.getScope(Scope.SESSION)) != null && session.supportsAttachments()) {
+            session.setAttachment(LOCATION_KEY, request.getRequestURI().getPath());
+        }
+
+        sendRedirect(response, loginPage);
+    }
+
+    void sendErrorByRedirect(HttpServerResponse response) {
+        sendRedirect(response, errorPage);
+    }
+
+    private void sendRedirect(HttpServerResponse response, String location) {
+        response.addResponseHeader(LOCATION, location);
+        response.setStatusCode(SEE_OTHER);
+    }
+
+    /*
+     * Suspend / Resume Options
+     *
+     * 1 - Cache URL only and redirect as GET request.
+     * 2 - Delegate suspend / resume to HTTP server - i.e. cache the whole request.
+     * 3 - Ignore address of security intercept and rederect to pre-defined location after auth.
+     */
+
+    /*
+     * Challenge Options
+     *
+     * 1 - Redirect to login page / error page.
+     * 2 - Access resource and serve directly.
+     * 3 - Internally forward request to page.
+     */
+
+    final class FormIdentityCredentials {
+        private final String username;
+        private final char[] password;
+
+        FormIdentityCredentials(String username, char[] password) {
+            this.username = username;
+            this.password = new char[password.length];
+            System.arraycopy(password, 0, this.password, 0, password.length);
+        }
+
+        String getUsername() {
+            return username;
+        }
+
+        char[] getPassword() {
+            char[] password = new char[this.password.length];
+            System.arraycopy(this.password, 0, password, 0, this.password.length);
+
+            return password;
+        }
+
+        void dispose() {
+            fill(password, (char) 0x00);
+        }
+
+    }
+}

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.http.impl;
 
+import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
 import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
 
@@ -63,7 +64,9 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
     public HttpServerAuthenticationMechanism createAuthenticationMechanism(String mechanismName, Map<String, ?> properties, CallbackHandler callbackHandler) throws HttpAuthenticationException {
         switch (mechanismName) {
             case BASIC_NAME:
+                String displayRealm = (String) properties.get(CONFIG_REALM);
                 String[] realms = null;
+                final String mechanismRealm;
                 final AvailableRealmsCallback availableRealmsCallback = new AvailableRealmsCallback();
                 try {
                     callbackHandler.handle(new Callback[] { availableRealmsCallback });
@@ -74,8 +77,23 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
                 } catch (IOException e) {
                     throw ElytronMessages.log.mechCallbackHandlerFailedForUnknownReason(mechanismName, e).toHttpAuthenticationException();
                 }
+                if (displayRealm == null) {
+                    displayRealm = realms == null || realms.length == 0 ? null : realms[0];
+                    mechanismRealm = displayRealm;
+                } else if (realms != null) {
+                    String resolvedRealm = null;
+                    for (String candidate : realms) {
+                        if (displayRealm.equals(candidate)) {
+                            resolvedRealm = displayRealm;
+                            break;
+                        }
+                    }
+                    mechanismRealm = resolvedRealm;
+                } else {
+                    mechanismRealm = null;
+                }
 
-                return new BasicAuthenticationMechanism(callbackHandler, realms == null || realms.length == 0 ? null : realms[0], false);
+                return new BasicAuthenticationMechanism(callbackHandler, mechanismRealm, displayRealm, false);
             case CLIENT_CERT_NAME:
                 return new ClientCertAuthenticationMechanism(callbackHandler);
         }

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -20,6 +20,7 @@ package org.wildfly.security.http.impl;
 import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
 import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
+import static org.wildfly.security.http.HttpConstants.FORM_NAME;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,6 +54,7 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
         ArrayList<String> mechanismNames = new ArrayList<>();
         mechanismNames.add(BASIC_NAME);
         mechanismNames.add(CLIENT_CERT_NAME);
+        mechanismNames.add(FORM_NAME);
 
         return mechanismNames.toArray(new String[mechanismNames.size()]);
     }
@@ -96,6 +98,8 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
                 return new BasicAuthenticationMechanism(callbackHandler, mechanismRealm, displayRealm, false);
             case CLIENT_CERT_NAME:
                 return new ClientCertAuthenticationMechanism(callbackHandler);
+            case FORM_NAME:
+                return new FormAuthenticationMechanism(callbackHandler, properties);
         }
         return null;
     }

--- a/src/main/java/org/wildfly/security/http/impl/UsernamePasswordAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/UsernamePasswordAuthenticationMechanism.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.impl;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
+import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+
+/**
+ * A base class for HTTP mechanisms that operate on validation fo plain text usernames and passwords.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+abstract class UsernamePasswordAuthenticationMechanism implements HttpServerAuthenticationMechanism {
+
+    private final CallbackHandler callbackHandler;
+    private final String mechanismRealm;
+
+    /**
+     * @param callbackHandler
+     * @param mechanismRealm
+     */
+    protected UsernamePasswordAuthenticationMechanism(CallbackHandler callbackHandler, String mechanismRealm) {
+        super();
+        this.callbackHandler = callbackHandler;
+        this.mechanismRealm = mechanismRealm;
+    }
+
+    protected boolean authenticate(String username, char[] password) throws HttpAuthenticationException {
+        RealmCallback realmCallback = mechanismRealm != null ? new RealmCallback("User realm", mechanismRealm) : null;
+        NameCallback nameCallback = new NameCallback("Remote Authentication Name", username);
+        nameCallback.setName(username);
+        final PasswordGuessEvidence evidence = new PasswordGuessEvidence(password);
+        EvidenceVerifyCallback evidenceVerifyCallback = new EvidenceVerifyCallback(evidence);
+
+        try {
+            final Callback[] callbacks;
+            if (realmCallback != null) {
+                callbacks = new Callback[] { realmCallback, nameCallback, evidenceVerifyCallback };
+            } else {
+                callbacks = new Callback[] { nameCallback, evidenceVerifyCallback };
+            }
+
+            callbackHandler.handle(callbacks);
+
+            return evidenceVerifyCallback.isVerified();
+        } catch (UnsupportedCallbackException e) {
+            return false;
+        } catch (IOException e) {
+            throw new HttpAuthenticationException(e);
+        } finally {
+            evidence.destroy();
+        }
+    }
+
+    protected boolean authorize(String username) throws HttpAuthenticationException {
+        AuthorizeCallback authorizeCallback = new AuthorizeCallback(username, username);
+
+        try {
+            callbackHandler.handle(new Callback[] {authorizeCallback});
+
+            return authorizeCallback.isAuthorized();
+        } catch (UnsupportedCallbackException e) {
+            return false;
+        } catch (IOException e) {
+            throw new HttpAuthenticationException(e);
+        }
+    }
+
+    protected void succeed() throws IOException, UnsupportedCallbackException {
+        callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.SUCCEEDED });
+    }
+
+    protected void fail() throws IOException, UnsupportedCallbackException {
+        callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+    }
+
+}

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -233,6 +233,17 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
             return wrapped.getSourceAddress();
         }
 
+        @Override
+        public boolean suspendRequest() {
+            return wrapped.suspendRequest();
+        }
+
+        @Override
+        public boolean resumeRequest() {
+            return wrapped.resumeRequest();
+        }
+
+
     }
 
 }

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -25,7 +25,6 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.AccessControlContext;
 import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collection;
@@ -108,10 +107,22 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
 
 
     private HttpServerMechanismsResponder wrap(final HttpServerMechanismsResponder toWrap) {
-        return toWrap != null ? (HttpServerResponse r) -> AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            toWrap.sendResponse(r);
-            return null;
-        }, accessControlContext) : null;
+        return toWrap != null ? (HttpServerResponse r) ->
+            {
+                try {
+                    AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+                        toWrap.sendResponse(r);
+                        return null;
+                    }
+                    , accessControlContext);
+                } catch (PrivilegedActionException e) {
+                    if (e.getCause() instanceof HttpAuthenticationException) {
+                        throw (HttpAuthenticationException) e.getCause();
+                    }
+                    throw new HttpAuthenticationException(e);
+                }
+            }
+            : null;
     }
 
     private class HttpServerRequestWrapper implements HttpServerRequest {


### PR DESCRIPTION
This can either go in now or wait until I have the remaining scenarios implemented.

This mechanism is now at the point where it is working by making use of redirects to redirect the client to the login page and after authentication is complete redirecting back to the secured resource that was originally requested.

Subsequent changes will be made to support: -
  Sending the login and error pages directly to the client.
  HTTP SPI adjustments to optionally support the server suspending a request / resuming a previous request.
 Dispatching login / error page handling to the server.
