### PR TITLE
[ELY-433] LdapRealm - X509 evidence verification

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -494,7 +494,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
                             return support;
                         }
 
-                        if (support != null && support.compareTo(support) < 0) {
+                        if (support != null && support.compareTo(response) > 0) {
                             response = support;
                         }
                     }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
@@ -1,0 +1,264 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.realm.ldap;
+
+import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SupportLevel;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
+import org.wildfly.security.util.ByteIterator;
+
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * An {@link EvidenceVerifier} that verifies a {@link org.wildfly.security.evidence.X509PeerCertificateChainEvidence}.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+class X509EvidenceVerifier implements EvidenceVerifier {
+
+    private final String ENV_BINARY_ATTRIBUTES = "java.naming.ldap.attributes.binary";
+
+    private final List<CertificateVerifier> certificateVerifiers;
+
+    X509EvidenceVerifier(final List<CertificateVerifier> certificateVerifiers) {
+        this.certificateVerifiers = certificateVerifiers;
+    }
+
+    /**
+     * Object allowing to verify X509 certificate against information from LDAP
+     */
+    interface CertificateVerifier {
+        /**
+         * Construct set of LDAP attributes, which should be loaded to be able to {@link #verifyCertificate}.
+         * @param requiredAttributes output set of attribute names
+         */
+        default void addRequiredLdapAttributes(Set<String> requiredAttributes) {}
+
+        /**
+         * Construct set of LDAP attributes, which should be loaded as binary data.
+         * @param binaryAttributes output set of attribute names
+         */
+        default void addBinaryLdapAttributes(Set<String> binaryAttributes) {}
+
+        /**
+         * Verify X509 certificate of user using identity information from LDAP
+         * @param certificate X509 certificate to verify
+         * @param attributes LDAP attributes values of given identity
+         * @return if certificate was accepted by this verifier
+         * @throws NamingException when problem with LDAP
+         */
+        boolean verifyCertificate(X509Certificate certificate, Attributes attributes) throws NamingException, RealmUnavailableException;
+    }
+
+    static class SerialNumberCertificateVerifier implements CertificateVerifier {
+
+        final String ldapAttribute;
+
+        SerialNumberCertificateVerifier(String ldapAttribute) {
+            this.ldapAttribute = ldapAttribute;
+        }
+
+        @Override
+        public void addRequiredLdapAttributes(Set<String> requiredAttributes) {
+            requiredAttributes.add(ldapAttribute);
+        }
+
+        @Override
+        public boolean verifyCertificate(X509Certificate certificate, Attributes attributes) throws NamingException {
+            Attribute attribute = attributes.get(ldapAttribute);
+            final int size = attribute.size();
+            for (int i = 0; i < size; i++) {
+                BigInteger value = new BigInteger((String) attribute.get(i));
+                if (certificate.getSerialNumber().equals(value)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    static class SubjectDnCertificateVerifier implements CertificateVerifier {
+
+        final String ldapAttribute;
+
+        SubjectDnCertificateVerifier(String ldapAttribute) {
+            this.ldapAttribute = ldapAttribute;
+        }
+
+        @Override
+        public void addRequiredLdapAttributes(Set<String> requiredAttributes) {
+            requiredAttributes.add(ldapAttribute);
+        }
+
+        @Override
+        public boolean verifyCertificate(X509Certificate certificate, Attributes attributes) throws NamingException {
+            Attribute attribute = attributes.get(ldapAttribute);
+            final int size = attribute.size();
+            for (int i = 0; i < size; i++) {
+                if (certificate.getSubjectDN().getName().equals(attribute.get(i))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    static class DigestCertificateVerifier implements CertificateVerifier {
+
+        final String ldapAttribute;
+        final String algorithm;
+
+        DigestCertificateVerifier(String ldapAttribute, String algorithm) {
+            this.ldapAttribute = ldapAttribute;
+            this.algorithm = algorithm;
+        }
+
+        @Override
+        public void addRequiredLdapAttributes(Set<String> requiredAttributes) {
+            requiredAttributes.add(ldapAttribute);
+        }
+
+        @Override
+        public boolean verifyCertificate(X509Certificate certificate, Attributes attributes) throws NamingException, RealmUnavailableException {
+            Attribute attribute = attributes.get(ldapAttribute);
+            final int size = attribute.size();
+            try {
+                MessageDigest md = MessageDigest.getInstance(algorithm);
+                for (int i = 0; i < size; i++) {
+                    String digest = ByteIterator.ofBytes(md.digest(certificate.getEncoded())).hexEncode(true).drainToString();
+                    if (digest.equalsIgnoreCase((String) attribute.get(i))) {
+                        return true;
+                    }
+                }
+            } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+                throw new RealmUnavailableException(e);
+            }
+            return false;
+        }
+    }
+
+    static class EncodedCertificateVerifier implements CertificateVerifier {
+
+        final String ldapAttribute;
+
+        EncodedCertificateVerifier(String ldapAttribute) {
+            this.ldapAttribute = ldapAttribute;
+        }
+
+        @Override
+        public void addRequiredLdapAttributes(Set<String> requiredAttributes) {
+            requiredAttributes.add(ldapAttribute);
+        }
+
+        @Override
+        public void addBinaryLdapAttributes(Set<String> binaryAttributes) {
+            binaryAttributes.add(ldapAttribute);
+        }
+
+        @Override
+        public boolean verifyCertificate(X509Certificate certificate, Attributes attributes) throws NamingException, RealmUnavailableException {
+            Attribute attribute = attributes.get(ldapAttribute);
+            final int size = attribute.size();
+            try {
+                for (int i = 0; i < size; i++) {
+                    if (Arrays.equals(certificate.getEncoded(), (byte[]) attribute.get(i))) {
+                        return true;
+                    }
+                }
+            } catch (CertificateEncodingException e) {
+                throw new RealmUnavailableException(e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public SupportLevel getEvidenceVerifySupport(DirContext context, Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
+        return evidenceType == X509PeerCertificateChainEvidence.class ? SupportLevel.POSSIBLY_SUPPORTED : SupportLevel.UNSUPPORTED;
+    }
+
+    @Override
+    public IdentityEvidenceVerifier forIdentity(DirContext context, String distinguishedName) throws RealmUnavailableException {
+        return new IdentityEvidenceVerifier() {
+
+            @Override
+            public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
+                return evidenceType == X509PeerCertificateChainEvidence.class ? SupportLevel.POSSIBLY_SUPPORTED : SupportLevel.UNSUPPORTED;
+            }
+
+            @Override
+            public boolean verifyEvidence(Evidence evidence) throws RealmUnavailableException {
+                if (evidence instanceof X509PeerCertificateChainEvidence) {
+                    X509Certificate certificate = ((X509PeerCertificateChainEvidence) evidence).getFirstCertificate();
+
+                    Set<String> requiredAttributes = new HashSet<>();
+                    Set<String> binaryAttributes = new HashSet<>();
+                    for (CertificateVerifier certificateVerifier : certificateVerifiers) {
+                        certificateVerifier.addRequiredLdapAttributes(requiredAttributes);
+                        certificateVerifier.addBinaryLdapAttributes(binaryAttributes);
+                    }
+                    try {
+                        Object binaryAttributesBackup = null;
+                        if (binaryAttributes.size() != 0) { // set attributes which should be returned in binary form
+                            binaryAttributesBackup = context.getEnvironment().get(ENV_BINARY_ATTRIBUTES);
+                            context.addToEnvironment(ENV_BINARY_ATTRIBUTES, String.join(" ", binaryAttributes));
+                        }
+
+                        String[] requestedAttributes = requiredAttributes.toArray(new String[requiredAttributes.size()]);
+                        Attributes attributes = context.getAttributes(distinguishedName, requestedAttributes);
+
+                        if (binaryAttributes.size() != 0) { // revert environment change
+                            if (binaryAttributesBackup == null) {
+                                context.removeFromEnvironment(ENV_BINARY_ATTRIBUTES);
+                            } else {
+                                context.addToEnvironment(ENV_BINARY_ATTRIBUTES, binaryAttributesBackup);
+                            }
+                        }
+
+                        for (CertificateVerifier certificateVerifier : certificateVerifiers) {
+                            if ( ! certificateVerifier.verifyCertificate(certificate, attributes)) {
+                                ElytronMessages.log.tracef("X509 client certificate rejected by %s of X509EvidenceVerifier", certificateVerifier);
+                                return false;
+                            }
+                        }
+                        ElytronMessages.log.trace("X509 client certificate accepted by X509EvidenceVerifier");
+                        return true;
+                    } catch (NamingException e) {
+                        throw new RealmUnavailableException(e);
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/src/main/java/org/wildfly/security/keystore/LdapKeyStoreSpi.java
+++ b/src/main/java/org/wildfly/security/keystore/LdapKeyStoreSpi.java
@@ -128,13 +128,15 @@ class LdapKeyStoreSpi extends KeyStoreSpi {
     }
 
     private void returnDirContext(DirContext context) {
-        if (binaryAttributesBackup != null) {
-            try {
+        try {
+            if (binaryAttributesBackup == null) {
+                context.removeFromEnvironment(ENV_BINARY_ATTRIBUTES);
+            } else {
                 context.addToEnvironment(ENV_BINARY_ATTRIBUTES, binaryAttributesBackup);
-                context.close();
-            } catch (NamingException e) {
-                throw log.failedToReturnDirContext(e);
             }
+            context.close();
+        } catch (NamingException e) {
+            throw log.failedToReturnDirContext(e);
         }
     }
 

--- a/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
+++ b/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
@@ -108,6 +108,7 @@ public class DirContextFactoryRule implements TestRule {
                     .importLdif(PasswordSupportSuiteChild.class.getResourceAsStream("/ldap/elytron-group-mapping-tests.ldif"))
                     .importLdif(PasswordSupportSuiteChild.class.getResourceAsStream("/ldap/elytron-otp-tests.ldif"))
                     .importLdif(PasswordSupportSuiteChild.class.getResourceAsStream("/ldap/elytron-keystore-tests.ldif"))
+                    .importLdif(PasswordSupportSuiteChild.class.getResourceAsStream("/ldap/elytron-x509-verification.ldif"))
                     .addTcpServer("Default TCP", "localhost", LDAP_PORT, "/ca/jks/localhost.keystore", "Elytron")
                     .start();
         } catch (Exception e) {

--- a/src/test/java/org/wildfly/security/ldap/DirectEvidenceVerificationSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/DirectEvidenceVerificationSuiteChild.java
@@ -33,7 +33,7 @@ import org.wildfly.security.evidence.PasswordGuessEvidence;
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
-public class PasswordValidationSuiteChild {
+public class DirectEvidenceVerificationSuiteChild {
 
     @Test
     public void testPlainUserWithSimpleName() throws Exception {

--- a/src/test/java/org/wildfly/security/ldap/LdapTestSuite.java
+++ b/src/test/java/org/wildfly/security/ldap/LdapTestSuite.java
@@ -31,7 +31,8 @@ import org.junit.runners.Suite;
         GroupMappingSuiteChild.class,
         ModifiabilitySuiteChild.class,
         PasswordSupportSuiteChild.class,
-        PasswordValidationSuiteChild.class,
+        DirectEvidenceVerificationSuiteChild.class,
+        X509EvidenceVerificationSuiteChild.class,
         PrincipalMappingSuiteChild.class,
         RoleMappingSuiteChild.class,
         KeyStoreSuiteChild.class

--- a/src/test/java/org/wildfly/security/ldap/X509EvidenceVerificationSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/X509EvidenceVerificationSuiteChild.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ldap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
+import org.wildfly.security.auth.server.IdentityLocator;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.auth.server.SupportLevel;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
+
+import java.io.InputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+/**
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+public class X509EvidenceVerificationSuiteChild {
+
+    @Test
+    public void testX509Auth() throws Exception {
+
+        SecurityRealm securityRealm = LdapSecurityRealmBuilder.builder()
+                .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
+                .identityMapping()
+                    .setSearchDn("dc=elytron,dc=wildfly,dc=org")
+                    .setRdnIdentifier("uid")
+                    .build()
+                .x509EvidenceVerifier()
+                    .addSerialNumberCertificateVerifier("x509serialNumber")
+                    .addSubjectDnCertificateVerifier("x509subject")
+                    .addDigestCertificateVerifier("x509digest", "SHA-1")
+                    .addEncodedCertificateVerifier("usercertificate")
+                    .build()
+                .build();
+
+        RealmIdentity realmIdentity = securityRealm.getRealmIdentity(IdentityLocator.fromName("scarab"));
+
+        SupportLevel credentialSupport = realmIdentity.getEvidenceVerifySupport(X509PeerCertificateChainEvidence.class, null);
+        assertEquals("Identity verification level support", SupportLevel.POSSIBLY_SUPPORTED, credentialSupport);
+
+        X509Certificate scarab = loadCertificate("/ca/certs/04.pem"); // scarab
+        X509Certificate ca = loadCertificate("/ca/cacert.pem"); // ca
+        Evidence evidence = new X509PeerCertificateChainEvidence(scarab, ca);
+        assertTrue(realmIdentity.verifyEvidence(evidence));
+    }
+
+    private X509Certificate loadCertificate(String name) throws CertificateException {
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        InputStream is = X509EvidenceVerificationSuiteChild.class.getResourceAsStream(name);
+        return (X509Certificate) certificateFactory.generateCertificate(is);
+    }
+
+}

--- a/src/test/resources/ldap/elytron-x509-verification.ldif
+++ b/src/test/resources/ldap/elytron-x509-verification.ldif
@@ -1,0 +1,72 @@
+# testing data + schema for X509 - based on https://tools.ietf.org/html/draft-klasen-ldap-x509certificate-schema-03
+
+dn: m-oid=1.3.6.1.4.1.10126.1.5.3.2, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.10126.1.5.3.2
+m-name: x509serialNumber
+m-description: Unique integer for each certificate issued by a particular CA
+m-equality: integerMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.27
+
+dn: m-oid=1.3.6.1.4.1.10126.1.5.3.7, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.10126.1.5.3.7
+m-name: x509subject
+m-description: Distinguished name of the entity associated with this public-key
+m-equality: distinguishedNameMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.12
+
+# digest attribute is not standard
+dn: m-oid=1.3.6.1.4.1.10126.1.5.3.397, ou=attributetypes, cn=wildfly, ou=schema
+objectclass: metaAttributeType
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.10126.1.5.3.397
+m-name: x509digest
+m-description: Digest (hash) of certificate
+m-equality: distinguishedNameMatch
+m-syntax: 1.3.6.1.4.1.1466.115.121.1.40
+
+dn: m-oid=1.3.6.1.4.1.10126.1.5.4.2.3, ou=objectclasses, cn=wildfly, ou=schema
+objectclass: metaObjectClass
+objectclass: metaTop
+objectclass: top
+m-oid: 1.3.6.1.4.1.10126.1.5.4.2.3
+m-name: x509PKC
+m-typeObjectClass: AUXILIARY
+m-may: x509serialNumber
+m-may: x509subject
+m-may: x509digest
+
+dn: uid=scarab,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: inetOrgPerson
+objectClass: person
+objectClass: organizationalPerson
+objectClass: x509PKC
+cn: scarabCn
+sn: scarabSn
+uid: scarab
+x509serialNumber: 4
+x509subject: OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Scarab
+x509digest: 3EBA55CA81969D198F5010F8AB3CEC1A387A968C
+usercertificate:: MIIDWTCCAkGgAwIBAgIBBDANBgkqhkiG9w0BAQUFADB9MRMwEQYDVQQDDApF
+ bHl0cm9uIENBMRAwDgYDVQQIDAdFbHl0cm9uMQswCQYDVQQGEwJVSzEiMCAGCSqGSIb3DQEJARYTZ
+ Wx5dHJvbkB3aWxkZmx5Lm9yZzEjMCEGA1UECgwaUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkwHh
+ cNMTYwMTI5MTA1ODIyWhcNMjYwMTI2MTA1ODIyWjBUMQ8wDQYDVQQDEwZTY2FyYWIxEDAOBgNVBAg
+ TB0VseXRyb24xCzAJBgNVBAYTAlVLMRAwDgYDVQQKEwdFbHl0cm9uMRAwDgYDVQQLEwdFbHl0cm9u
+ MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp9jIQBAhLHEW3+Zwdf8ehc9wOKB/BqHcJ
+ WicGn2Pp/Q3FUQxygKePMhmaMYNTKevG2jm2JXsK1dIki1d3qq0H+uw83VBfgQlsu8DfprEYINb9z
+ PSCohs6NlSZuQdMqJvyikXgMWgqi7us0VbDXohHMfUdvePGlL0iW6S/2Hcz2FvWidXSY0lho7P0Xc
+ HYQAX9Y/NLgPF36LIg/BWTyEu1cpgeskGD1BSvf3TzjS/fwe4VEIlIYlVRM/dtfCXmJpferqgzv8M
+ NWZIFr9bSHdnEuF4ZxhfUEtvGUMF8Gp0zvpNmhX0iWtYpZCvU/QYZOMQQxiK/ektIqOUSRVRxrtmH
+ wIDAQABow0wCzAJBgNVHRMEAjAAMA0GCSqGSIb3DQEBBQUAA4IBAQDIK1LU8nbR5nzRC1ofR0chLS
+ wDLOwFBneoW99Fsss59YBROF5TOGXT+JaljkKR3tDJEyMSya/avU2HKqBHjRd9T8geK1R4E5t8YkC
+ EHPfZIkG5z2TjzMt62KPsj/vNiA7QUCPsDHMoE0p9vLC0B6Q8h08YT4OOWoQpgZkOzCkT4vzqQtIt
+ 34xYAR3IVazpF5MLKeAzt8BimsDXnxePLNL5H53ZC3kyLFrRwvTfdKZPFH5KilPEfl0hGHhnU0Cf4
+ An/Ygl5hwPIldivnqWie39RkMHLUXzNzveRY8fXUq12oEmEIkAu3AkesJbjbFja5M70Xj1HwilM91
+ B7JwAYVjps


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-433

Allows to add X509EvidenceVerifier to the LdapRealm, which will use one or more CertificateVerifiers. Every verifier check same client certificate property (serial number, subject DN or hash of the certificate) against information in LDAP.
