### PR TITLE
[ELY-739] Coverity static analysis: Dereference null return value in AbstractDigestMechanism (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1353,6 +1353,11 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 5169, value = "[%s] Clients response token does not match expected token")
     String mechResponseTokenMismatch(String mechName);
 
+    @Message(id = 5170, value = "[%s] Problem during crypt: The encrypted result is null. The input data has a length of zero or too short to result in a new block.")
+    AuthenticationMechanismException mechProblemDuringCryptResultIsNull(String mechName);
+
+    @Message(id = 5171, value = "[%s] Problem during decrypt: The decrypted result is null. The input data has a length of zero or too short to result in a new block.")
+    AuthenticationMechanismException mechProblemDuringDecryptResultIsNull(String mechName);
 
     /* http package */
 

--- a/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
@@ -303,6 +303,9 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         } catch (Exception e) {
             throw log.mechProblemDuringCrypt(getMechanismName(), e).toSaslException();
         }
+        if (cipheredPart == null){
+            throw log.mechProblemDuringCryptResultIsNull(getMechanismName()).toSaslException();
+        }
 
         byte[] result = new byte[cipheredPart.length + 6];
         System.arraycopy(cipheredPart, 0, result, 0, cipheredPart.length);
@@ -331,6 +334,9 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
             clearText = unwrapCipher.update(message, offset, len - 6);
         } catch (Exception e) {
             throw log.mechProblemDuringDecrypt(getMechanismName(), e).toSaslException();
+        }
+        if (clearText == null){
+            throw log.mechProblemDuringDecryptResultIsNull(getMechanismName()).toSaslException();
         }
 
         byte[] hmac = new byte[10];
@@ -417,7 +423,11 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         SecretKey cipherKey;
 
         try {
-            ciph = Cipher.getInstance(trans.getTransformationSpec(SaslMechanismInformation.Names.DIGEST_MD5, cipher).getTransformation());
+            TransformationSpec transformationSpec = trans.getTransformationSpec(SaslMechanismInformation.Names.DIGEST_MD5, cipher);
+            if (transformationSpec == null ) {
+                throw log.mechUnknownCipher(getMechanismName(), cipher).toSaslException();
+            }
+            ciph = Cipher.getInstance(transformationSpec.getTransformation());
             int slash = ciph.getAlgorithm().indexOf('/');
             String alg = (slash > -1 ? ciph.getAlgorithm().substring(0, slash) : ciph.getAlgorithm());
 


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-739
