### PR TITLE
[ELY-738] Coverity static analysis: Dereference null return value in SingleSignOnServerMechanismFactory (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -69,6 +69,7 @@ import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.authz.AuthorizationCheckException;
 import org.wildfly.security.authz.AuthorizationFailureException;
 import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.mechanism.AuthenticationMechanismException;
 import org.wildfly.security.mechanism.scram.ScramServerErrorCode;
 import org.wildfly.security.mechanism.scram.ScramServerException;
@@ -1359,6 +1360,9 @@ public interface ElytronMessages extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 6013, value = "Failed to invalidate local session")
     void errorHttpMechSsoFailedInvalidateLocalSession(@Cause  Throwable cause);
+
+    @Message(id = 6014, value = "Authentication mechanism '%s' cannot be found")
+    HttpAuthenticationException httpServerAuthenticationMechanismNotFound(String mechanismName);
 
     /* asn1 package */
 

--- a/src/main/java/org/wildfly/security/http/HttpServerAuthenticationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerAuthenticationMechanismFactory.java
@@ -44,7 +44,7 @@ public interface HttpServerAuthenticationMechanismFactory {
      * @param mechanismName
      * @param properties
      * @param callbackHandler
-     * @return the configured {@link HttpServerAuthenticationMechanism}
+     * @return the configured {@link HttpServerAuthenticationMechanism} or null if no mechanism could be resolved for the given mechanism name.
      * @throws HttpAuthenticationException if there is an error creating the mechanism
      */
     HttpServerAuthenticationMechanism createAuthenticationMechanism(String mechanismName, Map<String, ?> properties, CallbackHandler callbackHandler) throws HttpAuthenticationException;

--- a/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -36,6 +36,8 @@ import javax.security.auth.callback.CallbackHandler;
 import java.security.Principal;
 import java.util.Map;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 /**
  * <p>A {@link HttpServerAuthenticationMechanismFactory} which enables single sign-on to the mechanisms provided by a another
  * http mechanism factory.
@@ -84,8 +86,11 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                 if (singleSignOnSession.logout()) {
                     return;
                 }
-
-                getTargetMechanism(mechanismName, singleSignOnSession).evaluateRequest(createHttpServerRequest(request, singleSignOnSession));
+                HttpServerAuthenticationMechanism mechanism = getTargetMechanism(mechanismName, singleSignOnSession);
+                if (mechanism == null) {
+                    throw log.httpServerAuthenticationMechanismNotFound(mechanismName);
+                }
+                mechanism.evaluateRequest(createHttpServerRequest(request, singleSignOnSession));
             }
 
             private SingleSignOnSession getSingleSignOnSession(HttpServerRequest request) {


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-738
