### PR TITLE
LdapRealm - password change test + null identity after remove

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -703,6 +703,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             try {
                 log.debugf("Removing identity [%s] with DN [%s] from LDAP", name, identity.getDistinguishedName());
                 context.destroySubcontext(new LdapName(identity.getDistinguishedName()));
+                identity = null; // force reload
             } catch (NamingException e) {
                 throw log.ldapRealmFailedDeleteIdentityFromServer(e);
             } finally {

--- a/src/test/resources/ldap/elytron-credential-tests.ldif
+++ b/src/test/resources/ldap/elytron-credential-tests.ldif
@@ -104,3 +104,13 @@ uid: bsdCryptUser
 userPassword:: e2NyeXB0fV9OLi4uL1RUcHlCeVRWdmRtV0dv
 # Password cryptPassword
 
+dn: uid=userToChange,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+cn: userToChangeCn
+sn: userToChangeSn
+uid: userToChange
+userPassword:: cGxhaW5QYXNzd29yZA==
+# Password plainPassword (changing during tests)


### PR DESCRIPTION
* Test of userPassword change
* Setting identity to null after delete (force reload) (to be consistent with FileSystemRealm)