### PR TITLE
[ELY-663] DirContext - referral mode, LdapRealm - custom filter

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealmBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealmBuilder.java
@@ -205,6 +205,7 @@ public class LdapSecurityRealmBuilder {
         private List<AttributeMapping> attributes = new ArrayList<>();
         private LdapName newIdentityParent = null;
         private Attributes newIdentityAttributes = null;
+        private String filterName;
         private String iteratorFilter;
 
         /**
@@ -280,6 +281,13 @@ public class LdapSecurityRealmBuilder {
             return this;
         }
 
+        public IdentityMappingBuilder setFilterName(String filterName) {
+            assertNotBuilt();
+
+            this.filterName = filterName;
+            return this;
+        }
+
         public IdentityMappingBuilder setIteratorFilter(String iteratorFilter) {
             assertNotBuilt();
 
@@ -304,9 +312,11 @@ public class LdapSecurityRealmBuilder {
             assertNotBuilt();
             built = true;
 
+            if (filterName == null) filterName = String.format("(%s={0})", nameAttribute);
+
             return LdapSecurityRealmBuilder.this.setIdentityMapping(new IdentityMapping(
                     searchDn, searchRecursive, searchTimeLimit, nameAttribute, attributes,
-                    newIdentityParent, newIdentityAttributes, iteratorFilter));
+                    newIdentityParent, newIdentityAttributes, filterName, iteratorFilter));
         }
 
         private void assertNotBuilt() {

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/SimpleDirContextFactoryBuilder.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/SimpleDirContextFactoryBuilder.java
@@ -219,7 +219,7 @@ public class SimpleDirContextFactoryBuilder {
 
         @Override
         public DirContext obtainDirContext(ReferralMode mode) throws NamingException {
-            return createDirContext(securityPrincipal, securityCredential.toCharArray(), null);
+            return createDirContext(securityPrincipal, securityCredential.toCharArray(), mode);
         }
 
         @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-663
* fixed setting of referral mode in DirContext
* LdapRealm - added posibility to set custom search filter to obtain identity by name (need for referral using)
* handling errors of name to LdapName conversion
 * the `if (this.name.startsWith(identityMapping.rdnIdentifier))` -condition should be revised yet! (but not related to this issue)- https://github.com/wildfly-security/wildfly-elytron/pull/514
* added more traces