### PR TITLE
[ELY-828] Make PeerIdentityContext.setPeerIdentity() protected

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/PeerIdentityContext.java
+++ b/src/main/java/org/wildfly/security/auth/client/PeerIdentityContext.java
@@ -99,7 +99,7 @@ public abstract class PeerIdentityContext {
         }
     }
 
-    void setPeerIdentity(PeerIdentity newIdentity) {
+    protected void setPeerIdentity(PeerIdentity newIdentity) {
         assert newIdentity == null || newIdentity.getPeerIdentityContext() == this;
         if (newIdentity == null) {
             currentIdentity.remove();


### PR DESCRIPTION
Currently, ```ConnectionPeerIdentityContext.getCurrentIdentity()``` always returns null. This PR makes the ```PeerIdentityContext.setPeerIdentity()``` method protected. This will allow subclasses of ```PeerIdentityContext``` to be able to initialize the currently set peer identity. In particular, this method could then be called from the ```org.jboss.remoting3.ConnectionPeerIdentityContext``` constructor to initialize the current identity to the connection identity, i.e., something like:

```
ConnectionPeerIdentityContext(final ConnectionImpl connection, final Collection<String> offeredMechanisms) {
...
    connectionIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, connection.getPrincipal(), 0, connection));
    setPeerIdentity(connectionIdentity);
...
}
``` 