### PR TITLE
[ELY-653] KeystorePasswordStore contains inconsistency about MODIFIAB…

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1577,6 +1577,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 9512, value = "Wrong Base64 encoded string used. Falling back to '%s'")
     void warnWrongBase64EncodedString(String base64);
 
+    @Message(id = 9513, value = "Cannot perform operation '%s': Credential store is set non modifiable")
+    CredentialStoreException nonModifiableCredentialStore(String operation);
+
     /* X.500 exceptions */
 
     @Message(id = 10000, value = "X.509 certificate extension with OID %s already exists")

--- a/src/main/java/org/wildfly/security/credential/store/CredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/CredentialStore.java
@@ -17,6 +17,8 @@
  */
 package org.wildfly.security.credential.store;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
@@ -152,7 +154,11 @@ public class CredentialStore {
      * @throws UnsupportedCredentialTypeException when the credentialType is not supported
      */
     public <C extends Credential> void store(String credentialAlias, C credential) throws CredentialStoreException, UnsupportedCredentialTypeException {
-        spi.store(credentialAlias, credential);
+        if (isModifiable()) {
+            spi.store(credentialAlias, credential);
+        } else {
+            throw log.nonModifiableCredentialStore("store");
+        }
     }
 
     /**
@@ -177,7 +183,11 @@ public class CredentialStore {
      * @throws UnsupportedCredentialTypeException when the credentialType is not supported
      */
     public <C extends Credential> void remove(String credentialAlias, Class<C> credentialType) throws CredentialStoreException, UnsupportedCredentialTypeException {
-        spi.remove(credentialAlias, credentialType);
+        if (isModifiable()) {
+            spi.remove(credentialAlias, credentialType);
+        } else {
+            throw log.nonModifiableCredentialStore("remove");
+        }
     }
 
     /**

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeystorePasswordStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeystorePasswordStore.java
@@ -222,14 +222,14 @@ public class KeystorePasswordStore extends CredentialStoreSpi {
         Collections.addAll(ca,
                 NAME, STORE_FILE, STORE_PASSWORD, STORE_BASE,
                 CREATE_STORAGE, KEY_ALIAS, KEY_PASSWORD,
-                KEY_SIZE, CRYPTO_ALGORITHM, RELOADABLE);
+                KEY_SIZE, CRYPTO_ALGORITHM, RELOADABLE, MODIFIABLE);
         supportedConfigurationAttributes = Collections.unmodifiableSet(ca);
     }
 
     // used for reporting only / do not modify
     private String storeName;
     private boolean reloadable = false;
-    private boolean modifiable = false;
+    private boolean modifiable = true;
     private File storeFile = null;
     private String storeBase = "";
     private char[] storagePassword = null;

--- a/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
+++ b/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
@@ -157,6 +157,7 @@ public class KeystorePasswordStoreTest {
         csAttributes.put(KeystorePasswordStore.CREATE_STORAGE, "true");
         csAttributes.put(KeystorePasswordStore.STORE_PASSWORD, "st_secret");
         csAttributes.put(KeystorePasswordStore.KEY_PASSWORD, "key_secret");
+        csAttributes.put(KeystorePasswordStore.MODIFIABLE, "true");
 
         String passwordAlias1 = "db1-password1";
         String passwordAlias2 = "db1-password2";
@@ -188,6 +189,7 @@ public class KeystorePasswordStoreTest {
         csAttributes.put(KeystorePasswordStore.STORE_FILE, stores.get("TWO"));
         csAttributes.put(KeystorePasswordStore.STORE_PASSWORD, "secret_store_TWO");
         csAttributes.put(KeystorePasswordStore.KEY_PASSWORD, "secret_key_TWO");
+        // testing if KeystorePasswordStore.MODIFIABLE default value is "true", so not setting anything
 
         String passwordAlias1 = "alias1";
         String passwordAlias2 = "alias2";


### PR DESCRIPTION
…LE configuration attribute
https://issues.jboss.org/browse/ELY-653

- check of isModifiable() is done in CredentialStore class, rather than on all implementations
- the isModifiable() method is abstract at SPI, it allows proper control then
- the default in KeystorePasswordStore (impl class) was set to 'true' as this is closer to what user might expect from this CredentialStore