### PR TITLE
[ELY-462] DirContext supplier instead of DirContextFactory

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -293,8 +293,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1056, value = "Invalid salt \"%s%s%s%s\"")
     IllegalArgumentException invalidSalt(char b0, char b1, char b2, char b3);
 
-    @Message(id = 1057, value = "No DirContextFactory set")
-    IllegalStateException noDirContextFactorySet();
+    @Message(id = 1057, value = "No DirContext supplier set")
+    IllegalStateException noDirContextSupplierSet();
 
     @Message(id = 1058, value = "No principal mapping definition")
     IllegalStateException noPrincipalMappingDefinition();
@@ -511,6 +511,9 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1124, value = "The security realm does not support updating a credential")
     UnsupportedOperationException credentialUpdateNotSupportedByRealm();
+
+    @Message(id = 1125, value = "Ldap-backed realm failed to obtain context")
+    RealmUnavailableException ldapRealmFailedToObtainContext(@Cause Throwable cause);
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
@@ -22,6 +22,8 @@ import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SupportLevel;
 import org.wildfly.security.credential.Credential;
 
+import javax.naming.directory.DirContext;
+
 /**
  * Within LDAP credentials could be stored in different ways, splitting out a CredentialLoader allows different strategies to be
  * plugged into the realm.
@@ -43,12 +45,12 @@ interface CredentialLoader {
      * Note: The DirContextFactory approach will be evolved further for better referral support so it makes it easier for it to
      * be passed in for each call.
      *
-     * @param contextFactory the dir context factory to use if a DirContext is required to query the server directly
+     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param credentialType the credential type (must not be {@code null})
      * @param algorithmName the credential algorithm name
      * @return the level of support for this credential type
      */
-    SupportLevel getCredentialAcquireSupport(DirContextFactory contextFactory, Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException;
+    SupportLevel getCredentialAcquireSupport(DirContext dirContext, Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException;
 
     /**
      * Obtain an {@link IdentityCredentialLoader} to query the credentials for a specific identity.
@@ -56,10 +58,10 @@ interface CredentialLoader {
      * Note: By this point referrals relating to the identity should have been resolved so the {@link DirContextFactory} should
      * be suitable for use with the supplied {@code distinguishedName}
      *
-     * @param contextFactory the {@link DirContextFactory} to use to connect to LDAP.
+     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param distinguishedName the distinguished name of the identity.
      * @return An {@link IdentityCredentialLoader} for the specified identity identified by their distinguished name.
      */
-    IdentityCredentialLoader forIdentity(DirContextFactory contextFactory, String distinguishedName) throws RealmUnavailableException;
+    IdentityCredentialLoader forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
 
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialPersister.java
@@ -2,6 +2,7 @@ package org.wildfly.security.auth.realm.ldap;
 
 import org.wildfly.security.auth.server.RealmUnavailableException;
 
+import javax.naming.directory.DirContext;
 
 /**
  * Within LDAP credentials could be stored in different ways, splitting out a CredentialPersister allows different strategies to
@@ -17,10 +18,10 @@ public interface CredentialPersister extends CredentialLoader {
      * Note: By this point referrals relating to the identity should have been resolved so the {@link DirContextFactory} should
      * be suitable for use with the supplied {@code distinguishedName}
      *
-     * @param contextFactory the {@link DirContextFactory} to use to connect to LDAP.
+     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param distinguishedName the distinguished name of the identity.
      * @return An {@link IdentityCredentialLoader} for the specified identity identified by their distinguished name.
      */
-    IdentityCredentialPersister forIdentity(DirContextFactory contextFactory, String distinguishedName) throws RealmUnavailableException;
+    IdentityCredentialPersister forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
 
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
@@ -1,0 +1,378 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.realm.ldap;
+
+import org.wildfly.common.Assert;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NameParser;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Control;
+import javax.naming.ldap.ExtendedRequest;
+import javax.naming.ldap.ExtendedResponse;
+import javax.naming.ldap.LdapContext;
+import java.util.Hashtable;
+
+/**
+ * Delegating {@link LdapContext}, which use {@link DirContextFactory} to obtain and return context.
+ * Context is obtained on construction and returned instead of closing.
+ * If non-Ldap context is obtained, LdapContext specific methods throws {@link UnsupportedOperationException}.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class DelegatingLdapContext implements LdapContext {
+
+    DirContext delegating;
+    DirContextFactory factory;
+
+    public DelegatingLdapContext(DirContextFactory dirContextFactory, DirContextFactory.ReferralMode mode) throws NamingException {
+        factory = dirContextFactory;
+        delegating = factory.obtainDirContext(mode);
+    }
+
+    @Override
+    public void close() throws NamingException {
+        factory.returnContext(delegating);
+    }
+
+    // LdapContext specific
+
+    @Override
+    public ExtendedResponse extendedOperation(ExtendedRequest request) throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        return ((LdapContext) delegating).extendedOperation(request);
+    }
+
+    @Override
+    public LdapContext newInstance(Control[] requestControls) throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        return ((LdapContext) delegating).newInstance(requestControls);
+    }
+
+    @Override
+    public void reconnect(Control[] connCtls) throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        ((LdapContext) delegating).reconnect(connCtls);
+    }
+
+    @Override
+    public Control[] getConnectControls() throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        return ((LdapContext) delegating).getConnectControls();
+    }
+
+    @Override
+    public void setRequestControls(Control[] requestControls) throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        ((LdapContext) delegating).setRequestControls(requestControls);
+    }
+
+    @Override
+    public Control[] getRequestControls() throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        return ((LdapContext) delegating).getRequestControls();
+    }
+
+    @Override
+    public Control[] getResponseControls() throws NamingException {
+        if ( ! (delegating instanceof LdapContext)) throw Assert.unsupported();
+        return ((LdapContext) delegating).getResponseControls();
+    }
+
+    // DirContext methods delegates only
+
+    @Override
+    public void bind(String name, Object obj, Attributes attrs) throws NamingException {
+        delegating.bind(name, obj, attrs);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name) throws NamingException {
+        return delegating.getAttributes(name);
+    }
+
+    @Override
+    public Attributes getAttributes(String name) throws NamingException {
+        return delegating.getAttributes(name);
+    }
+
+    @Override
+    public Attributes getAttributes(Name name, String[] attrIds) throws NamingException {
+        return delegating.getAttributes(name, attrIds);
+    }
+
+    @Override
+    public Attributes getAttributes(String name, String[] attrIds) throws NamingException {
+        return delegating.getAttributes(name, attrIds);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, int mod_op, Attributes attrs) throws NamingException {
+        delegating.modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(String name, int mod_op, Attributes attrs) throws NamingException {
+        delegating.modifyAttributes(name, mod_op, attrs);
+    }
+
+    @Override
+    public void modifyAttributes(Name name, ModificationItem[] mods) throws NamingException {
+        delegating.modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void modifyAttributes(String name, ModificationItem[] mods) throws NamingException {
+        delegating.modifyAttributes(name, mods);
+    }
+
+    @Override
+    public void bind(Name name, Object obj, Attributes attrs) throws NamingException {
+        delegating.bind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj, Attributes attrs) throws NamingException {
+        delegating.rebind(name, obj, attrs);
+    }
+
+    @Override
+    public void rebind(String name, Object obj, Attributes attrs) throws NamingException {
+        delegating.rebind(name, obj, attrs);
+    }
+
+    @Override
+    public DirContext createSubcontext(Name name, Attributes attrs) throws NamingException {
+        return delegating.createSubcontext(name, attrs);
+    }
+
+    @Override
+    public DirContext createSubcontext(String name, Attributes attrs) throws NamingException {
+        return delegating.createSubcontext(name, attrs);
+    }
+
+    @Override
+    public DirContext getSchema(Name name) throws NamingException {
+        return delegating.getSchema(name);
+    }
+
+    @Override
+    public DirContext getSchema(String name) throws NamingException {
+        return delegating.getSchema(name);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(Name name) throws NamingException {
+        return delegating.getSchemaClassDefinition(name);
+    }
+
+    @Override
+    public DirContext getSchemaClassDefinition(String name) throws NamingException {
+        return delegating.getSchemaClassDefinition(name);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
+        return delegating.search(name, matchingAttributes, attributesToReturn);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
+        return delegating.search(name, matchingAttributes, attributesToReturn);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes) throws NamingException {
+        return delegating.search(name, matchingAttributes);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes) throws NamingException {
+        return delegating.search(name, matchingAttributes);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filter, SearchControls cons) throws NamingException {
+        return delegating.search(name, filter, cons);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons) throws NamingException {
+        return delegating.search(name, filter, cons);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(Name name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
+        return delegating.search(name, filterExpr, filterArgs, cons);
+    }
+
+    @Override
+    public NamingEnumeration<SearchResult> search(String name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
+        return delegating.search(name, filterExpr, filterArgs, cons);
+    }
+
+    @Override
+    public Object lookup(Name name) throws NamingException {
+        return delegating.lookup(name);
+    }
+
+    @Override
+    public Object lookup(String name) throws NamingException {
+        return delegating.lookup(name);
+    }
+
+    @Override
+    public void bind(Name name, Object obj) throws NamingException {
+        delegating.bind(name, obj);
+    }
+
+    @Override
+    public void bind(String name, Object obj) throws NamingException {
+        delegating.bind(name, obj);
+    }
+
+    @Override
+    public void rebind(Name name, Object obj) throws NamingException {
+        delegating.rebind(name, obj);
+    }
+
+    @Override
+    public void rebind(String name, Object obj) throws NamingException {
+        delegating.rebind(name, obj);
+    }
+
+    @Override
+    public void unbind(Name name) throws NamingException {
+        delegating.unbind(name);
+    }
+
+    @Override
+    public void unbind(String name) throws NamingException {
+        delegating.unbind(name);
+    }
+
+    @Override
+    public void rename(Name oldName, Name newName) throws NamingException {
+        delegating.rename(oldName, newName);
+    }
+
+    @Override
+    public void rename(String oldName, String newName) throws NamingException {
+        delegating.rename(oldName, newName);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(Name name) throws NamingException {
+        return delegating.list(name);
+    }
+
+    @Override
+    public NamingEnumeration<NameClassPair> list(String name) throws NamingException {
+        return delegating.list(name);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(Name name) throws NamingException {
+        return delegating.listBindings(name);
+    }
+
+    @Override
+    public NamingEnumeration<Binding> listBindings(String name) throws NamingException {
+        return delegating.listBindings(name);
+    }
+
+    @Override
+    public void destroySubcontext(Name name) throws NamingException {
+        delegating.destroySubcontext(name);
+    }
+
+    @Override
+    public void destroySubcontext(String name) throws NamingException {
+        delegating.destroySubcontext(name);
+    }
+
+    @Override
+    public Context createSubcontext(Name name) throws NamingException {
+        return delegating.createSubcontext(name);
+    }
+
+    @Override
+    public Context createSubcontext(String name) throws NamingException {
+        return delegating.createSubcontext(name);
+    }
+
+    @Override
+    public Object lookupLink(Name name) throws NamingException {
+        return delegating.lookupLink(name);
+    }
+
+    @Override
+    public Object lookupLink(String name) throws NamingException {
+        return delegating.lookupLink(name);
+    }
+
+    @Override
+    public NameParser getNameParser(Name name) throws NamingException {
+        return delegating.getNameParser(name);
+    }
+
+    @Override
+    public NameParser getNameParser(String name) throws NamingException {
+        return delegating.getNameParser(name);
+    }
+
+    @Override
+    public Name composeName(Name name, Name prefix) throws NamingException {
+        return delegating.composeName(name, prefix);
+    }
+
+    @Override
+    public String composeName(String name, String prefix) throws NamingException {
+        return delegating.composeName(name, prefix);
+    }
+
+    @Override
+    public Object addToEnvironment(String propName, Object propVal) throws NamingException {
+        return delegating.addToEnvironment(propName, propVal);
+    }
+
+    @Override
+    public Object removeFromEnvironment(String propName) throws NamingException {
+        return delegating.removeFromEnvironment(propName);
+    }
+
+    @Override
+    public Hashtable<?, ?> getEnvironment() throws NamingException {
+        return delegating.getEnvironment();
+    }
+
+    @Override
+    public String getNameInNamespace() throws NamingException {
+        return delegating.getNameInNamespace();
+    }
+}

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/EvidenceVerifier.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/EvidenceVerifier.java
@@ -22,6 +22,8 @@ import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.server.SupportLevel;
 import org.wildfly.security.evidence.Evidence;
 
+import javax.naming.directory.DirContext;
+
 /**
  * An individual evidence verifier to associate with an LDAP {@link SecurityRealm}, multiple verifiers
  * can be associated with the realm allowing for different verification strategies to be applied to different named credentials.
@@ -33,13 +35,13 @@ interface EvidenceVerifier {
     /**
      * Get the {@link SupportLevel} for the level of evidence validation support for the named credential.
      *
-     * @param contextFactory the {@link DirContextFactory} to access the LDAP server
+     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param evidenceType the evidence type (must not be {@code null})
      * @param algorithmName the evidence algorithm name or {@code null} if none
      * @return the level of support for the named credential
      * @throws RealmUnavailableException if the realm is currently unable to handle requests
      */
-    SupportLevel getEvidenceVerifySupport(DirContextFactory contextFactory, Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException;
+    SupportLevel getEvidenceVerifySupport(DirContext dirContext, Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException;
 
     /**
      * Obtain an {@link IdentityEvidenceVerifier} to verify the evidence for a specific identity.
@@ -47,10 +49,10 @@ interface EvidenceVerifier {
      * Note: By this point referrals relating to the identity should have been resolved so the {@link DirContextFactory} should
      * be suitable for use with the supplied {@code distinguishedName}
      *
-     * @param contextFactory the {@link DirContextFactory} to use to connect to LDAP.
+     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param distinguishedName the distinguished name of the identity.
      * @return An {@link IdentityEvidenceVerifier} for the specified identity identified by their distinguished name.
      */
-    IdentityEvidenceVerifier forIdentity(DirContextFactory contextFactory, String distinguishedName) throws RealmUnavailableException;
+    IdentityEvidenceVerifier forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
 
 }

--- a/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
@@ -54,7 +54,7 @@ public abstract class AbstractAttributeMappingSuiteChild {
         builder.setDefaultRealmName("default")
                 .addRealm("default",
                         LdapSecurityRealmBuilder.builder()
-                                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                                 .identityMapping()
                                         .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                                         .searchRecursive()

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
@@ -62,7 +62,7 @@ public class ModifiabilitySuiteChild {
         attributes.put(new BasicAttribute("description", "new user"));
 
         realm = LdapSecurityRealmBuilder.builder()
-            .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+            .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
             .setPageSize(3)
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")

--- a/src/test/java/org/wildfly/security/ldap/PasswordSupportSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordSupportSuiteChild.java
@@ -68,7 +68,7 @@ public class PasswordSupportSuiteChild {
     @BeforeClass
     public static void createRealm() {
         simpleToDnRealm = LdapSecurityRealmBuilder.builder()
-            .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+            .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                 .setRdnIdentifier("uid")

--- a/src/test/java/org/wildfly/security/ldap/PasswordValidationSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordValidationSuiteChild.java
@@ -20,6 +20,7 @@ package org.wildfly.security.ldap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
@@ -37,7 +38,7 @@ public class PasswordValidationSuiteChild {
     @Test
     public void testPlainUserWithSimpleName() throws Exception {
         SecurityRealm securityRealm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                     .setRdnIdentifier("uid")
@@ -51,12 +52,13 @@ public class PasswordValidationSuiteChild {
         assertEquals("Identity verification level support", SupportLevel.SUPPORTED, credentialSupport);
 
         assertTrue(realmIdentity.verifyEvidence(new PasswordGuessEvidence("plainPassword".toCharArray())));
+        assertFalse(realmIdentity.verifyEvidence(new PasswordGuessEvidence("wrongPassword".toCharArray())));
     }
 
     @Test
     public void testPlainUserWithX500Name() throws Exception {
         SecurityRealm securityRealm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setRdnIdentifier("uid")
                     .build()
@@ -69,6 +71,7 @@ public class PasswordValidationSuiteChild {
         assertEquals("Identity verification level support", SupportLevel.SUPPORTED, credentialSupport);
 
         assertTrue(realmIdentity.verifyEvidence(new PasswordGuessEvidence("plainPassword".toCharArray())));
+        assertFalse(realmIdentity.verifyEvidence(new PasswordGuessEvidence("wrongPassword".toCharArray())));
     }
 
 }

--- a/src/test/java/org/wildfly/security/ldap/PrincipalMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/PrincipalMappingSuiteChild.java
@@ -38,7 +38,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testSimpleToDn() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                     .setRdnIdentifier("uid")
@@ -55,7 +55,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testDnToSimple() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setRdnIdentifier("uid")
                     .build()
@@ -71,7 +71,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testSimpleToSimpleValidate() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                     .setRdnIdentifier("uid")
@@ -88,7 +88,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testSimpleToSimpleReload() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                     .setRdnIdentifier("uid")
@@ -105,7 +105,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testDnToDnNoLookup() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setRdnIdentifier("uid")
                     .build()
@@ -118,7 +118,7 @@ public class PrincipalMappingSuiteChild {
     @Test
     public void testDnToDnVerify() throws RealmUnavailableException {
         SecurityRealm realm = LdapSecurityRealmBuilder.builder()
-                .setDirContextFactory(LdapTestSuite.dirContextFactory.create())
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
                 .identityMapping()
                     .setRdnIdentifier("uid")
                     .setSearchDn("dc=elytron,dc=wildfly,dc=org")

--- a/src/test/java/org/wildfly/security/ldap/TestEnvironmentSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/TestEnvironmentSuiteChild.java
@@ -19,7 +19,7 @@
 package org.wildfly.security.ldap;
 
 import org.junit.Test;
-import org.wildfly.security.auth.realm.ldap.DirContextFactory;
+import org.wildfly.common.function.ExceptionSupplier;
 
 import javax.naming.NamingException;
 import javax.naming.directory.DirContext;
@@ -76,11 +76,11 @@ public class TestEnvironmentSuiteChild {
         System.setProperty("com.sun.jndi.ldap.connect.pool.timeout", "300000");
         System.setProperty("com.sun.jndi.ldap.connect.pool.debug", "all");
 
-        DirContextFactory factory = LdapTestSuite.dirContextFactory.create(principal, credential);
+        ExceptionSupplier<DirContext, NamingException> supplier = LdapTestSuite.dirContextFactory.create(principal, credential);
 
-        DirContext context = factory.obtainDirContext(null);
+        DirContext context = supplier.get();
         assertNotNull(context);
-        factory.returnContext(context);
+        context.close();
     }
 
 }


### PR DESCRIPTION
* DirContextFactory replaced by ExceptionSupplier<DirContext, NamingException>
* Required for movement of DirContext definition in subsystem from LDAP realm to standalone block
* Obtaining DirContext, which was done in every CredentialLoader, is now happening just once - in LdapRealm

Changes API - should be merged together with https://github.com/wildfly-security/elytron-subsystem/pull/198