### PR TITLE
SSL client side - allow null keyManager

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
+++ b/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
@@ -271,7 +271,7 @@ public final class SSLContextBuilder {
             sessionContext.setSessionTimeout(sessionTimeout);
             final X509TrustManager x509TrustManager = trustManagerSecurityFactory.create();
             final boolean canAuthPeers = securityDomain != null && securityDomain.getEvidenceVerifySupport(X509PeerCertificateChainEvidence.class).mayBeSupported();
-            sslContext.init(new KeyManager[] {
+            sslContext.init(keyManagerSecurityFactory == null ? null : new KeyManager[] {
                 keyManagerSecurityFactory.create()
             }, new TrustManager[] {
                 canAuthPeers ?

--- a/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -88,17 +88,17 @@ public class SSLAuthenticationTest {
 
     @BeforeClass
     public static void setupClient() throws Exception {
-        SSLContext clientContext = SSLContext.getInstance("TLS");
-        clientContext.init(new KeyManager[] { getKeyManager("/ca/jks/ladybird.keystore") },
-                new TrustManager[] { getCATrustManager() }, null);
-
-        SSLAuthenticationTest.clientContext = clientContext;
+        clientContext = new SSLContextBuilder()
+                .setClientMode(true)
+                .setKeyManager(getKeyManager("/ca/jks/ladybird.keystore"))
+                .setTrustManager(getCATrustManager())
+                .build().create();
     }
 
     /**
      * Get the key manager backed by the specified key store.
      *
-     * @param keystoreName the name of the key store to load.
+     * @param keystorePath the path to the keystore with X509 private key
      * @return the initialised key manager.
      */
     private static X509ExtendedKeyManager getKeyManager(final String keystorePath) throws Exception {
@@ -174,7 +174,7 @@ public class SSLAuthenticationTest {
         assertTrue("Server SSL Session Valid", serverSession.isValid());
         SecurityIdentity identity =  (SecurityIdentity) serverSession.getValue(SSLUtils.SSL_SESSION_IDENTITY_KEY);
         assertNotNull(identity);
-        assertEquals("Principa Name", "ladybird", identity.getPrincipal().getName());
+        assertEquals("Principal Name", "ladybird", identity.getPrincipal().getName());
 
         SSLSocket clientSocket = socketFuture.get();
         SSLSession clientSession = clientSocket.getSession();


### PR DESCRIPTION
* Allowed null keyManager for client SSLContext (when client auth not used)
* SSL test with SSLContextBuilder on both sides already

Related to https://github.com/wildfly-security/elytron-subsystem/pull/204