### PR TITLE
[ELY-643] SSLContext - added useCipherSuitesOrder + needClientAuth fix

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
+++ b/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
@@ -32,6 +32,7 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
     private final CipherSuiteSelector cipherSuiteSelector;
     private final boolean wantClientAuth;
     private final boolean needClientAuth;
+    private final boolean useCipherSuitesOrder;
     private final boolean clientMode;
 
     /**
@@ -42,9 +43,10 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
      * @param wantClientAuth {@code true} to request client authentication
      * @param needClientAuth {@code true} to require client authentication
      */
-    SSLConfiguratorImpl(final ProtocolSelector protocolSelector, final CipherSuiteSelector cipherSuiteSelector, final boolean wantClientAuth, final boolean needClientAuth) {
+    SSLConfiguratorImpl(final ProtocolSelector protocolSelector, final CipherSuiteSelector cipherSuiteSelector, final boolean wantClientAuth, final boolean needClientAuth, final boolean useCipherSuitesOrder) {
         this.protocolSelector = protocolSelector;
         this.cipherSuiteSelector = cipherSuiteSelector;
+        this.useCipherSuitesOrder = useCipherSuitesOrder;
         this.wantClientAuth = wantClientAuth;
         this.needClientAuth = needClientAuth;
         clientMode = false;
@@ -56,9 +58,10 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
      * @param protocolSelector the protocol selector (must not be {@code null})
      * @param cipherSuiteSelector the cipher suite selector (must not be {@code null})
      */
-    SSLConfiguratorImpl(final ProtocolSelector protocolSelector, final CipherSuiteSelector cipherSuiteSelector) {
+    SSLConfiguratorImpl(final ProtocolSelector protocolSelector, final CipherSuiteSelector cipherSuiteSelector, final boolean useCipherSuitesOrder) {
         this.protocolSelector = protocolSelector;
         this.cipherSuiteSelector = cipherSuiteSelector;
+        this.useCipherSuitesOrder = useCipherSuitesOrder;
         this.wantClientAuth = false;
         this.needClientAuth = false;
         clientMode = true;
@@ -67,9 +70,9 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
     void configure(SSLParameters params, String[] supportedProtocols, String[] supportedCipherSuites) {
         params.setProtocols(protocolSelector.evaluate(supportedProtocols));
         params.setCipherSuites(cipherSuiteSelector.evaluate(supportedCipherSuites));
-        params.setUseCipherSuitesOrder(true);
-        params.setNeedClientAuth(needClientAuth);
-        params.setWantClientAuth(wantClientAuth);
+        params.setUseCipherSuitesOrder(useCipherSuitesOrder);
+        params.setWantClientAuth(wantClientAuth); // unsets need
+        if (needClientAuth) params.setNeedClientAuth(needClientAuth); // unsets want
     }
 
     public void configure(final SSLContext context, final SSLServerSocket sslServerSocket) {

--- a/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
+++ b/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
@@ -55,6 +55,7 @@ public final class SSLContextBuilder {
     private SecurityDomain securityDomain;
     private CipherSuiteSelector cipherSuiteSelector = CipherSuiteSelector.openSslDefault();
     private ProtocolSelector protocolSelector = ProtocolSelector.DEFAULT_SELECTOR;
+    private boolean useCipherSuitesOrder = true;
     private boolean wantClientAuth;
     private boolean needClientAuth;
     private boolean authenticationOptional;
@@ -97,6 +98,18 @@ public final class SSLContextBuilder {
     public SSLContextBuilder setProtocolSelector(final ProtocolSelector protocolSelector) {
         Assert.checkNotNullParam("protocolSelector", protocolSelector);
         this.protocolSelector = protocolSelector;
+
+        return this;
+    }
+
+    /**
+     * Sets whether the local cipher suites preference should be honored.
+     *
+     * @param useCipherSuitesOrder whether the local cipher suites preference should be honored.
+     */
+    public SSLContextBuilder setUseCipherSuitesOrder(final boolean useCipherSuitesOrder) {
+        Assert.checkNotNullParam("useCipherSuitesOrder", useCipherSuitesOrder);
+        this.useCipherSuitesOrder = useCipherSuitesOrder;
 
         return this;
     }
@@ -279,7 +292,7 @@ public final class SSLContextBuilder {
                     x509TrustManager
             }, null);
             // now, set up the wrapping configuration
-            final SSLConfigurator sslConfigurator = clientMode ? new SSLConfiguratorImpl(protocolSelector, cipherSuiteSelector) : new SSLConfiguratorImpl(protocolSelector, cipherSuiteSelector, wantClientAuth || canAuthPeers, needClientAuth);
+            final SSLConfigurator sslConfigurator = clientMode ? new SSLConfiguratorImpl(protocolSelector, cipherSuiteSelector, useCipherSuitesOrder) : new SSLConfiguratorImpl(protocolSelector, cipherSuiteSelector, wantClientAuth || canAuthPeers, needClientAuth, useCipherSuitesOrder);
             final ConfiguredSSLContextSpi contextSpi = new ConfiguredSSLContextSpi(sslContext, sslConfigurator);
             return new DelegatingSSLContext(contextSpi);
         });


### PR DESCRIPTION
* added useCipherSuitesOrder to the Builder - https://issues.jboss.org/browse/ELY-643
* fixed setting of needClientAuth+wantClientAuth - Zach's issue - https://issues.jboss.org/browse/ELY-646