### PR TITLE
[ELY-656] while initializing KeystorePasswordStore an NPE is thrown instead of proper log message

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeystorePasswordStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeystorePasswordStore.java
@@ -474,7 +474,8 @@ public class KeystorePasswordStore extends CredentialStoreSpi {
                 }
             }
 
-            adminKey = ((KeyStore.SecretKeyEntry) vaultStorage.getEntry(adminKeyAlias, adminKeyProtectionParam)).getSecretKey();
+            KeyStore.Entry adminKeyEntry = vaultStorage.getEntry(adminKeyAlias, adminKeyProtectionParam);
+            adminKey = adminKeyEntry != null ? ((KeyStore.SecretKeyEntry)adminKeyEntry).getSecretKey() : null;
             if (adminKey == null) {
                 throw log.storeAdminKeyNotPresent(storeName, adminKeyAlias);
             }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-656