### PR TITLE
SASL External mechanism tests

### DIFF
--- a/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
@@ -1,0 +1,239 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.sasl.external;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.security.sasl.WildFlySasl;
+import org.wildfly.security.sasl.test.BaseTestCase;
+
+/**
+ * Tests for the SASL Client for EXTERNAL mechanism (
+ * <a href="https://tools.ietf.org/html/rfc4422#appendix-A">https://tools.ietf.org/html/rfc4422#appendix-A</a>).
+ *
+ * @author Josef Cacek
+ */
+public class ExternalSaslClientTest extends BaseTestCase {
+
+    private static final byte[] BYTES_EMPTY = new byte[0];
+    private static final String ADMIN = "admin";
+    private static final String EXTERNAL = "EXTERNAL";
+
+    private static final String[] MECHANISMS_EXTERNAL_ONLY = new String[] { EXTERNAL };
+    private static final String[] MECHANISMS_WITH_EXTERNAL = new String[] { "DIGEST-MD5", EXTERNAL, "TEST" };
+    private static final String[] MECHANISMS_WITHOUT_EXTERNAL = new String[] { "DIGEST-MD5", "TEST" };
+
+    @Test
+    @Ignore("ELY-799")
+    public void testMechanismNames() throws Exception {
+        SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+        assertNotNull("SaslServerFactory not registered", factory);
+
+        final String[] empty = new String[] {};
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_FORWARD_SECRECY)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOACTIVE)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOANONYMOUS)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NODICTIONARY)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOPLAINTEXT)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_PASS_CREDENTIALS)));
+
+        assertArrayEquals(MECHANISMS_EXTERNAL_ONLY,
+                factory.getMechanismNames(setProps(WildFlySasl.MECHANISM_QUERY_ALL, Sasl.POLICY_NOPLAINTEXT)));
+        assertArrayEquals(MECHANISMS_EXTERNAL_ONLY, factory.getMechanismNames(null));
+    }
+
+    @Test
+    @Ignore("ELY-800")
+    public void testCreateSaslClientUsingRegistry() throws Exception {
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_FORWARD_SECRECY), null));
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", setProps(Sasl.POLICY_NOACTIVE),
+                null));
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NOANONYMOUS), null));
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NODICTIONARY), null));
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NOPLAINTEXT), null));
+        assertNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_PASS_CREDENTIALS), null));
+
+
+        SaslClient saslClient = Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", setProps(),
+                null);
+        assertNotNull(saslClient);
+        assertEquals(ExternalSaslClient.class, saslClient.getClass());
+
+        saslClient = Sasl.createSaslClient(MECHANISMS_WITH_EXTERNAL, null, "test", "localhost", setProps(),
+                null);
+        assertNotNull(saslClient);
+        assertEquals(ExternalSaslClient.class, saslClient.getClass());
+
+        assertNull(Sasl.createSaslClient(MECHANISMS_WITHOUT_EXTERNAL, null, "test", "localhost", setProps(), null));
+
+        assertNotNull(Sasl.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", null, null));
+    }
+
+    @Test
+    @Ignore("ELY-800")
+    public void testCreateSaslClientUsingFactory() throws Exception {
+        final SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+        assertNotNull("SaslClientFactory not registered", factory);
+
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_FORWARD_SECRECY), null));
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NOACTIVE), null));
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NOANONYMOUS), null));
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NODICTIONARY), null));
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_NOPLAINTEXT), null));
+        assertNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost",
+                setProps(Sasl.POLICY_PASS_CREDENTIALS), null));
+
+        final SaslClient saslClient = factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", setProps(),
+                null);
+        assertNotNull(saslClient);
+        assertEquals(ExternalSaslClient.class, saslClient.getClass());
+
+        assertNotNull(factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", null, null));
+    }
+
+    @Test
+    public void testServerChallengeProvideAuthzId() throws Exception {
+        final SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+
+        final SaslClient saslClient = factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, ADMIN, "test", "localhost", setProps(),
+                null);
+
+        assertEquals(EXTERNAL, saslClient.getMechanismName());
+        assertTrue(saslClient.hasInitialResponse());
+        assertFalse(saslClient.isComplete());
+
+        // The challenge is null if the authentication has succeeded and no more challenge data is to be sent to the client.
+        assertArrayEquals(ADMIN.getBytes(StandardCharsets.UTF_8), saslClient.evaluateChallenge(BYTES_EMPTY));
+
+        assertTrue(saslClient.isComplete());
+
+        try {
+            saslClient.evaluateChallenge(BYTES_EMPTY);
+            fail("evaluateChallenge() invocation should fail  when the authentication is already completed");
+        } catch (SaslException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testServerChallengeEmptyAuthzId() throws Exception {
+        final SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+
+        final SaslClient saslClient = factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, null, "test", "localhost", setProps(),
+                null);
+
+        assertEquals(EXTERNAL, saslClient.getMechanismName());
+        assertTrue(saslClient.hasInitialResponse());
+        assertFalse(saslClient.isComplete());
+
+        // The challenge is null if the authentication has succeeded and no more challenge data is to be sent to the client.
+        assertArrayEquals(BYTES_EMPTY, saslClient.evaluateChallenge(BYTES_EMPTY));
+
+        assertTrue(saslClient.isComplete());
+
+        try {
+            saslClient.evaluateChallenge(BYTES_EMPTY);
+            fail("evaluateChallenge() invocation should fail  when the authentication is already completed");
+        } catch (SaslException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test failing (as we only authenticate "admin") authn for unsupported data "test" from client.
+     */
+    @Test(expected = SaslException.class)
+    public void testWrongServerChallenge() throws Exception {
+        final SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+        final SaslClient saslClient = factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, ADMIN, "test", "localhost", setProps(),
+                null);
+        assertFalse(saslClient.isComplete());
+        saslClient.evaluateChallenge("test".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @Ignore("ELY-802")
+    public void testWrapUnwrap() throws Exception {
+        final SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
+
+        final SaslClient saslClient = factory.createSaslClient(MECHANISMS_EXTERNAL_ONLY, ADMIN, "test", "localhost", setProps(),
+                null);
+
+        try {
+            saslClient.wrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as not yet completed");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+        try {
+            saslClient.unwrap(new byte[] {}, 0, 0);
+            fail("unwrap() invocation should throw IllegalStateException as not yet completed");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+
+        saslClient.evaluateChallenge(BYTES_EMPTY);
+        assertTrue(saslClient.isComplete());
+
+        try {
+            saslClient.wrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as this mechanism supports neither integrity nor privacy");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+        try {
+            saslClient.unwrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as this mechanism supports neither integrity nor privacy");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    private Map<String, ?> setProps(String... propNames) {
+        return Stream.of(propNames).collect(Collectors.toMap(Function.identity(), s -> "true"));
+    }
+}

--- a/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.sasl.external;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.security.sasl.WildFlySasl;
+import org.wildfly.security.sasl.test.BaseTestCase;
+import org.wildfly.security.sasl.util.AbstractSaslParticipant;
+
+/**
+ * Tests for the SASL Server for EXTERNAL mechanism (
+ * <a href="https://tools.ietf.org/html/rfc4422#appendix-A">https://tools.ietf.org/html/rfc4422#appendix-A</a>).
+ *
+ * @author Josef Cacek
+ */
+public class ExternalSaslServerTest extends BaseTestCase {
+
+    private static final String ADMIN = "admin";
+    private static final String EXTERNAL = "EXTERNAL";
+
+    private static final CallbackHandler CALLBACK_HANDLER_AUTHZ_ADMIN = callbacks -> {
+        for (Callback callback : callbacks) {
+            if (callback instanceof AuthorizeCallback) {
+                final AuthorizeCallback ac = (AuthorizeCallback) callback;
+                ac.setAuthorized(ADMIN.equals(ac.getAuthorizationID()));
+            } else {
+                throw new UnsupportedCallbackException(callback);
+            }
+        }
+    };
+
+    @Test
+    @Ignore("ELY-799,ELY-788")
+    public void testMechanismNames() throws Exception {
+        SaslServerFactory factory = obtainSaslServerFactory(ExternalSaslServerFactory.class);
+        assertNotNull("SaslServerFactory not registered", factory);
+
+        final String[] empty = new String[] {};
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_FORWARD_SECRECY)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOACTIVE)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOANONYMOUS)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NODICTIONARY)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_NOPLAINTEXT)));
+        assertArrayEquals(empty, factory.getMechanismNames(setProps(Sasl.POLICY_PASS_CREDENTIALS)));
+
+        final String[] allMechanisms = new String[] { EXTERNAL };
+        assertArrayEquals(allMechanisms,
+                factory.getMechanismNames(setProps(WildFlySasl.MECHANISM_QUERY_ALL, Sasl.POLICY_NOPLAINTEXT)));
+        assertArrayEquals(allMechanisms, factory.getMechanismNames(null));
+    }
+
+    @Test
+    @Ignore("ELY-800,ELY-788")
+    public void testCreateSaslServerUsingRegistry() throws Exception {
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_FORWARD_SECRECY), null));
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOACTIVE), null));
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOANONYMOUS), null));
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NODICTIONARY), null));
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOPLAINTEXT), null));
+        assertNull(Sasl.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_PASS_CREDENTIALS), null));
+
+        SaslServer server = Sasl.createSaslServer(EXTERNAL, "test", "localhost", null, null);
+        assertNotNull(server);
+        assertEquals(ExternalSaslServer.class, server.getClass());
+    }
+
+    @Test
+    @Ignore("ELY-800,ELY-788")
+    public void testCreateSaslServerUsingFactory() throws Exception {
+        SaslServerFactory factory = obtainSaslServerFactory(ExternalSaslServerFactory.class);
+        assertNotNull("SaslServerFactory not registered", factory);
+
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_FORWARD_SECRECY), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOACTIVE), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOANONYMOUS), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NODICTIONARY), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_NOPLAINTEXT), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost",
+                setProps(Sasl.POLICY_NOPLAINTEXT, WildFlySasl.MECHANISM_QUERY_ALL), null));
+        assertNull(factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(Sasl.POLICY_PASS_CREDENTIALS), null));
+
+        SaslServer server = factory.createSaslServer(EXTERNAL, "test", "localhost", null, null);
+        assertNotNull(server);
+        assertEquals(ExternalSaslServer.class, server.getClass());
+    }
+
+    @Test
+    @Ignore("ELY-803")
+    public void testAuthnClientData() throws Exception {
+        SaslServerFactory factory = obtainSaslServerFactory(ExternalSaslServerFactory.class);
+        assertNotNull("SaslServerFactory not registered", factory);
+
+        SaslServer saslServer = factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(),
+                CALLBACK_HANDLER_AUTHZ_ADMIN);
+        assertEquals(EXTERNAL, saslServer.getMechanismName());
+
+        assertFalse(saslServer.isComplete());
+
+        // The challenge is null if the authentication has succeeded and no more challenge data is to be sent to the client.
+        assertNull(saslServer.evaluateResponse(ADMIN.getBytes(StandardCharsets.UTF_8)));
+
+        assertTrue(saslServer.isComplete());
+        assertEquals(ADMIN, saslServer.getAuthorizationID());
+
+
+        try {
+            saslServer.evaluateResponse(AbstractSaslParticipant.NO_BYTES);
+            fail("evaluateResponse() invocation should fail  when the authentication is already completed");
+        } catch (SaslException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test failing (as we only authenticate "admin") authn for unsupported data "test" from client.
+     */
+    @Test(expected = SaslException.class)
+    public void testFailedAuthn() throws Exception {
+        SaslServer saslServer = obtainSaslServerFactory(ExternalSaslServerFactory.class).createSaslServer(EXTERNAL, "test",
+                "localhost", setProps(), CALLBACK_HANDLER_AUTHZ_ADMIN);
+        assertFalse(saslServer.isComplete());
+        saslServer.evaluateResponse("test".getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Test failing authn (as we only authenticate "admin") for empty data received from client.
+     */
+    @Test(expected = SaslException.class)
+    public void testAuthnEmptyData() throws Exception {
+        SaslServer saslServer = obtainSaslServerFactory(ExternalSaslServerFactory.class).createSaslServer(EXTERNAL, "test",
+                "localhost", setProps(), CALLBACK_HANDLER_AUTHZ_ADMIN);
+
+        assertFalse(saslServer.isComplete());
+
+        saslServer.evaluateResponse(AbstractSaslParticipant.NO_BYTES);
+    }
+
+    @Test
+    @Ignore("ELY-802")
+    public void testWrapUnwrap() throws Exception {
+        SaslServerFactory factory = obtainSaslServerFactory(ExternalSaslServerFactory.class);
+        assertNotNull("SaslServerFactory not registered", factory);
+
+        SaslServer saslServer = factory.createSaslServer(EXTERNAL, "test", "localhost", setProps(),
+                CALLBACK_HANDLER_AUTHZ_ADMIN);
+
+        try {
+            saslServer.wrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as not yet completed");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+        try {
+            saslServer.unwrap(new byte[] {}, 0, 0);
+            fail("unwrap() invocation should throw IllegalStateException as not yet completed");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+
+        saslServer.evaluateResponse(ADMIN.getBytes(StandardCharsets.UTF_8));
+        assertTrue(saslServer.isComplete());
+
+        try {
+            saslServer.wrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as this mechanism supports neither integrity nor privacy");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+        try {
+            saslServer.unwrap(new byte[] {}, 0, 0);
+            fail("wrap() invocation should throw IllegalStateException as this mechanism supports neither integrity nor privacy");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+    }
+
+    private Map<String, ?> setProps(String... propNames) {
+        return Stream.of(propNames).collect(Collectors.toMap(Function.identity(), s -> "true"));
+    }
+}


### PR DESCRIPTION
Tests for `ExternalSasl*` implementations. Some tests are ignored with ELY issue number provided.