### PR TITLE
[ELY-580] Add the ability to filter out unavailable mechanisms using the MechanismConfigurationSelector once the host name and protocol name are known

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/AbstractMechanismAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/AbstractMechanismAuthenticationFactory.java
@@ -54,6 +54,17 @@ abstract class AbstractMechanismAuthenticationFactory<M, F, E extends Exception>
         return doCreate(name, new ServerAuthenticationContext(securityDomain, mechanismConfigurationSelector).createCallbackHandler(), factoryTransformation);
     }
 
+    /**
+     * Determine if the given {@link MechanismInformation} can actually be resolved to a {@link MechanismConfiguration}.
+     *
+     * @param mechanismInformation information about an authentication attempt
+     * @return {@code true} if the given {@link MechanismInformation} can be resolved to a {@link MechanismConfiguration},
+     * {@code false} otherwise
+     */
+    public boolean isMechAvailable(MechanismInformation mechanismInformation) {
+        return mechanismConfigurationSelector.selectConfiguration(mechanismInformation) != null;
+    }
+
     abstract M doCreate(String name, CallbackHandler callbackHandler, final UnaryOperator<F> factoryTransformation) throws E;
 
     abstract Collection<Class<? extends Evidence>> getSupportedEvidenceTypes(String mechName);

--- a/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
+++ b/src/main/java/org/wildfly/security/auth/server/HttpAuthenticationFactory.java
@@ -20,6 +20,7 @@ package org.wildfly.security.auth.server;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static org.wildfly.security.http.HttpConstants.HOST;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -37,6 +38,7 @@ import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpConstants;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.util.SecurityIdentityServerMechanismFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.DigestPassword;
@@ -114,6 +116,29 @@ public final class HttpAuthenticationFactory extends AbstractMechanismAuthentica
                 return false;
             }
         }
+    }
+
+    /**
+     * Get the host name from the given {@link HttpServerRequest}.
+     *
+     * @param httpServerRequest the HTTP request
+     * @return the host name derived from the given HTTP request
+     */
+    public static String getHostName(final HttpServerRequest httpServerRequest) {
+        final String host = httpServerRequest.getFirstRequestHeaderValue(HOST);
+        String resolvedHostName = null;
+        if (host != null) {
+            if (host.startsWith("[")) {
+                int close = host.indexOf(']');
+                if (close > 0) {
+                    resolvedHostName = host.substring(0, close);
+                }
+            } else {
+                int colon = host.lastIndexOf(':');
+                resolvedHostName = colon > 0 ? host.substring(0, colon) : host;
+            }
+        }
+        return resolvedHostName;
     }
 
     /**

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSession;
@@ -49,13 +50,13 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public class HttpAuthenticator {
 
-    private final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
+    private final Function<HttpServerRequest, List<HttpServerAuthenticationMechanism>> mechanismSupplier;
     private final HttpExchangeSpi httpExchangeSpi;
     private final boolean required;
     private final boolean ignoreOptionalFailures;
     private volatile boolean authenticated = false;
 
-    private HttpAuthenticator(final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier, final HttpExchangeSpi httpExchangeSpi,
+    private HttpAuthenticator(final Function<HttpServerRequest, List<HttpServerAuthenticationMechanism>> mechanismSupplier, final HttpExchangeSpi httpExchangeSpi,
                               final boolean required, final boolean ignoreOptionalFailures) {
         this.mechanismSupplier = mechanismSupplier;
         this.httpExchangeSpi = httpExchangeSpi;
@@ -98,7 +99,7 @@ public class HttpAuthenticator {
         private volatile HttpServerMechanismsResponder successResponder;
 
         private boolean authenticate() throws HttpAuthenticationException {
-            List<HttpServerAuthenticationMechanism> authenticationMechanisms = mechanismSupplier.get();
+            List<HttpServerAuthenticationMechanism> authenticationMechanisms = mechanismSupplier.apply(this);
             responders = new ArrayList<>(authenticationMechanisms.size());
             try {
                 for (HttpServerAuthenticationMechanism nextMechanism : authenticationMechanisms) {
@@ -318,7 +319,7 @@ public class HttpAuthenticator {
      */
     public static class Builder {
 
-        private Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
+        private Function<HttpServerRequest, List<HttpServerAuthenticationMechanism>> mechanismSupplier;
         private HttpExchangeSpi httpExchangeSpi;
         private boolean required;
         private boolean ignoreOptionalFailures;
@@ -330,10 +331,10 @@ public class HttpAuthenticator {
          * Set the {@link Supplier<List<HttpServerAuthenticationMechanism>>} to use to obtain the actual {@link HttpServerAuthenticationMechanism} instances based
          * on the configured policy.
          *
-         * @param mechanismSupplier the {@link Supplier<List<HttpServerAuthenticationMechanism>>} with the configured authentication policy.
+         * @param mechanismSupplier the {@link Function<HttpServerRequest, List<HttpServerAuthenticationMechanism>>} with the configured authentication policy.
          * @return the {@link Builder} to allow method call chaining.
          */
-        public Builder setMechanismSupplier(Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier) {
+        public Builder setMechanismSupplier(Function<HttpServerRequest, List<HttpServerAuthenticationMechanism>> mechanismSupplier) {
             this.mechanismSupplier = mechanismSupplier;
 
             return this;


### PR DESCRIPTION
I looked into finding a way to pass the host name and protocol name to the ```AbstractMechanismAuthenticationFactory#getMechanismNames``` method in order to be able to use the ```MechanismConfigurationSelector``` to filter out mechanisms that aren't actually available. However, the problem with this is that at the time the ```getMechanismNames``` method is called, we don't yet know the host name and protocol name that are going to be used for the authentication attempt. As a possible alternative approach, we could add an ```isMechAvailable``` method to ```AbstractMechanismAuthenticationFactory``` and have the mechanism supplier make use of this method to filter out mechanisms once the host name and protocol name are known.

Related elytron-web, wildfly-core, and wildfly PRs:
https://github.com/wildfly-security/elytron-web/pull/18
https://github.com/wildfly-security-incubator/wildfly-core/pull/3
https://github.com/wildfly-security-incubator/wildfly/pull/16