### PR TITLE
[ELY-673] Empty result of password search in Elytron ldap-realm causes NPE

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/UserPasswordCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/UserPasswordCredentialLoader.java
@@ -127,14 +127,16 @@ class UserPasswordCredentialLoader implements CredentialPersister {
             try {
                 Attributes attributes = context.getAttributes(distinguishedName, new String[] { userPasswordAttributeName });
                 Attribute attribute = attributes.get(userPasswordAttributeName);
-                final int size = attribute.size();
-                for (int i = 0; i < size; i++) {
-                    byte[] value = (byte[]) attribute.get(i);
+                if (attribute != null) {
+                    final int size = attribute.size();
+                    for (int i = 0; i < size; i++) {
+                        byte[] value = (byte[]) attribute.get(i);
 
-                    Password password = parseUserPassword(value);
+                        Password password = parseUserPassword(value);
 
-                    if (credentialType.isAssignableFrom(PasswordCredential.class) && (credentialAlgorithm == null || credentialAlgorithm.equals(password.getAlgorithm()))) {
-                        return credentialType.cast(new PasswordCredential(password));
+                        if (credentialType.isAssignableFrom(PasswordCredential.class) && (credentialAlgorithm == null || credentialAlgorithm.equals(password.getAlgorithm()))) {
+                            return credentialType.cast(new PasswordCredential(password));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-673
