### PR TITLE
[ELY-554] Switch to using a MechanismConfigurationSelector

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -491,6 +491,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1118, value = "Public key could not be obtained. Probably due to an invalid PEM format.")
     IllegalArgumentException tokenRealmJwtInvalidPublicKeyPem();
 
+    @Message(id = 1119, value = "Unable to resolve MechanismConfiguration for mechanism='%s', host='%s', protocol='%s'.")
+    IllegalStateException unableToSelectMechanismConfiguration(String mechanismName, String hostName, String protocol);
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -491,8 +491,11 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1118, value = "Public key could not be obtained. Probably due to an invalid PEM format.")
     IllegalArgumentException tokenRealmJwtInvalidPublicKeyPem();
 
-    @Message(id = 1119, value = "Unable to resolve MechanismConfiguration for mechanism='%s', host='%s', protocol='%s'.")
-    IllegalStateException unableToSelectMechanismConfiguration(String mechanismName, String hostName, String protocol);
+    @Message(id = 1119, value = "Unable to resolve MechanismConfiguration for mechanismType='%s', mechanismName='%s', hostName='%s', protocol='%s'.")
+    IllegalStateException unableToSelectMechanismConfiguration(String mechanismType, String mechanismName, String hostName, String protocol);
+
+    @Message(id = 1120, value = "Too late to set mechanism information as authentication has already begun.")
+    IllegalStateException tooLateToSetMechanismInformation();
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/callback/MechanismInformationCallback.java
+++ b/src/main/java/org/wildfly/security/auth/callback/MechanismInformationCallback.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import org.wildfly.security.auth.server.MechanismInformation;
+
 /**
  * A {@link Callback} to pass the information about the current mechanism to the {@link CallbackHandler}.
  *
@@ -32,60 +34,24 @@ public class MechanismInformationCallback implements ExtendedCallback, Serializa
 
     private static final long serialVersionUID = -8376970360160709801L;
 
-    private final String mechanismType;
-    private final String mechanismName;
-    private final String hostName;
-    private final String protocol;
+    private final MechanismInformation mechanismInformation;
 
     /**
      * Construct a new instance with the appropriate mechanism information.
      *
-     * @param mechanismType the mechanism type.
-     * @param mechanismName the name of the mechanism.
-     * @param hostName the host name for the current authentication.
-     * @param protocol the protocol for the current authentication.
+     * @param mechanismInformation the mechanism information for the current authentication attempt.
      */
-    public MechanismInformationCallback(final String mechanismType, final String mechanismName, final String hostName, final String protocol) {
-        this.mechanismType = mechanismType;
-        this.mechanismName = mechanismName;
-        this.hostName = hostName;
-        this.protocol = protocol;
+    public MechanismInformationCallback(final MechanismInformation mechanismInformation) {
+        this.mechanismInformation = mechanismInformation;
     }
 
     /**
-     * Get the type of the mechanism for the current authentication.
+     * Get the type of the mechanism information for the current authentication attempt.
      *
      * @return the type of the mechanism for the current authentication.
      */
-    public String getMechanismType() {
-        return mechanismType;
-    }
-
-    /**
-     * Get the name of the mechanism for the current authentication.
-     *
-     * @return the name of the mechanism for the current authentication.
-     */
-    public String getMechanismName() {
-        return mechanismName;
-    }
-
-    /**
-     * Get the host name for the current authentication.
-     *
-     * @return the host name for the current authentication.
-     */
-    public String getHostName() {
-        return hostName;
-    }
-
-    /**
-     * Get the protocol for the current authentication.
-     *
-     * @return the protocol for the current authentication.
-     */
-    public String getProtocol() {
-        return protocol;
+    public MechanismInformation getMechanismInformation() {
+        return mechanismInformation;
     }
 
 }

--- a/src/main/java/org/wildfly/security/auth/callback/MechanismInformationCallback.java
+++ b/src/main/java/org/wildfly/security/auth/callback/MechanismInformationCallback.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.callback;
+
+import java.io.Serializable;
+
+import javax.security.auth.callback.CallbackHandler;
+
+/**
+ * A {@link Callback} to pass the information about the current mechanism to the {@link CallbackHandler}.
+ *
+ * As an informational {@code Callback} it is optional for the {@code CallbackHandler} to handle this.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class MechanismInformationCallback implements ExtendedCallback, Serializable {
+
+    private static final long serialVersionUID = -8376970360160709801L;
+
+    private final String mechanismType;
+    private final String mechanismName;
+    private final String hostName;
+    private final String protocol;
+
+    /**
+     * Construct a new instance with the appropriate mechanism information.
+     *
+     * @param mechanismType the mechanism type.
+     * @param mechanismName the name of the mechanism.
+     * @param hostName the host name for the current authentication.
+     * @param protocol the protocol for the current authentication.
+     */
+    public MechanismInformationCallback(final String mechanismType, final String mechanismName, final String hostName, final String protocol) {
+        this.mechanismType = mechanismType;
+        this.mechanismName = mechanismName;
+        this.hostName = hostName;
+        this.protocol = protocol;
+    }
+
+    /**
+     * Get the type of the mechanism for the current authentication.
+     *
+     * @return the type of the mechanism for the current authentication.
+     */
+    public String getMechanismType() {
+        return mechanismType;
+    }
+
+    /**
+     * Get the name of the mechanism for the current authentication.
+     *
+     * @return the name of the mechanism for the current authentication.
+     */
+    public String getMechanismName() {
+        return mechanismName;
+    }
+
+    /**
+     * Get the host name for the current authentication.
+     *
+     * @return the host name for the current authentication.
+     */
+    public String getHostName() {
+        return hostName;
+    }
+
+    /**
+     * Get the protocol for the current authentication.
+     *
+     * @return the protocol for the current authentication.
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
@@ -23,7 +23,6 @@ import static java.util.Collections.singleton;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -50,8 +49,8 @@ import org.wildfly.security.password.interfaces.DigestPassword;
  */
 public final class HttpAuthenticationFactory extends AbstractMechanismAuthenticationFactory<HttpServerAuthenticationMechanism, HttpServerAuthenticationMechanismFactory, HttpAuthenticationException> {
 
-    HttpAuthenticationFactory(final SecurityDomain securityDomain, final Map<String, MechanismConfiguration> mechanismConfigurations, final HttpServerAuthenticationMechanismFactory factory) {
-        super(securityDomain, mechanismConfigurations, factory);
+    HttpAuthenticationFactory(final SecurityDomain securityDomain, final MechanismConfigurationSelector mechanismConfigurationSelector, final HttpServerAuthenticationMechanismFactory factory) {
+        super(securityDomain, mechanismConfigurationSelector, factory);
     }
 
     HttpServerAuthenticationMechanism doCreate(final String name, final CallbackHandler callbackHandler, final UnaryOperator<HttpServerAuthenticationMechanismFactory> factoryTransformation) throws HttpAuthenticationException {
@@ -142,8 +141,8 @@ public final class HttpAuthenticationFactory extends AbstractMechanismAuthentica
             return this;
         }
 
-        public Builder addMechanism(final String mechanismName, final MechanismConfiguration mechanismConfiguration) {
-            super.addMechanism(mechanismName, mechanismConfiguration);
+        public Builder setMechanismConfigurationSelector(final MechanismConfigurationSelector mechanismConfigurationSelector) {
+            super.setMechanismConfigurationSelector(mechanismConfigurationSelector);
             return this;
         }
 
@@ -153,7 +152,7 @@ public final class HttpAuthenticationFactory extends AbstractMechanismAuthentica
         }
 
         public HttpAuthenticationFactory build() {
-            return new HttpAuthenticationFactory(getSecurityDomain(), getMechanismConfigurations(), getFactory());
+            return new HttpAuthenticationFactory(getSecurityDomain(), getMechanismConfigurationSelector(), getFactory());
         }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/server/MechanismAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismAuthenticationFactory.java
@@ -92,13 +92,12 @@ public interface MechanismAuthenticationFactory<M, F, E extends Exception> {
         Builder<M, F, E> setSecurityDomain(SecurityDomain securityDomain);
 
         /**
-         * Add a mechanism to the factory being built.  The same configuration may be used for more than one mechanism.
+         * Set the {@link MechanismConfigurationSelector} for the factory being built.
          *
-         * @param mechanismName the mechanism name (may not be {@code null})
-         * @param mechanismConfiguration the configuration to use (may not be {@code null})
+         * @param mechanismConfigurationSelector the {@link MechanismConfigurationSelector} for the factory being built.
          * @return this builder
          */
-        Builder<M, F, E> addMechanism(String mechanismName, MechanismConfiguration mechanismConfiguration);
+        Builder<M, F, E> setMechanismConfigurationSelector(MechanismConfigurationSelector mechanismConfigurationSelector);
 
         /**
          * Set the mechanism's underlying factory.

--- a/src/main/java/org/wildfly/security/auth/server/MechanismConfigurationSelector.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismConfigurationSelector.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server;
+
+/**
+ * A selector to choose which {@link MechanismConfiguration} to use based on information know about the current authentication
+ * attempt.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@FunctionalInterface
+public interface MechanismConfigurationSelector {
+
+    /**
+     * Select the {@link MechanismConfiguration} to use for the current authentication attempt.
+     *
+     * @param mechanismInformation information about the current authentication attempt.
+     * @return the {@link MechanismConfiguration} to use for the current authentication attempt.
+     */
+    MechanismConfiguration selectConfiguration(MechanismInformation mechanismInformation);
+
+    /**
+     * Create a constant {@link MechanismConfigurationSelector} which will always return the same {@link MechanismConfiguration}
+     * instance.
+     *
+     * @param mechanismConfiguration
+     * @return
+     */
+    static MechanismConfigurationSelector constantSelector(final MechanismConfiguration mechanismConfiguration) {
+        return information -> mechanismConfiguration;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/MechanismInformation.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismInformation.java
@@ -53,4 +53,27 @@ public interface MechanismInformation {
      */
     String getProtocol();
 
+    MechanismInformation DEFAULT = new MechanismInformation() {
+
+        @Override
+        public String getProtocol() {
+            return null;
+        }
+
+        @Override
+        public String getMechanismType() {
+            return null;
+        }
+
+        @Override
+        public String getMechanismName() {
+            return null;
+        }
+
+        @Override
+        public String getHostName() {
+            return null;
+        }
+    };
+
 }

--- a/src/main/java/org/wildfly/security/auth/server/MechanismInformation.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismInformation.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server;
+
+/**
+ * Information about the current mechanism being used for authentication.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface MechanismInformation {
+
+    /**
+     * Get the type of the authentication mechanism.
+     *
+     * @return the type of the authentication mechanism.
+     */
+    String getMechanismType();
+
+
+    /**
+     * Get the name of the current authentication mechanism.
+     *
+     * @return the name of the current authentication mechanism.
+     */
+    String getMechanismName();
+
+    /**
+     * Get the name of the host the current authentication attempt is for.
+     *
+     * @return the name of the host the current authentication attempt is for.
+     */
+    String getHostName();
+
+    /**
+     * Get the protocol for the current authentication attempt.
+     *
+     * @return the protocol for the current authentication attempt.
+     */
+    String getProtocol();
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/SaslAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/SaslAuthenticationFactory.java
@@ -48,8 +48,8 @@ import org.wildfly.security.sasl.util.TrustManagerSaslServerFactory;
 public final class SaslAuthenticationFactory extends AbstractMechanismAuthenticationFactory<SaslServer, SaslServerFactory, SaslException> {
     private final SaslServerFactory saslServerFactory;
 
-    SaslAuthenticationFactory(final SecurityDomain securityDomain, final Map<String, MechanismConfiguration> mechanismConfigurations, final SaslServerFactory saslServerFactory) {
-        super(securityDomain, mechanismConfigurations, saslServerFactory);
+    SaslAuthenticationFactory(final SecurityDomain securityDomain, final MechanismConfigurationSelector mechanismConfigurationSelector, final SaslServerFactory saslServerFactory) {
+        super(securityDomain, mechanismConfigurationSelector, saslServerFactory);
         this.saslServerFactory = saslServerFactory;
     }
 
@@ -116,8 +116,8 @@ public final class SaslAuthenticationFactory extends AbstractMechanismAuthentica
             return this;
         }
 
-        public Builder addMechanism(final String mechanismName, final MechanismConfiguration mechanismConfiguration) {
-            super.addMechanism(mechanismName, mechanismConfiguration);
+        public Builder setMechanismConfigurationSelector(final MechanismConfigurationSelector mechanismConfigurationSelector) {
+            super.setMechanismConfigurationSelector(mechanismConfigurationSelector);
             return this;
         }
 
@@ -131,7 +131,7 @@ public final class SaslAuthenticationFactory extends AbstractMechanismAuthentica
             if (! factory.delegatesThrough(TrustManagerSaslServerFactory.class)) {
                 factory = new TrustManagerSaslServerFactory(factory, null); // Use the default trust manager
             }
-            return new SaslAuthenticationFactory(getSecurityDomain(), getMechanismConfigurations(), factory);
+            return new SaslAuthenticationFactory(getSecurityDomain(), getMechanismConfigurationSelector(), factory);
         }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -118,27 +118,27 @@ public final class SecurityDomain {
         if (sm != null) {
             sm.checkPermission(CREATE_AUTH_CONTEXT);
         }
-        return new ServerAuthenticationContext(this, MechanismConfiguration.EMPTY);
+        return new ServerAuthenticationContext(this, MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY));
     }
 
     /**
      * Create a new authentication context for this security domain which can be used to carry out a single authentication
-     * operation.  The context is configured with a collection of mechanism realms to offer.
+     * operation.
      *
-     * @param mechanismConfiguration the mechanism configuration to use
+     * @param mechanismConfigurationSelector the selector to use to obtain the mechanism configuration
      * @return the new authentication context
      */
-    public ServerAuthenticationContext createNewAuthenticationContext(MechanismConfiguration mechanismConfiguration) {
+    public ServerAuthenticationContext createNewAuthenticationContext(MechanismConfigurationSelector mechanismConfigurationSelector) {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(CREATE_AUTH_CONTEXT);
         }
-        return new ServerAuthenticationContext(this, mechanismConfiguration);
+        return new ServerAuthenticationContext(this, mechanismConfigurationSelector);
     }
 
-    ServerAuthenticationContext createNewAuthenticationContext(SecurityIdentity capturedIdentity, MechanismConfiguration mechanismConfiguration) {
+    ServerAuthenticationContext createNewAuthenticationContext(SecurityIdentity capturedIdentity, MechanismConfigurationSelector mechanismConfigurationSelector) {
         assert capturedIdentity.getSecurityDomain() == this;
-        return new ServerAuthenticationContext(capturedIdentity, mechanismConfiguration);
+        return new ServerAuthenticationContext(capturedIdentity, mechanismConfigurationSelector);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
@@ -460,7 +460,7 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
         }
 
         final SecurityDomain domain = this.securityDomain;
-        final ServerAuthenticationContext context = domain.createNewAuthenticationContext(this, MechanismConfiguration.EMPTY);
+        final ServerAuthenticationContext context = domain.createNewAuthenticationContext(this, MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY));
         try {
             if (! (context.importIdentity(this) && context.authorize(name, authorize))) {
                 throw log.runAsAuthorizationFailed(getPrincipal(), new NamePrincipal(name), null);

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -28,7 +28,6 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -692,10 +691,10 @@ public final class ServerAuthenticationContext {
                 } else if (callback instanceof ServerCredentialCallback) {
                     final ServerCredentialCallback serverCredentialCallback = (ServerCredentialCallback) callback;
 
-                    final List<SecurityFactory<Credential>> serverCredentials = stateRef.get().getMechanismConfiguration().getServerCredentialFactories();
-                    for (SecurityFactory<Credential> factory : serverCredentials) {
+                    SecurityFactory<Credential> serverCredentialFactory = stateRef.get().getMechanismConfiguration().getServerCredentialFactory();
+                    if (serverCredentialFactory != null) {
                         try {
-                            final Credential credential = factory.create();
+                            final Credential credential = serverCredentialFactory.create();
                             if (serverCredentialCallback.isCredentialSupported(credential)) {
                                 serverCredentialCallback.setCredential(credential);
                                 handleOne(callbacks, idx + 1);

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -79,11 +79,12 @@ import org.wildfly.security.ssl.SSLUtils;
 import org.wildfly.security.x500.X500;
 
 /**
- * Server-side authentication context.  Instances of this class are used to preform all authentication and re-authorization
+ * Server-side authentication context.  Instances of this class are used to perform all authentication and re-authorization
  * operations that involve the usage of an identity in a {@linkplain SecurityDomain security domain}.
  * <p>
  * There are various effective states, described as follows:
  * <ul>
+ *     <li>The <em>inactive</em> state.</li>
  *     <li>
  *         The <em>unassigned</em> states:
  *         <ul>
@@ -110,11 +111,18 @@ import org.wildfly.security.x500.X500;
  * </ul>
  *
  * <p>
- * When an instance of this class is first constructed, it is in the <em>initial</em> state.  In this state, the context
- * retains an <em>captured {@linkplain SecurityIdentity identity}</em> and an optional <em>{@linkplain MechanismConfiguration mechanism configuration}</em>.
- * The <em>captured identity</em> may be used for various context-sensitive authorization decisions.  The <em>mechanism
- * configuration</em> is used to associate an authentication mechanism-specific configuration, including rewriters,
- * {@linkplain MechanismRealmConfiguration mechanism realms}, server credential factories, and more.
+ * When an instance of this class is first constructed, it is in the <em>inactive</em> state. In this state, the context retains
+ * a <em>captured {@linkplain SecurityIdentity identity}</em> and contains a reference to a
+ * <em>{@linkplain MechanismConfigurationSelector}</em>. The <em>captured identity</em> may be used for various
+ * context-sensitive authorization decisions. Additional mechanism information can be supplied to this state so that when
+ * authentication begins an appropriate <em>{@linkplain MechanismConfiguration}</em> can be selected.
+ * <p>
+ * Once authentication commences the state will automatically transition to the <em>initial</em> state. In this state, the
+ * context retains an <em>captured {@linkplain SecurityIdentity identity}</em> and a <em>{@linkplain MechanismConfiguration mechanism configuration}</em>
+ * which was resolved from the information supplied to the <em>inactive</em> state. The <em>captured identity</em> may be
+ * used for various context-sensitive authorization decisions.  The <em>mechanism configuration</em> is used to associate
+ * an authentication mechanism-specific configuration, including rewriters, {@linkplain MechanismRealmConfiguration mechanism realms},
+ * server credential factories, and more.
  * <p>
  * When an authentication mechanism is "realm-aware" (that is, it has a notion of realms that is specific to that particular
  * authentication mechanism, e.g. <a href="https://tools.ietf.org/html/rfc2831">the DIGEST-MD5 SASL mechanism</a>), it

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -64,7 +64,6 @@ public class HttpConstants {
      */
 
     public static final String CHARSET = "charset";
-    public static final String HOST = "Host";
     public static final String REALM = "realm";
 
     /*
@@ -72,6 +71,7 @@ public class HttpConstants {
      */
 
     public static final String AUTHORIZATION = "Authorization";
+    public static final String HOST = "Host";
     public static final String LOCATION = "Location";
     public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
 

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -69,7 +69,7 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
     private final String postLocation;
 
     FormAuthenticationMechanism(final CallbackHandler callbackHandler, final Map<String, ?> properties) {
-        super(checkNotNullParam("callbackHandler", callbackHandler), null);
+        super(checkNotNullParam("callbackHandler", callbackHandler));
         checkNotNullParam("properties", properties);
 
         String postLocation = (String) properties.get(CONFIG_POST_LOCATION);
@@ -99,7 +99,7 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
                 String username = identityCredentials.getUsername();
                 char[] password = identityCredentials.getPassword();
                 try {
-                    if (authenticate(username, password) && authorize(username)) {
+                    if (authenticate(null, username, password) && authorize(username)) {
                         succeed();
                         request.authenticationComplete();
                         request.resumeRequest();
@@ -143,7 +143,7 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
 
         char[] passwordChars = password.toCharArray();
         try {
-            if (authenticate(username, passwordChars)) {
+            if (authenticate(null, username, passwordChars)) {
                 if (authorize(username)) {
                     succeed();
 

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -17,22 +17,17 @@
  */
 package org.wildfly.security.http.impl;
 
-import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
 import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
+import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 import static org.wildfly.security.http.HttpConstants.FORM_NAME;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 
-import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.kohsuke.MetaInfServices;
-import org.wildfly.security._private.ElytronMessages;
-import org.wildfly.security.auth.callback.AvailableRealmsCallback;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
@@ -66,36 +61,7 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
     public HttpServerAuthenticationMechanism createAuthenticationMechanism(String mechanismName, Map<String, ?> properties, CallbackHandler callbackHandler) throws HttpAuthenticationException {
         switch (mechanismName) {
             case BASIC_NAME:
-                String displayRealm = (String) properties.get(CONFIG_REALM);
-                String[] realms = null;
-                final String mechanismRealm;
-                final AvailableRealmsCallback availableRealmsCallback = new AvailableRealmsCallback();
-                try {
-                    callbackHandler.handle(new Callback[] { availableRealmsCallback });
-                    realms = availableRealmsCallback.getRealmNames();
-                } catch (UnsupportedCallbackException ignored) {
-                } catch (HttpAuthenticationException e) {
-                    throw e;
-                } catch (IOException e) {
-                    throw ElytronMessages.log.mechCallbackHandlerFailedForUnknownReason(mechanismName, e).toHttpAuthenticationException();
-                }
-                if (displayRealm == null) {
-                    displayRealm = realms == null || realms.length == 0 ? null : realms[0];
-                    mechanismRealm = displayRealm;
-                } else if (realms != null) {
-                    String resolvedRealm = null;
-                    for (String candidate : realms) {
-                        if (displayRealm.equals(candidate)) {
-                            resolvedRealm = displayRealm;
-                            break;
-                        }
-                    }
-                    mechanismRealm = resolvedRealm;
-                } else {
-                    mechanismRealm = null;
-                }
-
-                return new BasicAuthenticationMechanism(callbackHandler, mechanismRealm, displayRealm, false);
+                return new BasicAuthenticationMechanism(callbackHandler, (String) properties.get(CONFIG_REALM), false);
             case CLIENT_CERT_NAME:
                 return new ClientCertAuthenticationMechanism(callbackHandler);
             case FORM_NAME:

--- a/src/main/java/org/wildfly/security/http/impl/UsernamePasswordAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/UsernamePasswordAuthenticationMechanism.java
@@ -40,21 +40,19 @@ import org.wildfly.security.http.HttpServerAuthenticationMechanism;
  */
 abstract class UsernamePasswordAuthenticationMechanism implements HttpServerAuthenticationMechanism {
 
-    private final CallbackHandler callbackHandler;
-    private final String mechanismRealm;
+    protected final CallbackHandler callbackHandler;
 
     /**
      * @param callbackHandler
      * @param mechanismRealm
      */
-    protected UsernamePasswordAuthenticationMechanism(CallbackHandler callbackHandler, String mechanismRealm) {
+    protected UsernamePasswordAuthenticationMechanism(CallbackHandler callbackHandler) {
         super();
         this.callbackHandler = callbackHandler;
-        this.mechanismRealm = mechanismRealm;
     }
 
-    protected boolean authenticate(String username, char[] password) throws HttpAuthenticationException {
-        RealmCallback realmCallback = mechanismRealm != null ? new RealmCallback("User realm", mechanismRealm) : null;
+    protected boolean authenticate(String realmName, String username, char[] password) throws HttpAuthenticationException {
+        RealmCallback realmCallback = realmName != null ? new RealmCallback("User realm", realmName) : null;
         NameCallback nameCallback = new NameCallback("Remote Authentication Name", username);
         nameCallback.setName(username);
         final PasswordGuessEvidence evidence = new PasswordGuessEvidence(password);

--- a/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.http.util;
+
+import static org.wildfly.security.http.HttpConstants.HOST;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.wildfly.security.auth.callback.MechanismInformationCallback;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.HttpServerRequest;
+
+/**
+ * A wrapper {@link HttpServerAuthenticationMechanismFactory} to ensure that mechanism information for the current
+ * authentication request is set before the first authentication callbacks.
+ *
+ * The host name and protocol are derived from the current request being authenticated.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SetMechanismInformationMechanismFactory implements HttpServerAuthenticationMechanismFactory {
+
+    private HttpServerAuthenticationMechanismFactory delegate;
+
+    public SetMechanismInformationMechanismFactory(final HttpServerAuthenticationMechanismFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String[] getMechanismNames(Map<String, ?> properties) {
+        return delegate.getMechanismNames(properties);
+    }
+
+    @Override
+    public HttpServerAuthenticationMechanism createAuthenticationMechanism(final String mechanismName, Map<String, ?> properties,
+            final CallbackHandler callbackHandler) throws HttpAuthenticationException {
+        final HttpServerAuthenticationMechanism mechanism = delegate.createAuthenticationMechanism(mechanismName, properties, callbackHandler);
+        return mechanism != null ? new HttpServerAuthenticationMechanism() {
+
+            @Override
+            public String getMechanismName() {
+                return mechanism.getMechanismName();
+            }
+
+            @Override
+            public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+                String host = request.getFirstRequestHeaderValue(HOST);
+                String resolvedHostName = null;
+                if (host != null) {
+                  if (host.startsWith("[")) {
+                      int close = host.indexOf(']');
+                      if (close > 0) {
+                          resolvedHostName = host.substring(0, close);
+                      }
+                  } else {
+                      int colon = host.lastIndexOf(':');
+                      resolvedHostName = colon > 0 ? host.substring(0, colon -1) : host;
+                  }
+                }
+
+                try {
+                    callbackHandler.handle(new Callback[] { new MechanismInformationCallback("HTTP", getMechanismName(),
+                            resolvedHostName, request.getRequestURI().getScheme()) });
+                } catch (IOException e) {
+                    throw new HttpAuthenticationException(e);
+                } catch (UnsupportedCallbackException ignored) {
+                }
+
+                mechanism.evaluateRequest(request);
+            }
+        } : null;
+    }
+
+
+
+}

--- a/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -27,6 +27,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.wildfly.security.auth.callback.MechanismInformationCallback;
+import org.wildfly.security.auth.server.MechanismInformation;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
@@ -81,8 +82,32 @@ public class SetMechanismInformationMechanismFactory implements HttpServerAuthen
                 }
 
                 try {
-                    callbackHandler.handle(new Callback[] { new MechanismInformationCallback("HTTP", getMechanismName(),
-                            resolvedHostName, request.getRequestURI().getScheme()) });
+                    final String mechanismName = getMechanismName();
+                    final String hostName = resolvedHostName;
+                    final String protocol = request.getRequestURI().getScheme();
+                    callbackHandler.handle(new Callback[] { new MechanismInformationCallback(new MechanismInformation() {
+
+                        @Override
+                        public String getProtocol() {
+                            return protocol;
+                        }
+
+                        @Override
+                        public String getMechanismType() {
+                            return "HTTP";
+                        }
+
+                        @Override
+                        public String getMechanismName() {
+                            return mechanismName;
+                        }
+
+                        @Override
+                        public String getHostName() {
+                            return hostName;
+                        }
+                    })});
+
                 } catch (IOException e) {
                     throw new HttpAuthenticationException(e);
                 } catch (UnsupportedCallbackException ignored) {

--- a/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
@@ -28,6 +28,7 @@ import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
 import org.wildfly.security.auth.callback.MechanismInformationCallback;
+import org.wildfly.security.auth.server.MechanismInformation;
 
 /**
  * A {@link SaslServerFactory} implementation that will always ensure mechanism information is passed to the {@link CallbackHandler} before the first authentication callbacks.
@@ -55,7 +56,28 @@ public final class SetMechanismInformationSaslServerFactory extends AbstractDele
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 if (informationSent == false) {
                     informationSent = true;
-                    cbh.handle(new Callback[] { new MechanismInformationCallback("SASL", mechanism, serverName, protocol) });
+                    cbh.handle(new Callback[] { new MechanismInformationCallback(new MechanismInformation() {
+
+                        @Override
+                        public String getProtocol() {
+                            return protocol;
+                        }
+
+                        @Override
+                        public String getMechanismType() {
+                            return "SASL";
+                        }
+
+                        @Override
+                        public String getMechanismName() {
+                            return mechanism;
+                        }
+
+                        @Override
+                        public String getHostName() {
+                            return serverName;
+                        }
+                    }) });
                 }
                 cbh.handle(callbacks);
             }

--- a/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.sasl.util;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.wildfly.security.auth.callback.MechanismInformationCallback;
+
+/**
+ * A {@link SaslServerFactory} implementation that will always ensure mechanism information is passed to the {@link CallbackHandler} before the first authentication callbacks.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class SetMechanismInformationSaslServerFactory extends AbstractDelegatingSaslServerFactory {
+
+    /**
+     * Construct a new instance of the {@code SetMechanismInformationSaslServerFactory}.
+     *
+     * @param delegate the {@link SaslServerFactory} being delegated to.
+     */
+    public SetMechanismInformationSaslServerFactory(SaslServerFactory delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public SaslServer createSaslServer(final String mechanism, final String protocol, final String serverName, Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
+        final CallbackHandler wrapper = new CallbackHandler() {
+
+            private volatile boolean informationSent = false;
+
+            @Override
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                if (informationSent == false) {
+                    informationSent = true;
+                    cbh.handle(new Callback[] { new MechanismInformationCallback("SASL", mechanism, serverName, protocol) });
+                }
+                cbh.handle(callbacks);
+            }
+        };
+
+        return super.createSaslServer(mechanism, protocol, serverName, props, wrapper);
+    }
+
+}

--- a/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -37,6 +37,7 @@ import org.wildfly.security.auth.permission.LoginPermission;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.realm.SimpleRealmEntry;
 import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
 import org.wildfly.security.auth.server.MechanismRealmConfiguration;
 import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
@@ -264,7 +265,7 @@ public class SaslServerBuilder {
         for (MechanismRealmConfiguration realmConfiguration : mechanismRealms.values()) {
             mechBuilder.addMechanismRealm(realmConfiguration);
         }
-        builder.addMechanism(mechanismName, mechBuilder.build());
+        builder.setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(mechBuilder.build()));
         final SaslServer server = builder.build().createMechanism(mechanismName);
         if (!dontAssertBuiltServer) {
             Assert.assertNotNull(server);


### PR DESCRIPTION
This is not complete as it still needs a callback to supply this initial information for selection however this shows leaving selecting the MechanismConfiguration until as late as possible to allow additional information to be provided.

Would probably add some aggregate methods to MechanismConfigurationSelector, also will probably add a method that takes a Predicate<MechanismInformation> - when it comes to our subsystem I think will most likely go for an ordered list of MechanismConfiguration instances and first to match on the MechanismInformation wins.

An additional side effect is that this means MechanismConfiguration no longer drives the availability of mechanisms - I think this is Ok if we make sure we have filters by name available - it also reduces the amount of default configuration we will require listing all mechanisms. 