### PR TITLE
[ELY-804] LdapRealm referrals: direct verification + THROW mode + iterating refac

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -385,7 +385,7 @@ public interface ElytronMessages extends BasicLogger {
     RuntimeException ldapRealmFailedObtainAttributes(String dn, @Cause Throwable cause);
 
     @Message(id = 1080, value = "Attribute [%s] value [%s] must be in X.500 format in order to obtain RDN [%s].")
-    RuntimeException ldapRealmInvalidRdnForAttribute(String attributeName, String value, String rdn);
+    RuntimeException ldapRealmInvalidRdnForAttribute(String attributeName, String value, String rdn, @Cause Throwable cause);
 
     @Message(id = 1081, value = "Filesystem-backed realm encountered invalid OTP definition in path \"%s\" line %d for identity name \"%s\"")
     RealmUnavailableException fileSystemRealmInvalidOtpDefinition(Path path, int lineNumber, String name, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
@@ -21,8 +21,6 @@ import java.util.Locale;
 
 import org.wildfly.common.Assert;
 
-import java.util.Locale;
-
 /**
  * Definition of a mapping from LDAP to an Elytron attribute.
  *

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 
 import org.wildfly.common.Assert;
 
+import java.util.Locale;
+
 /**
  * Definition of a mapping from LDAP to an Elytron attribute.
  *
@@ -30,19 +32,70 @@ public class AttributeMapping {
 
     private final String ldapName;
     private final String searchDn;
+    private final boolean recursiveSearch;
     private final String filter;
-    private String name;
-    private String rdn;
+    private final String name;
+    private final String rdn;
+    private final int recursiveDepth;
+
+    String getLdapName() {
+        return ldapName;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    String getSearchDn() {
+        return searchDn;
+    }
+
+    boolean getRecursiveSearch() {
+        return recursiveSearch;
+    }
+
+    String getFilter() {
+        return filter;
+    }
+
+    String getRdn() {
+        return rdn;
+    }
+
+    int getRecursiveDepth() {
+        return recursiveDepth;
+    }
+
+    boolean isFiltered() {
+        return filter != null;
+    }
 
     /**
-     * Create an attribute mapping based on the given attribute in LDAP.
+     * <p>Create an attribute mapping based on the given attribute in LDAP.
+     * Attribute of the identity LDAP entry will be used as identity attribute value.
      *
      * @param ldapName the name of the attribute in LDAP from where values are obtained
      * @return this builder
      */
-    public static AttributeMapping from(String ldapName) {
+    public static Builder fromAttribute(String ldapName) {
         Assert.checkNotNullParam("ldapName", ldapName);
-        return new AttributeMapping(ldapName);
+        Builder builder = new Builder();
+        builder.ldapName = ldapName.toUpperCase(Locale.ROOT);
+        builder.name = builder.ldapName;
+        return builder;
+    }
+
+    /**
+     * <p>Create an attribute mapping based on DN in LDAP.
+     * The DN of LDAP entry of the identity will be used as identity attribute value.
+     *
+     * @return this builder
+     */
+    public static Builder fromDn() {
+        Builder builder = new Builder();
+        builder.ldapName = null;
+        builder.name = "dn";
+        return builder;
     }
 
     /**
@@ -53,76 +106,116 @@ public class AttributeMapping {
      * separated entry. For instance, retrieving roles from entries with a object class of <em>groupOfNames</em> where the identity's DN is
      * a value of a <em>member</em> attribute.
      *
-     * @param searchDn the name of the context to be used when executing the filter
      * @param filter the filter that is going to be used to search for entries and obtain values for this attribute
      * @param ldapName the name of the attribute in LDAP from where the values are obtained
      * @return this builder
      */
-    public static AttributeMapping fromFilter(String searchDn, String filter, String ldapName) {
-        Assert.checkNotNullParam("searchDn", searchDn);
+    public static Builder fromFilter(String filter, String ldapName) {
         Assert.checkNotNullParam("filter", filter);
         Assert.checkNotNullParam("ldapName", ldapName);
-        return new AttributeMapping(searchDn, filter, ldapName);
+        Builder builder = new Builder();
+        builder.filter = filter;
+        builder.ldapName = ldapName.toUpperCase(Locale.ROOT);
+        builder.name = builder.ldapName;
+        return builder;
     }
 
     /**
-     * <p>The behavior is exactly the same as {@link #fromFilter(String, String, String)}, except that it uses the
-     * same name of the context defined in {@link org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder.IdentityMappingBuilder#setSearchDn(String)}.
+     * <p>The behavior is exactly the same as {@link #fromFilter(String, String)}, except that instead
+     * of attribute value is DN of found entries used. As the search DN is used search DN from identity mapping.
      *
      * @param filter the filter that is going to be used to search for entries and obtain values for this attribute
-     * @param ldapName the name of the attribute in LDAP from where the values are obtained
      * @return this builder
      */
-    public static AttributeMapping fromFilter(String filter, String ldapName) {
+    public static Builder fromFilterDn(String filter) {
         Assert.checkNotNullParam("filter", filter);
-        Assert.checkNotNullParam("ldapName", ldapName);
-        return new AttributeMapping(null, filter, ldapName);
+        Builder builder = new Builder();
+        builder.filter = filter;
+        builder.name = "dn";
+        return builder;
     }
 
-    AttributeMapping(String ldapName) {
-        this(null, null, ldapName);
-    }
+    public static class Builder {
 
-    AttributeMapping(String searchDn, String filter, String ldapName) {
-        Assert.checkNotNullParam("ldapName", ldapName);
-        this.searchDn = searchDn;
-        this.filter = filter;
-        this.ldapName = ldapName.toUpperCase(Locale.ROOT);
-    }
+        private String ldapName;
+        private String searchDn;
+        private boolean recursiveSearch = true;
+        private String filter;
+        private String name;
+        private String rdn;
+        private int recursiveDepth;
 
-    public AttributeMapping asRdn(String rdn) {
-        Assert.checkNotNullParam("rdn", rdn);
-        this.rdn = rdn;
-        return this;
-    }
-
-    public AttributeMapping to(String name) {
-        Assert.checkNotNullParam("to", name);
-        this.name = name;
-        return this;
-    }
-
-    String getLdapName() {
-        return this.ldapName;
-    }
-
-    String getName() {
-        if (this.name == null) {
-            return this.ldapName;
+        /**
+         * Set type of RDN, whose value will be used as identity attribute value.
+         * Use in case the attribute value is in DN form or when DN of entry is used.
+         *
+         * @param rdn the name of type of RDN
+         * @return this builder
+         */
+        public Builder extractRdn(String rdn) {
+            Assert.checkNotNullParam("rdn", rdn);
+            this.rdn = rdn;
+            return this;
         }
 
-        return this.name;
+        /**
+         * Set name of identity attribute to which will be mapping done.
+         *
+         * @param name the name of identity attribute (not LDAP attribute)
+         * @return this builder
+         */
+        public Builder to(String name) {
+            Assert.checkNotNullParam("name", name);
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Set search DN of LDAP search for attribute entries.
+         * If not specified, search DN from identity mapping will be used.
+         * @param searchDn the name of the context (DN) to be used when executing the filter
+         * @return this builder
+         */
+        public Builder searchDn(String searchDn) {
+            this.searchDn = searchDn;
+            return this;
+        }
+
+        /**
+         * Set whether LDAP search for attribute entries should be recursive
+         * @param recursiveSearch whether the LDAP search should be recursive
+         * @return this builder
+         */
+        public Builder searchRecursively(boolean recursiveSearch) {
+            this.recursiveSearch = recursiveSearch;
+            return this;
+        }
+
+        /**
+         * Set recursive search of filtered attribute (for recursive roles assignment and similar)
+         * @param recursiveDepth maximum depth of recursion, 0 by default (direct only)
+         * @return this builder
+         */
+        public Builder roleRecursion(int recursiveDepth) {
+            Assert.checkMinimumParameter("recursiveDepth", 0, recursiveDepth);
+            Assert.checkNotNullParam("filter", filter);
+            this.recursiveDepth = recursiveDepth;
+            return this;
+        }
+
+        public AttributeMapping build() {
+            return new AttributeMapping(searchDn, recursiveSearch, filter, ldapName, name, rdn, recursiveDepth);
+        }
     }
 
-    String getSearchDn() {
-        return this.searchDn;
+    AttributeMapping(String searchDn, boolean recursiveSearch, String filter, String ldapName, String name, String rdn, int recursiveDepth) {
+        this.searchDn = searchDn;
+        this.recursiveSearch = recursiveSearch;
+        this.filter = filter;
+        this.ldapName = ldapName;
+        this.name = name;
+        this.rdn = rdn;
+        this.recursiveDepth = recursiveDepth;
     }
 
-    String getFilter() {
-        return this.filter;
-    }
-
-    String getRdn() {
-        return this.rdn;
-    }
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
@@ -27,6 +27,7 @@ import javax.naming.NameClassPair;
 import javax.naming.NameParser;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.ReferralException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.ModificationItem;
@@ -135,6 +136,15 @@ class DelegatingLdapContext implements LdapContext {
                 delegating.close();
             }
         };
+    }
+
+    public DelegatingLdapContext wrapReferralContextObtaining(ReferralException e) throws NamingException {
+        if (socketFactory != null) ThreadLocalSSLSocketFactory.set(socketFactory);
+        try {
+            return new DelegatingLdapContext((DirContext) e.getReferralContext(), socketFactory);
+        } finally {
+            if (socketFactory != null) ThreadLocalSSLSocketFactory.unset();
+        }
     }
 
     // LdapContext specific

--- a/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
@@ -31,16 +31,22 @@ import org.wildfly.security.auth.server.ServerAuthenticationContext;
 import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.permission.PermissionVerifier;
 
+import java.util.Arrays;
+
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public abstract class AbstractAttributeMappingSuiteChild {
 
-    protected void assertAttributeValue(Attributes.Entry lastName, String... expectedValues) {
-        assertNotNull("Attribute [" + lastName.getKey() + "] not found.", lastName);
+    protected void assertAttributeValue(Attributes.Entry values, String... expectedValues) {
+        assertNotNull("Attribute values are null.", values);
 
         for (String expectedValue : expectedValues) {
-            assertTrue("Value [" + expectedValue + "] for attribute [" + lastName.getKey() + "] not found.", lastName.contains(expectedValue));
+            assertTrue("Value [" + expectedValue + "] for attribute [" + values.getKey() + "] not found in " + Arrays.toString(values.toArray()), values.contains(expectedValue));
+        }
+
+        for (Object value : values.toArray()) {
+            assertTrue("Value [" + value + "] for attribute [" + values.getKey() + "] was not expected", Arrays.asList(expectedValues).contains(value));
         }
     }
 

--- a/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
@@ -33,6 +33,6 @@ public class GroupMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes(attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))", "CN").to("Groups"));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))", "CN").to("Groups").build());
     }
 }

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
@@ -67,12 +67,12 @@ public class ModifiabilitySuiteChild {
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                 .setRdnIdentifier("uid")
-                .map(AttributeMapping.from("uid").to("userName"), // mapping ldap attributes to elytron attributes
-                     AttributeMapping.from("cn").to("firstName"),
-                     AttributeMapping.from("sn").to("lastName"),
-                     AttributeMapping.from("description").to("description"),
-                     AttributeMapping.from("telephoneNumber").to("phones"),
-                     AttributeMapping.fromFilter("ou=Finance,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").asRdn("OU").to("businessArea"))
+                .map(AttributeMapping.fromAttribute("uid").to("userName").build(), // mapping ldap attributes to elytron attributes
+                     AttributeMapping.fromAttribute("cn").to("firstName").build(),
+                     AttributeMapping.fromAttribute("sn").to("lastName").build(),
+                     AttributeMapping.fromAttribute("description").to("description").build(),
+                     AttributeMapping.fromAttribute("telephoneNumber").to("phones").build(),
+                     AttributeMapping.fromFilterDn("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build())
                 .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
                 .setNewIdentityAttributes(attributes)
                 .setIteratorFilter("(uid=*)")

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
@@ -184,6 +184,7 @@ public class ModifiabilitySuiteChild {
         while(iterator.hasNext()){
             ModifiableRealmIdentity identity = iterator.next();
             Assert.assertTrue(identity.exists());
+            System.out.println(identity.getAuthorizationIdentity().getAttributes().getFirst("userName"));
             identity.dispose();
             count++;
         }

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
@@ -34,7 +34,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithMemberOfRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, AttributeMapping.from("memberOf").asRdn("CN").to(RoleDecoder.KEY_ROLES)) ;
+        }, AttributeMapping.fromAttribute("memberOf").extractRdn("CN").to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test
@@ -42,7 +42,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu");
-        }, AttributeMapping.fromFilter("ou=Roles,dc=elytron,dc=wildfly,dc=org", "(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES)) ;
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").searchDn("ou=Roles,dc=elytron,dc=wildfly,dc=org").to(RoleDecoder.KEY_ROLES).build()) ;
     }
 
     @Test
@@ -50,7 +50,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu", "RoleFromBaseDN");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test
@@ -58,6 +58,6 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES));
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES).searchRecursively(false).build());
     }
 }

--- a/src/test/resources/ldap/elytron-role-mapping-tests.ldif
+++ b/src/test/resources/ldap/elytron-role-mapping-tests.ldif
@@ -75,4 +75,33 @@ uid: userWithRdnAttribute
 userPassword:: cGxhaW5QYXNzd29yZA==
 # Password plainPassword
 
+# Recursive roles
+dn: uid=jduke,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: person
+objectclass: inetOrgPerson
+uid: jduke
+cn: Java Duke
+sn: Duke
+userPassword: Password1
 
+dn: cn=R1,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: R1
+member: uid=jduke,dc=elytron,dc=wildfly,dc=org
+description: the R1 group
+
+dn: cn=R2,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: R2
+member: cn=R1,dc=elytron,dc=wildfly,dc=org
+description: the R2 group
+
+dn: cn=R3,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: R3
+member: cn=R2,dc=elytron,dc=wildfly,dc=org
+description: the R3 group


### PR DESCRIPTION
Based on https://github.com/wildfly-security/wildfly-elytron/pull/564 (only "[ELY-804]" commit to review here)
Related subsystem change: https://github.com/wildfly-security/elytron-subsystem/pull/316
https://issues.jboss.org/browse/ELY-804

LdapRealm:
* Added support of direct verification with referred directory
* Added support of THROW referral mode
* realm iterating refactoring: pagination + referrals handling in `LdapSecurityRealm.LdapSearch`
 * no pagination/referrals handling outside of LdapSearch object anymore :)