### PR TITLE
[ELY-743] Coverity static analysis: Dereference null return value in ServerAuthenticationContext (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -347,7 +347,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm {
         public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String algorithmName) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentialType", credentialType);
             if (!exists()) {
-                return null;
+                return SupportLevel.UNSUPPORTED;
             }
 
             if (LdapSecurityRealm.this.getCredentialAcquireSupport(credentialType, algorithmName) == SupportLevel.UNSUPPORTED) {

--- a/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
@@ -63,7 +63,7 @@ public interface RealmIdentity {
      * @param credentialType the exact credential type (must not be {@code null})
      * @param algorithmName the algorithm name, or {@code null} if any algorithm is acceptable or the credential type does
      *  not support algorithm names
-     * @return the level of support for this credential type
+     * @return the level of support for this credential type (may not be {@code null})
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
     SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName) throws RealmUnavailableException;

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1835,7 +1835,7 @@ public final class ServerAuthenticationContext {
         @Override
         boolean isSamePrincipal(final Principal principal) {
             String name = capturedIdentity.getSecurityDomain().getPrincipalDecoder().getName(principal);
-            return isSameName(name);
+            return name != null ? isSameName(name) : false;
         }
 
         @Override
@@ -2036,7 +2036,7 @@ public final class ServerAuthenticationContext {
         @Override
         boolean isSamePrincipal(final Principal principal) {
             String name = authorizedIdentity.getSecurityDomain().getPrincipalDecoder().getName(principal);
-            return isSameName(name);
+            return name != null ? isSameName(name) : false;
         }
 
         RealmInfo getRealmInfo() {


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-743
