### PR TITLE
[ELY-668] LdapRealm acquire support without DirContext

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
@@ -45,12 +45,11 @@ interface CredentialLoader {
      * Note: The DirContextFactory approach will be evolved further for better referral support so it makes it easier for it to
      * be passed in for each call.
      *
-     * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param credentialType the credential type (must not be {@code null})
      * @param algorithmName the credential algorithm name
      * @return the level of support for this credential type
      */
-    SupportLevel getCredentialAcquireSupport(DirContext dirContext, Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException;
+    SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException;
 
     /**
      * Obtain an {@link IdentityCredentialLoader} to query the credentials for a specific identity.

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -270,9 +270,8 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
         Assert.checkNotNullParam("credentialType", credentialType);
         SupportLevel response = SupportLevel.UNSUPPORTED;
 
-        DirContext dirContext = obtainContext();
         for (CredentialLoader loader : credentialLoaders) {
-            SupportLevel support = loader.getCredentialAcquireSupport(dirContext, credentialType, algorithmName);
+            SupportLevel support = loader.getCredentialAcquireSupport(credentialType, algorithmName);
             if (support.isDefinitelySupported()) {
                 // One claiming it is definitely supported is enough!
                 return support;
@@ -281,7 +280,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
                 response = support;
             }
         }
-        closeContext(dirContext);
 
         return response;
     }
@@ -356,7 +354,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
 
             DirContext dirContext = obtainContext();
             for (CredentialLoader loader : credentialLoaders) {
-                if (loader.getCredentialAcquireSupport(dirContext, credentialType, algorithmName).mayBeSupported()) {
+                if (loader.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported()) {
                     IdentityCredentialLoader icl = loader.forIdentity(dirContext, identity.getDistinguishedName());
 
                     SupportLevel temp = icl.getCredentialAcquireSupport(credentialType, algorithmName);
@@ -394,7 +392,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
 
             DirContext dirContext = obtainContext();
             for (CredentialLoader loader : credentialLoaders) {
-                if (loader.getCredentialAcquireSupport(dirContext, credentialType, algorithmName).mayBeSupported()) {
+                if (loader.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported()) {
                     IdentityCredentialLoader icl = loader.forIdentity(dirContext, this.identity.getDistinguishedName());
 
                     Credential credential = icl.getCredential(credentialType, algorithmName);

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/OtpCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/OtpCredentialLoader.java
@@ -50,7 +50,7 @@ class OtpCredentialLoader implements CredentialPersister {
     }
 
     @Override
-    public SupportLevel getCredentialAcquireSupport(final DirContext context, final Class<? extends Credential> credentialType, final String algorithmName) {
+    public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String algorithmName) {
         if (credentialType == PasswordCredential.class) {
             if (algorithmName == null) {
                 return SupportLevel.SUPPORTED;
@@ -139,7 +139,7 @@ class OtpCredentialLoader implements CredentialPersister {
 
         @Override
         public boolean getCredentialPersistSupport(final Class<? extends Credential> credentialType, final String algorithmName) {
-            return OtpCredentialLoader.this.getCredentialAcquireSupport(context, credentialType, algorithmName).mayBeSupported();
+            return OtpCredentialLoader.this.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported();
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/UserPasswordCredentialLoader.java
@@ -62,7 +62,7 @@ class UserPasswordCredentialLoader implements CredentialPersister {
     }
 
     @Override
-    public SupportLevel getCredentialAcquireSupport(DirContext context, final Class<? extends Credential> credentialType, final String credentialAlgorithm) throws RealmUnavailableException {
+    public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String credentialAlgorithm) throws RealmUnavailableException {
         if (credentialType == PasswordCredential.class) {
             if (credentialAlgorithm == null) return SupportLevel.SUPPORTED;
             if (UserPasswordPasswordUtil.isAlgorithmSupported(credentialAlgorithm)) return SupportLevel.POSSIBLY_SUPPORTED;
@@ -82,7 +82,7 @@ class UserPasswordCredentialLoader implements CredentialPersister {
             public SupportLevel getEvidenceVerifySupport(DirContext context, final Class<? extends Evidence> evidenceType, final String evidenceAlgorithm) throws RealmUnavailableException {
                 // If we can acquire PasswordCredential and it support provided evidence, we can verify.
                 if ( ! PasswordCredential.canVerifyEvidence(evidenceType, evidenceAlgorithm)) return SupportLevel.UNSUPPORTED;
-                return getCredentialAcquireSupport(context, PasswordCredential.class, evidenceAlgorithm);
+                return getCredentialAcquireSupport(PasswordCredential.class, evidenceAlgorithm);
             }
 
             @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-668

Realm.getCredentialAcquireSupport() was using DirContext, which was causing WildFly/Undertow was unable to start without LDAP server online.