### PR TITLE
LdapKeyStore improvements

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -157,8 +157,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
                         new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
                 });
 
-                NamingEnumeration<SearchResult> result = context.search(identityMapping.searchDn, identityMapping.iteratorFilter,
-                        identityMapping.iteratorFilterArgs, createSearchControls(identityMapping.rdnIdentifier));
+                NamingEnumeration<SearchResult> result = context.search(identityMapping.searchDn, identityMapping.iteratorFilter, createSearchControls(identityMapping.rdnIdentifier));
                 try {
                     while (result.hasMore()) {
                         SearchResult entry = result.next();
@@ -185,8 +184,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
 
             private void loadCompleteResult(DirContext context) throws NamingException {
                 end = true;
-                NamingEnumeration<SearchResult> result = context.search(identityMapping.searchDn, identityMapping.iteratorFilter,
-                        identityMapping.iteratorFilterArgs, createSearchControls(identityMapping.rdnIdentifier));
+                NamingEnumeration<SearchResult> result = context.search(identityMapping.searchDn, identityMapping.iteratorFilter, createSearchControls(identityMapping.rdnIdentifier));
                 try {
                     while (result.hasMore()) {
                         SearchResult entry = result.next();
@@ -942,9 +940,8 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
         private final LdapName newIdentityParent;
         private final Attributes newIdentityAttributes;
         private final String iteratorFilter;
-        private final Object[] iteratorFilterArgs;
 
-        public IdentityMapping(String searchDn, boolean searchRecursive, int searchTimeLimit, String rdnIdentifier, List<AttributeMapping> attributes, LdapName newIdentityParent, Attributes newIdentityAttributes, String iteratorFilter, Object[] iteratorFilterArgs) {
+        public IdentityMapping(String searchDn, boolean searchRecursive, int searchTimeLimit, String rdnIdentifier, List<AttributeMapping> attributes, LdapName newIdentityParent, Attributes newIdentityAttributes, String iteratorFilter) {
             Assert.checkNotNullParam("rdnIdentifier", rdnIdentifier);
             this.searchDn = searchDn;
             this.searchRecursive = searchRecursive;
@@ -954,7 +951,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
             this.newIdentityParent = newIdentityParent;
             this.newIdentityAttributes = newIdentityAttributes;
             this.iteratorFilter = iteratorFilter;
-            this.iteratorFilterArgs = iteratorFilterArgs;
         }
     }
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealmBuilder.java
@@ -49,6 +49,8 @@ public class LdapSecurityRealmBuilder {
      *  modification after the build is complete.
      */
 
+    private static final int DEFAULT_SEARCH_TIME_LIMIT = 10000;
+
     private boolean built = false;
     private ExceptionSupplier<DirContext, NamingException> dirContextSupplier;
     private NameRewriter nameRewriter = NameRewriter.IDENTITY_REWRITER;
@@ -199,12 +201,11 @@ public class LdapSecurityRealmBuilder {
         private String searchDn = null;
         private boolean searchRecursive = false;
         private String nameAttribute;
-        private int searchTimeLimit = 10000;
+        private int searchTimeLimit = DEFAULT_SEARCH_TIME_LIMIT;
         private List<AttributeMapping> attributes = new ArrayList<>();
         private LdapName newIdentityParent = null;
         private Attributes newIdentityAttributes = null;
         private String iteratorFilter;
-        private Object[] iteratorFilterArgs;
 
         /**
          * <p>Set the name of the context to be used when executing queries.
@@ -240,9 +241,9 @@ public class LdapSecurityRealmBuilder {
         }
 
         /**
-         * Sets the time limit of the SearchControls in milliseconds.
+         * Sets the time limit of LDAP search in milliseconds.
          *
-         * @param limit the limit in milliseconds. Defaults to 5000 milliseconds.
+         * @param limit the limit in milliseconds. Defaults to {@value #DEFAULT_SEARCH_TIME_LIMIT} milliseconds.
          * @return this builder
          */
         public IdentityMappingBuilder setSearchTimeLimit(int limit) {
@@ -253,7 +254,7 @@ public class LdapSecurityRealmBuilder {
         }
 
         /**
-         * Set the name of the attribute in LDAP that holds the user name.
+         * Set the name of the attribute in LDAP that holds the user name and will appear in path of new entries.
          *
          * @param nameAttribute the name attribute
          * @return this builder
@@ -286,13 +287,6 @@ public class LdapSecurityRealmBuilder {
             return this;
         }
 
-        public IdentityMappingBuilder setIteratorFilterArgs(Object[] iteratorFilterArgs) {
-            assertNotBuilt();
-
-            this.iteratorFilterArgs = iteratorFilterArgs;
-            return this;
-        }
-
         /**
          * Define an attribute mapping configuration.
          *
@@ -312,7 +306,7 @@ public class LdapSecurityRealmBuilder {
 
             return LdapSecurityRealmBuilder.this.setIdentityMapping(new IdentityMapping(
                     searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes,
-                    newIdentityParent, newIdentityAttributes, iteratorFilter, iteratorFilterArgs));
+                    newIdentityParent, newIdentityAttributes, iteratorFilter));
         }
 
         private void assertNotBuilt() {

--- a/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
@@ -24,6 +24,7 @@ import org.wildfly.common.function.ExceptionSupplier;
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
 import javax.naming.ldap.LdapName;
 import java.security.KeyStore;
 import java.security.KeyStoreSpi;
@@ -31,6 +32,8 @@ import java.security.Provider;
 
 /**
  * A LDAP backed {@link KeyStore} implementation.
+ *
+ * To create the new instances the {@link LdapKeyStore.Builder} should be used.
  *
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
@@ -46,8 +49,13 @@ public class LdapKeyStore extends KeyStore {
 
     public static class Builder {
 
+        private static final int DEFAULT_SEARCH_TIME_LIMIT = 10000;
+
         private ExceptionSupplier<DirContext, NamingException> dirContextSupplier;
         private String searchPath;
+        private int searchScope = SearchControls.SUBTREE_SCOPE;
+        private int searchTimeLimit = DEFAULT_SEARCH_TIME_LIMIT;
+
         private String filterAlias;
         private String filterCertificate;
         private String filterIterate;
@@ -60,7 +68,6 @@ public class LdapKeyStore extends KeyStore {
         private String certificateAttribute = "usercertificate";
         private String certificateType = "X.509";
         private String certificateChainAttribute = "userSMIMECertificate";
-        private String certificateChainType = "X.509";
         private String certificateChainEncoding = "PKCS7";
         private String keyAttribute = "userPKCS12";
         private String keyType = "PKCS12";
@@ -68,103 +75,244 @@ public class LdapKeyStore extends KeyStore {
         private Builder() {
         }
 
+        /**
+         * Build a LDAP keystore.
+         *
+         * @return the LDAP keystore
+         */
         public LdapKeyStore build() {
-            Assert.assertNotNull(dirContextSupplier);
-            Assert.assertNotNull(searchPath);
-            Assert.assertNotNull(filterAlias);
-            Assert.assertNotNull(filterCertificate);
-            Assert.assertNotNull(filterIterate);
-            Assert.assertNotNull(aliasAttribute);
-            Assert.assertNotNull(certificateAttribute);
-            Assert.assertNotNull(certificateType);
-            Assert.assertNotNull(certificateChainAttribute);
-            Assert.assertNotNull(certificateChainType);
-            Assert.assertNotNull(certificateChainEncoding);
-            Assert.assertNotNull(keyAttribute);
-            Assert.assertNotNull(keyType);
+            Assert.checkNotNullParam("dirContextSupplier", dirContextSupplier);
+            Assert.checkNotNullParam("searchPath", searchPath);
+            Assert.checkNotNullParam("searchScope", searchScope);
+            Assert.checkNotNullParam("searchTimeLimit", searchTimeLimit);
 
-            LdapKeyStoreSpi spi = new LdapKeyStoreSpi(dirContextSupplier, searchPath, filterAlias, filterCertificate,
-                    filterIterate, createPath, createRdn, createAttributes, aliasAttribute, certificateAttribute,
-                    certificateType, certificateChainAttribute, certificateChainType, certificateChainEncoding,
+            Assert.checkNotNullParam("aliasAttribute", aliasAttribute);
+            Assert.checkNotNullParam("certificateAttribute", certificateAttribute);
+            Assert.checkNotNullParam("certificateType", certificateType);
+            Assert.checkNotNullParam("certificateChainAttribute", certificateChainAttribute);
+            Assert.checkNotNullParam("certificateChainEncoding", certificateChainEncoding);
+            Assert.checkNotNullParam("keyAttribute", keyAttribute);
+            Assert.checkNotNullParam("keyType", keyType);
+
+            if (filterAlias == null) filterAlias = "(" + aliasAttribute + "={0})";
+            if (filterCertificate == null) filterCertificate = "(" + certificateAttribute + "={0})";
+            if (filterIterate == null) filterIterate = "(" + aliasAttribute + "=*)";
+
+            LdapKeyStoreSpi spi = new LdapKeyStoreSpi(dirContextSupplier, searchPath, searchScope, searchTimeLimit,
+                    filterAlias, filterCertificate, filterIterate, createPath, createRdn, createAttributes, aliasAttribute,
+                    certificateAttribute, certificateType, certificateChainAttribute, certificateChainEncoding,
                     keyAttribute, keyType);
             return new LdapKeyStore(spi, null, null);
         }
 
+        /**
+         * Set the {@link DirContext} supplier, which will be used to obtain DirContext to perform
+         * operation over {@link KeyStore}.
+         *
+         * @param dirContextSupplier
+         * @return this builder
+         */
         public Builder setDirContextSupplier(ExceptionSupplier<DirContext, NamingException> dirContextSupplier) {
             this.dirContextSupplier = dirContextSupplier;
             return this;
         }
 
+        /**
+         * Set the name of the context (DN, distinguish name) to be used when executing queries.
+         *
+         * @param searchPath the name of the context to search
+         * @return this builder
+         */
         public Builder setSearchPath(String searchPath) {
             this.searchPath = searchPath;
             return this;
         }
 
+        /**
+         * Set if queries are searching the entire subtree (true) or only one level search is used (false).
+         * Default value: SUBTREE_SCOPE
+         *
+         * @return this builder
+         */
+        public Builder setSearchScope(int searchScope) {
+            this.searchScope = searchScope;
+            return this;
+        }
+
+        /**
+         * Set if queries are searching the entire subtree (true) or only one level search is used (false).
+         * Default value: true
+         *
+         * @return this builder
+         */
+        public Builder setSearchRecursive(boolean recursive) {
+            this.searchScope = recursive ? SearchControls.SUBTREE_SCOPE : SearchControls.ONELEVEL_SCOPE;
+            return this;
+        }
+
+        /**
+         * Set the time limit of LDAP search in milliseconds.
+         *
+         * @param searchTimeLimit the limit in milliseconds. Defaults to {@value #DEFAULT_SEARCH_TIME_LIMIT} milliseconds.
+         * @return this builder
+         */
+        public Builder setSearchTimeLimit(int searchTimeLimit) {
+            this.searchTimeLimit = searchTimeLimit;
+            return this;
+        }
+
+        /**
+         * Set the LDAP filter used to search keystore item by alias.
+         * If not specified "(alias-attribute={0})" is used.
+         *
+         * @param filterAlias the LDAP filter, substring "{0}" will by replaced by searched alias
+         * @return this builder
+         */
         public Builder setFilterAlias(String filterAlias) {
             this.filterAlias = filterAlias;
             return this;
         }
 
+        /**
+         * Set the LDAP filter used to search keystore item by certificate.
+         * If not specified "(certificate-attribute={0})" is used.
+         *
+         * @param filterCertificate the LDAP filter, substring "{0}" will by replaced by encoded searched certificate
+         * @return this builder
+         */
         public Builder setFilterCertificate(String filterCertificate) {
             this.filterCertificate = filterCertificate;
             return this;
         }
 
+        /**
+         * Set the LDAP filter used to search all keystore items.
+         * If not specified "(alias-attribute=*)" is used.
+         *
+         * @param filterIterate the LDAP filter
+         * @return this builder
+         */
         public Builder setFilterIterate(String filterIterate) {
             this.filterIterate = filterIterate;
             return this;
         }
 
+        /**
+         * Set the name of the context (DN, distinguish name), where will be LDAP entries of new keystore items created.
+         *
+         * @param createPath the name of the context, where to create
+         * @return this builder
+         */
         public Builder setCreatePath(LdapName createPath) {
             this.createPath = createPath;
             return this;
         }
 
+        /**
+         * Set the name of the attribute in LDAP, that will be used as RDN - last part of path of new entries.
+         * This attribute can be different from aliasAttribute, but its value will be alias too for
+         * newly created entries.
+         *
+         * @param createRdn the name of attribute which will be used as RDN
+         * @return this builder
+         */
         public Builder setCreateRdn(String createRdn) {
             this.createRdn = createRdn;
             return this;
         }
 
+        /**
+         * Set the attributes of newly created LDAP entries and their values.
+         *
+         * @param createAttributes the attributes and their initial values
+         * @return this builder
+         */
         public Builder setCreateAttributes(Attributes createAttributes) {
             this.createAttributes = createAttributes;
             return this;
         }
 
+        /**
+         * Set the name of the attribute in LDAP that holds the alias of keystore item.
+         *
+         * @param aliasAttribute the name of attribute that holds the alias
+         * @return this builder
+         */
         public Builder setAliasAttribute(String aliasAttribute) {
             this.aliasAttribute = aliasAttribute;
             return this;
         }
 
+        /**
+         * Set the name of the attribute in LDAP that holds the encoded certificate.
+         *
+         * @param certificateAttribute the name of attribute that holds the encoded certificate
+         * @return this builder
+         */
         public Builder setCertificateAttribute(String certificateAttribute) {
             this.certificateAttribute = certificateAttribute;
             return this;
         }
 
+        /**
+         * Set the type of certificate, which is stored in certificateAttribute and certificateChainAttribute.
+         * This type is used for decoding certificate and certificate chain from LDAP attribute value.
+         *
+         * @see java.security.cert.CertificateFactory#getInstance(String)
+         *
+         * @param certificateType the name of attribute that holds the encoded certificate
+         * @return this builder
+         */
         public Builder setCertificateType(String certificateType) {
             this.certificateType = certificateType;
             return this;
         }
 
+        /**
+         * Set the name of the attribute in LDAP that holds the encoded certificate chain.
+         *
+         * @param certificateChainAttribute the name of attribute that holds the encoded certificate chain
+         * @return this builder
+         */
         public Builder setCertificateChainAttribute(String certificateChainAttribute) {
             this.certificateChainAttribute = certificateChainAttribute;
             return this;
         }
 
-        public Builder setCertificateChainType(String certificateChainType) {
-            this.certificateChainType = certificateChainType;
-            return this;
-        }
-
+        /**
+         * Set the encoding of certificate chain, which is stored in certificateChainAttribute.
+         * This encoding is used for encoding certificate chain into the LDAP attribute value.
+         *
+         * @see java.security.cert.CertPath#getEncoded(String)
+         *
+         * @param certificateChainEncoding the name of the encoding to use
+         * @return this builder
+         */
         public Builder setCertificateChainEncoding(String certificateChainEncoding) {
             this.certificateChainEncoding = certificateChainEncoding;
             return this;
         }
 
+        /**
+         * Set the name of the attribute in LDAP that holds the private key.
+         * Private key is stored encased in KeyStore, encrypted by password of keystore item.
+         *
+         * @param keyAttribute the name of attribute that holds the private key
+         * @return this builder
+         */
         public Builder setKeyAttribute(String keyAttribute) {
             this.keyAttribute = keyAttribute;
             return this;
         }
 
+        /**
+         * Set type of keystores, into which is encased every private key before storing into keyAttribute.
+         *
+         * @see KeyStore#getInstance(String)
+         *
+         * @param keyType the type of keystore
+         * @return this builder
+         */
         public Builder setKeyType(String keyType) {
             this.keyType = keyType;
             return this;


### PR DESCRIPTION
Improvements of LdapKeyStore made in relation to integration into subsystem.

**LdapKeyStore**
* added support of recursive LDAP search and search time limit
* removed useless iteratorFilterArgs and certificateChainType attributes (type of certificates in chain must be the same as type of main certificate of alias)
* default values of LDAP filters (based on attribute names)
* added javadoc