### PR TITLE
[ELY-395] First add all the OpenSSL cipher suites so we can remove those with no authentication or encryption.

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/CipherSuiteSelector.java
+++ b/src/main/java/org/wildfly/security/ssl/CipherSuiteSelector.java
@@ -410,7 +410,8 @@ public abstract class CipherSuiteSelector {
                         } else {
                             switch (name) {
                                 /* -- openssl special -- */
-                                case "DEFAULT":             current = current.deleteFully(CipherSuitePredicate.matchOpenSslDefaultDeletes()); break;
+                                case "DEFAULT":             current = current.add(CipherSuitePredicate.matchOpenSslAll())
+                                                                             .deleteFully(CipherSuitePredicate.matchOpenSslDefaultDeletes()); break;
                                 case "COMPLEMENTOFDEFAULT": current = current.add(CipherSuitePredicate.matchAnonDH()); break;
                                 case "ALL":                 current = current.add(CipherSuitePredicate.matchOpenSslAll()); break;
                                 case "COMPLEMENTOFALL":     current = current.add(CipherSuitePredicate.matchOpenSslComplementOfAll()); break;


### PR DESCRIPTION
Started a chat in HipChat regarding if this would be better ALL:!aNULL:!eNULL or !aNULL:!eNULL:ALL - this PR matches the first form.

If the DEFAULT value is prefixed by a delete fully selector that will have been previously applied so the 'ALL' portion will not add those back in.