### PR TITLE
[ELY-791] properties realm error handling

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -145,7 +145,7 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1005, value = "Realm map does not contain mapping for default realm '%s'")
     IllegalArgumentException realmMapDoesNotContainDefault(String defaultRealm);
 
-    @Message(id = 1006, value = "No realm name found in password property file")
+    @Message(id = 1006, value = "No realm name found in users property file - file must contain \"#$REALM_NAME=RealmName$\" line")
     RealmUnavailableException noRealmFoundInProperties();
 
     @LogMessage(level = Logger.Level.DEBUG)
@@ -187,8 +187,6 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1019, value = "Unable to obtain exclusive access to backing identity")
     RealmUnavailableException unableToObtainExclusiveAccess();
-
-    // 1019
 
     @Message(id = 1020, value = "Filesystem-backed realm failed to update identity \"%s\"")
     RealmUnavailableException fileSystemUpdatedFailed(String name, @Cause Throwable cause);
@@ -543,6 +541,10 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1131, value = "Public and private key parameters are mismatched")
     IllegalArgumentException mismatchedPublicPrivateKeyParameters();
+
+    @Message(id = 1132, value = "Decoding hashed password from users property file failed - should not be set as plain-text property file?")
+    RealmUnavailableException decodingHashedPasswordFromPropertiesRealmFailed(@Cause Exception e);
+
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/password/spec/DigestPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/DigestPasswordSpec.java
@@ -18,7 +18,7 @@
 package org.wildfly.security.password.spec;
 
 /**
- * A {@link PasswordSpec} for a password represented by a Digest Response as seen in DigestMD5 SASL mechanism.
+ * A {@link PasswordSpec} for a password represented by a Digest Response as seen in Digest-MD5 SASL/HTTP mechanism.
  *
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
@@ -29,20 +29,34 @@ public final class DigestPasswordSpec implements PasswordSpec {
     private final String realm;
     private final byte[] digest;
 
+    /**
+     * @param username the username
+     * @param realm the realm (name of a collection of accounts)
+     * @param digest the digest: H( username ":" realm ":" password )
+     */
     public DigestPasswordSpec(String username, String realm, byte[] digest) {
         this.username = username;
         this.realm = realm;
         this.digest = digest;
     }
 
+    /**
+     * @return the username
+     */
     public String getUsername() {
         return username;
     }
 
+    /**
+     * @return the realm (name of a collection of accounts)
+     */
     public String getRealm() {
         return realm;
     }
 
+    /**
+     * @return the digest: H( username ":" realm ":" password )
+     */
     public byte[] getDigest() {
         return digest;
     }

--- a/src/main/java/org/wildfly/security/util/DecodeException.java
+++ b/src/main/java/org/wildfly/security/util/DecodeException.java
@@ -19,7 +19,7 @@
 package org.wildfly.security.util;
 
 /**
- * An exception which indicates that base 64 decoding has failed due to invalid or truncated input.
+ * An exception which indicates that Base64/hex decoding has failed due to invalid or truncated input.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */

--- a/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
@@ -67,7 +67,7 @@ public class LegacyPropertiesSecurityRealmTest {
         Security.addProvider(provider);
 
         specialCharsRealm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(LegacyPropertiesSecurityRealmTest.class.getResourceAsStream("specialchars.properties"))
+                .setUsersStream(LegacyPropertiesSecurityRealmTest.class.getResourceAsStream("specialchars.properties"))
                 .setPlainText(true)
                 .build();
     }
@@ -85,7 +85,7 @@ public class LegacyPropertiesSecurityRealmTest {
     @Test
     public void testDefaultFile() throws IOException {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(this.getClass().getResourceAsStream("empty.properties"))
+                .setUsersStream(this.getClass().getResourceAsStream("empty.properties"))
                 .build();
 
         assertNotNull("SecurityRealm", realm);
@@ -97,7 +97,7 @@ public class LegacyPropertiesSecurityRealmTest {
     @Test
     public void testPlainFile() throws Exception {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(this.getClass().getResourceAsStream("clear.properties"))
+                .setUsersStream(this.getClass().getResourceAsStream("clear.properties"))
                 .setPlainText(true)
                 .build();
 
@@ -148,7 +148,7 @@ public class LegacyPropertiesSecurityRealmTest {
     @Test
     public void testHashedFile() throws Exception {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(this.getClass().getResourceAsStream("users.properties"))
+                .setUsersStream(this.getClass().getResourceAsStream("users.properties"))
                 .build();
 
         PasswordGuessEvidence goodGuess = new PasswordGuessEvidence(ELYTRON_PASSWORD_CLEAR.toCharArray());
@@ -194,7 +194,7 @@ public class LegacyPropertiesSecurityRealmTest {
     @Test
     public void testPlainFileSpecialChars() throws Exception {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(this.getClass().getResourceAsStream("clear-special.properties"))
+                .setUsersStream(this.getClass().getResourceAsStream("clear-special.properties"))
                 .setPlainText(true)
                 .build();
 
@@ -376,7 +376,7 @@ public class LegacyPropertiesSecurityRealmTest {
     @Test
     public void testHashedFile_colonAsDelimiter() throws Exception {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
-                .setPasswordsStream(this.getClass().getResourceAsStream("colondelimiter.properties"))
+                .setUsersStream(this.getClass().getResourceAsStream("colondelimiter.properties"))
                 .build();
 
         checkVerifyIdentity(realm, "elytron", ELYTRON_PASSWORD_CLEAR);

--- a/src/test/java/org/wildfly/security/authz/jacc/AbstractAuthorizationTestCase.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/AbstractAuthorizationTestCase.java
@@ -61,7 +61,7 @@ public abstract class AbstractAuthorizationTestCase {
 
         try {
             realm = LegacyPropertiesSecurityRealm.builder()
-                    .setPasswordsStream(getClass().getResourceAsStream("clear.properties"))
+                    .setUsersStream(getClass().getResourceAsStream("clear.properties"))
                     .setPlainText(true)
                     .build();
         } catch (IOException e) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-791
subsystem part: https://github.com/wildfly-security/elytron-subsystem/pull/311

* [ELY-791] handling of password decode exception
* unified "users/passwords" properties file to "users" (API change - require subsystem part)