### PR TITLE
[ELY-840] Use configured Provider[] for PasswordFactory Creation.  Includes [ELY-658] OAuth2 Changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <version.hsqldb>2.3.1</version.hsqldb>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
         <version.com.nimbusds.nimbus-jose-jwt>4.13.1</version.com.nimbusds.nimbus-jose-jwt>
+        <version.com.squareup.okhttp3.mockwebserver>3.4.1</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.0.Beta1</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
@@ -441,6 +442,14 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${version.com.nimbusds.nimbus-jose-jwt}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Mock Web Server -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${version.com.squareup.okhttp3.mockwebserver}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -22,7 +22,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.InvalidObjectException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
@@ -470,11 +469,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1105, value = "OAuth2-based realm failed to introspect token")
     RealmUnavailableException tokenRealmOAuth2TokenIntrospectionFailed(@Cause Throwable cause);
 
-    @Message(id = 1106, value = "OAuth2-based realm requires a SSLContext when the token introspection endpoint [%s] is using SSL/TLS.")
-    IllegalStateException tokenRealmOAuth2SSLContextNotSpecified(URL tokenIntrospectionUrl);
-
-    @Message(id = 1107, value = "OAuth2-based realm requires a HostnameVerifier when the token introspection endpoint [%s] is using SSL/TLS.")
-    IllegalStateException tokenRealmOAuth2HostnameVerifierNotSpecified(URL tokenIntrospectionUrl);
+    @Message(id = 1106, value = "Could not obtain SSLContext")
+    IllegalStateException failedToObtainSSLContext(@Cause Throwable cause);
 
     @Message(id = 1108, value = "Ldap-backed realm identity search failed")
     RuntimeException ldapRealmIdentitySearchFailed(@Cause Throwable cause);
@@ -582,6 +578,9 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 1142, value = "Invalid iteration count %d (must be at least 1)")
     ConfigXMLParseException xmlInvalidIterationCount(@Param ConfigurationXMLStreamReader reader, int wrongCount);
+
+    @Message(id = 1143, value = "Invalid URL [%s]")
+    ConfigXMLParseException xmlInvalidUrl(String url);
 
     /* keystore package */
 

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -69,6 +69,7 @@ import org.wildfly.security.auth.principal.AnonymousPrincipal;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.server.IdentityCredentials;
 import org.wildfly.security.auth.server.NameRewriter;
+import org.wildfly.security.credential.BearerTokenCredential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.credential.source.CredentialStoreCredentialSource;
@@ -823,6 +824,16 @@ public abstract class AuthenticationConfiguration {
 
     public final AuthenticationConfiguration useRealm(String realm) {
         return new SetRealmAuthenticationConfiguration(this, realm);
+    }
+
+    /**
+     * Create a new configuration which is the same as this configuration, but which uses the given {@link BearerTokenCredential} to authenticate.
+     *
+     * @param credential the bearer token credential to use
+     * @return the new configuration
+     */
+    public final AuthenticationConfiguration useBearerTokenCredential(BearerTokenCredential credential) {
+        return credential == null ? this : useCredentials(getCredentialSource().with(IdentityCredentials.NONE.withCredential(credential)));
     }
 
     // client methods

--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Authenticator;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -68,6 +69,7 @@ import org.wildfly.client.config.ClientConfiguration;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.client.config.ConfigurationXMLStreamReader;
 import org.wildfly.client.config.XMLLocation;
+import org.wildfly.common.Assert;
 import org.wildfly.common.function.ExceptionBiFunction;
 import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.common.function.ExceptionUnaryOperator;
@@ -77,6 +79,7 @@ import org.wildfly.security.auth.server.IdentityCredentials;
 import org.wildfly.security.auth.server.NameRewriter;
 import org.wildfly.security.auth.util.ElytronAuthenticator;
 import org.wildfly.security.auth.util.RegexNameRewriter;
+import org.wildfly.security.credential.BearerTokenCredential;
 import org.wildfly.security.credential.KeyPairCredential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.PublicKeyCredential;
@@ -84,6 +87,7 @@ import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.credential.source.CredentialStoreCredentialSource;
 import org.wildfly.security.credential.source.KeyStoreCredentialSource;
+import org.wildfly.security.credential.source.OAuth2CredentialSource;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.keystore.PasswordEntry;
 import org.wildfly.security.keystore.WrappingPasswordKeyStore;
@@ -216,7 +220,6 @@ public final class ElytronXmlParser {
      * @throws ConfigXMLParseException if the resource failed to be parsed
      */
     static SecurityFactory<AuthenticationContext> parseAuthenticationClientType(ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
-        SecurityFactory<AuthenticationContext> futureContext = null;
         requireNoAttributes(reader);
         ExceptionSupplier<RuleNode<AuthenticationConfiguration>, ConfigXMLParseException> authFactory = () -> null;
         ExceptionSupplier<RuleNode<SecurityFactory<SSLContext>>, ConfigXMLParseException> sslFactory = () -> null;
@@ -793,8 +796,8 @@ public final class ElytronXmlParser {
                         break;
                     }
                     case "clear-password": {
-                        char[] password = parseClearPassword(reader);
-                        function = andThenOp(function, credentialSource -> credentialSource.with(IdentityCredentials.NONE.withCredential(new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, password)))));
+                        Password password = parseClearPassword(reader);
+                        function = andThenOp(function, credentialSource -> credentialSource.with(IdentityCredentials.NONE.withCredential(new PasswordCredential(password))));
                         break;
                     }
                     case "hashed-password": {
@@ -820,6 +823,16 @@ public final class ElytronXmlParser {
                     case "public-key-pem": {
                         PublicKey publicKey = parsePem(reader, PublicKey.class);
                         function = andThenOp(function, credentialSource -> credentialSource.with(IdentityCredentials.NONE.withCredential(new PublicKeyCredential(publicKey))));
+                        break;
+                    }
+                    case "bearer-token": {
+                        BearerTokenCredential bearerToken = parseBearerTokenType(reader);
+                        function = andThenOp(function, credentialSource -> credentialSource.with(IdentityCredentials.NONE.withCredential(bearerToken)));
+                        break;
+                    }
+                    case "oauth2-bearer-token": {
+                        CredentialSource credentialStore = parseOAuth2BearerTokenType(reader);
+                        function = andThenOp(function, credentialSource -> credentialSource.with(credentialStore));
                         break;
                     }
                     default: {
@@ -1139,7 +1152,7 @@ public final class ElytronXmlParser {
                             throw reader.unexpectedElement();
                         }
                         gotCredential = true;
-                        final char[] clearPassword = parseClearPassword(reader);
+                        final char[] clearPassword = parseClearPassword(reader).getPassword();
                         passwordFactory = () -> clearPassword;
                         break;
                     }
@@ -1245,7 +1258,7 @@ public final class ElytronXmlParser {
                     }
                     case "key-store-clear-password": {
                         if (keyStoreCredential != null) throw reader.unexpectedElement();
-                        keyStoreCredential = () -> new PasswordEntry(ClearPassword.createRaw("clear", parseClearPassword(reader)));
+                        keyStoreCredential = () -> new PasswordEntry(parseClearPassword(reader));
                         break;
                     }
                     default: throw reader.unexpectedElement();
@@ -1846,7 +1859,7 @@ public final class ElytronXmlParser {
      * @return the clear password characters
      * @throws ConfigXMLParseException if the resource failed to be parsed or the module is not found
      */
-    static char[] parseClearPassword(ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
+    static ClearPassword parseClearPassword(ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
         final int attributeCount = reader.getAttributeCount();
         char[] password = null;
         for (int i = 0; i < attributeCount; i ++) {
@@ -1865,7 +1878,12 @@ public final class ElytronXmlParser {
             if (tag == START_ELEMENT) {
                 throw reader.unexpectedElement();
             } else if (tag == END_ELEMENT) {
-                return password;
+                try {
+                    PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+                    return Assert.assertNotNull(factory.generatePassword(new ClearPasswordSpec(password)).castAs(ClearPassword.class));
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException cause) {
+                    throw xmlLog.xmlFailedToCreateCredential(reader.getLocation(), cause);
+                }
             } else {
                 throw reader.unexpectedContent();
             }
@@ -1939,6 +1957,107 @@ public final class ElytronXmlParser {
         throw reader.unexpectedDocumentEnd();
     }
 
+    /**
+     * Parse an XML element of type {@code bearer-token-type} from an XML reader.
+     *
+     * @param reader the XML stream reader
+     * @throws ConfigXMLParseException if the resource failed to be parsed
+     */
+    static BearerTokenCredential parseBearerTokenType(ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
+        String value = requireSingleAttribute(reader, "value");
+        while (reader.hasNext()) {
+            final int tag = reader.nextTag();
+            if (tag == START_ELEMENT) {
+                throw reader.unexpectedElement();
+            } else if (tag == END_ELEMENT) {
+                return new BearerTokenCredential(value);
+            } else {
+                throw reader.unexpectedContent();
+            }
+        }
+        throw reader.unexpectedDocumentEnd();
+    }
+
+    /**
+     * Parse an XML element of type {@code oauth2-bearer-token-type} from an XML reader.
+     *
+     * @param reader the XML stream reader
+     * @throws ConfigXMLParseException if the resource failed to be parsed
+     */
+    static CredentialSource parseOAuth2BearerTokenType(ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
+        URI tokenEndpointUri = requireSingleURIAttribute(reader, "token-endpoint-uri");
+        OAuth2CredentialSource.Builder builder;
+        try {
+            builder = OAuth2CredentialSource.builder(tokenEndpointUri.toURL());
+        } catch (MalformedURLException e) {
+            throw xmlLog.xmlInvalidUrl(tokenEndpointUri.toString());
+        }
+        while (reader.hasNext()) {
+            final int tag = reader.nextTag();
+            if (tag == START_ELEMENT) {
+                checkElementNamespace(reader);
+                switch (reader.getLocalName()) {
+                    case "resource-owner-credentials": {
+                        builder = parseOAuth2ResourceOwnerCredentials(reader, builder);
+                        break;
+                    }
+                    default: throw reader.unexpectedElement();
+                }
+            } else if (tag == END_ELEMENT) {
+                return builder.build();
+            } else {
+                throw reader.unexpectedContent();
+            }
+        }
+        throw reader.unexpectedDocumentEnd();
+    }
+
+    /**
+     * Parse an XML element of type {@code oauth2-bearer-token-type} from an XML reader.
+     *
+     * @param reader the XML stream reader
+     * @param builder the builder
+     * @throws ConfigXMLParseException if the resource failed to be parsed
+     */
+    static OAuth2CredentialSource.Builder parseOAuth2ResourceOwnerCredentials(ConfigurationXMLStreamReader reader, OAuth2CredentialSource.Builder builder) throws ConfigXMLParseException {
+        final int attributeCount = reader.getAttributeCount();
+        String userName = null;
+        String password = null;
+        for (int i = 0; i < attributeCount; i ++) {
+            checkAttributeNamespace(reader, i);
+            switch (reader.getAttributeLocalName(i)) {
+                case "name": {
+                    if (userName != null) throw reader.unexpectedAttribute(i);
+                    userName = reader.getAttributeValue(i);
+                    break;
+                }
+                case "password": {
+                    if (password != null) throw reader.unexpectedAttribute(i);
+                    password = reader.getAttributeValue(i);
+                    break;
+                }
+                default: throw reader.unexpectedAttribute(i);
+            }
+        }
+        if (userName == null) {
+            throw missingAttribute(reader, "name");
+        }
+        if (password == null) {
+            throw missingAttribute(reader, "password");
+        }
+        while (reader.hasNext()) {
+            final int tag = reader.nextTag();
+            if (tag == START_ELEMENT) {
+                throw reader.unexpectedElement();
+            } else if (tag == END_ELEMENT) {
+                return builder.useResourceOwnerPassword(userName, password);
+            } else {
+                throw reader.unexpectedContent();
+            }
+        }
+        throw reader.unexpectedDocumentEnd();
+    }
+
     // util
 
     private static void checkElementNamespace(final ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
@@ -1962,6 +2081,14 @@ public final class ElytronXmlParser {
     }
 
     private static String requireSingleAttribute(final ConfigurationXMLStreamReader reader, final String attributeName) throws ConfigXMLParseException {
+        return requireSingleAttribute(reader, attributeName, (ExceptionSupplier<String, ConfigXMLParseException>) () -> reader.getAttributeValue(0));
+    }
+
+    private static URI requireSingleURIAttribute(final ConfigurationXMLStreamReader reader, final String attributeName) throws ConfigXMLParseException {
+        return requireSingleAttribute(reader, attributeName, () -> reader.getURIAttributeValue(0));
+    }
+
+    private static <A> A requireSingleAttribute(final ConfigurationXMLStreamReader reader, final String attributeName, ExceptionSupplier<A, ConfigXMLParseException> attributeFunction) throws ConfigXMLParseException {
         final int attributeCount = reader.getAttributeCount();
         if (attributeCount < 1) {
             throw reader.missingRequiredAttribute("", attributeName);
@@ -1973,7 +2100,7 @@ public final class ElytronXmlParser {
         if (attributeCount > 1) {
             throw reader.unexpectedAttribute(1);
         }
-        return reader.getAttributeValue(0);
+        return attributeFunction.get();
     }
 
     private static ConfigXMLParseException missingAttribute(final ConfigurationXMLStreamReader reader, final String name) {

--- a/src/main/java/org/wildfly/security/auth/client/SetCredentialsConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/SetCredentialsConfiguration.java
@@ -119,6 +119,11 @@ class SetCredentialsConfiguration extends AuthenticationConfiguration implements
         return super.filterOneSaslMechanism(mechanismName);
     }
 
+    @Override
+    CredentialSource getCredentialSource() {
+        return credentialSource;
+    }
+
     AuthenticationConfiguration reparent(final AuthenticationConfiguration newParent) {
         return new SetCredentialsConfiguration(newParent, credentialSource);
     }

--- a/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
+++ b/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
@@ -74,13 +74,7 @@ public class OAuth2IntrospectValidator implements TokenValidator {
         this.clientSecret = Assert.checkNotNullParam("clientSecret", configuration.clientSecret);
 
         if (tokenIntrospectionUrl.getProtocol().equalsIgnoreCase("https")) {
-            if (configuration.sslContext == null) {
-                throw log.tokenRealmOAuth2SSLContextNotSpecified(tokenIntrospectionUrl);
-            }
-
-            if (configuration.hostnameVerifier == null) {
-                throw log.tokenRealmOAuth2HostnameVerifierNotSpecified(tokenIntrospectionUrl);
-            }
+            Assert.checkNotNullParam("sslContext", configuration.sslContext);
         }
 
         this.sslContext = configuration.sslContext;
@@ -175,16 +169,6 @@ public class OAuth2IntrospectValidator implements TokenValidator {
 
         boolean isHttps = url.getProtocol().equalsIgnoreCase("https");
 
-        if (isHttps) {
-            if (sslContext == null) {
-                throw log.tokenRealmOAuth2SSLContextNotSpecified(url);
-            }
-
-            if (hostnameVerifier == null) {
-                throw log.tokenRealmOAuth2HostnameVerifierNotSpecified(url);
-            }
-        }
-
         try {
             log.debugf("Opening connection to token introspection endpoint [%s]", url);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -193,7 +177,10 @@ public class OAuth2IntrospectValidator implements TokenValidator {
                 HttpsURLConnection https = (HttpsURLConnection) connection;
 
                 https.setSSLSocketFactory(sslContext.getSocketFactory());
-                https.setHostnameVerifier(hostnameVerifier);
+
+                if (hostnameVerifier != null) {
+                    https.setHostnameVerifier(hostnameVerifier);
+                }
             }
 
             return connection;

--- a/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
+++ b/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
@@ -1,0 +1,281 @@
+package org.wildfly.security.credential.source;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.log;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
+import org.wildfly.security.credential.BearerTokenCredential;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.util.ByteStringBuilder;
+
+/**
+ * A {@link CredentialSource} capable of authenticating against a OAuth2 compliant authorization server and obtaining
+ * access tokens in form of a {@link BearerTokenCredential}.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class OAuth2CredentialSource implements CredentialSource {
+
+    /**
+     * Creates a new {@link Builder} instance in order to configure and build a {@link OAuth2CredentialSource}.
+     *
+     * @param tokenEndpointUrl the token endpoint that will be used to obtain OAuth2 access tokens
+     * @return a new builder instance
+     */
+    public static Builder builder(URL tokenEndpointUrl) {
+        return new Builder(tokenEndpointUrl);
+    }
+
+    private final String grantType;
+    private final URL tokenEndpointUri;
+    private final Consumer<Map<String, String>> consumer;
+    private String scopes;
+    private final Supplier<SSLContext> sslContextSupplier;
+    private final Supplier<HostnameVerifier> hostnameVerifierSupplier;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param grantType the OAuth2 grant type as defined by the specification
+     * @param tokenEndpointUri the OAuth2 Token Endpoint {@link URI}
+     * @param scopes a string with the scope of the access request
+     * @param sslContextSupplier a supplier from where the {@link SSLContext} is obtained in case the token endpoint is using TLS/HTTPS
+     * @param hostnameVerifierSupplier a supplier from where the {@link HostnameVerifier} is obtained in case the token endpoint is using TLS/HTTPS
+     */
+    private OAuth2CredentialSource(String grantType, URL tokenEndpointUri, String scopes, Supplier<SSLContext> sslContextSupplier, Supplier<HostnameVerifier> hostnameVerifierSupplier) {
+        this(grantType, tokenEndpointUri, stringStringMap -> {}, scopes, sslContextSupplier, hostnameVerifierSupplier);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param grantType the OAuth2 grant type as defined by the specification
+     * @param tokenEndpointUrl the OAuth2 Token Endpoint {@link URL}
+     * @param consumer a callback that can be used to push addition parameters to requests sent to the authorization server
+     * @param scopes a string with the scope of the access request
+     * @param sslContextSupplier a supplier from where the {@link SSLContext} is obtained in case the token endpoint is using TLS/HTTPS
+     * @param hostnameVerifierSupplier a supplier from where the {@link HostnameVerifier} is obtained in case the token endpoint is using TLS/HTTPS
+     */
+    private OAuth2CredentialSource(String grantType, URL tokenEndpointUrl, Consumer<Map<String, String>> consumer, String scopes, Supplier<SSLContext> sslContextSupplier, Supplier<HostnameVerifier> hostnameVerifierSupplier) {
+        this.grantType = checkNotNullParam("grantType", grantType);
+        this.tokenEndpointUri = checkNotNullParam("tokenEndpointUri", tokenEndpointUrl);
+
+        if (isHttps(tokenEndpointUrl)) {
+            checkNotNullParam("sslContextSupplier", sslContextSupplier);
+        }
+
+        this.consumer = consumer;
+        this.scopes = scopes;
+        this.sslContextSupplier = sslContextSupplier;
+        this.hostnameVerifierSupplier = hostnameVerifierSupplier;
+    }
+
+    @Override
+    public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) throws IOException {
+        return getCredential(credentialType, algorithmName, parameterSpec) != null ? SupportLevel.SUPPORTED : SupportLevel.UNSUPPORTED;
+    }
+
+    @Override
+    public <C extends Credential> C getCredential(Class<C> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) throws IOException {
+        if (credentialType.isAssignableFrom(credentialType)) {
+            try {
+                HttpURLConnection connection = null;
+
+                try {
+                    connection = openConnection();
+                    connection.setDoOutput(true);
+                    connection.setRequestMethod("POST");
+                    connection.setInstanceFollowRedirects(false);
+
+                    connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+                    HashMap<String, String> parameters = new HashMap<>();
+
+                    parameters.put("grant_type", grantType);
+                    consumer.accept(parameters);
+
+                    if (scopes != null) {
+                        parameters.put("scope", scopes);
+                    }
+
+                    byte[] paramBytes = buildParameters(parameters);
+
+                    try (OutputStream outputStream = connection.getOutputStream()) {
+                        outputStream.write(paramBytes);
+                    }
+
+                    try (InputStream inputStream = new BufferedInputStream(connection.getInputStream())) {
+                        JsonObject jsonObject = Json.createReader(inputStream).readObject();
+                        String accessToken = jsonObject.getString("access_token");
+                        return credentialType.cast(new BearerTokenCredential(accessToken));
+                    }
+                } catch (IOException ioe) {
+                    InputStream errorStream = null;
+
+                    if (connection != null && connection.getErrorStream() != null) {
+                        errorStream = connection.getErrorStream();
+
+                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream))) {
+                            StringBuffer response = reader.lines().reduce(new StringBuffer(), StringBuffer::append, (buffer1, buffer2) -> buffer1);
+                            log.errorf(ioe, "Unexpected response from server [%s]. Response: [%s]", tokenEndpointUri, response);
+                        } catch (IOException ignore) {
+                        }
+                    }
+
+                    throw log.mechUnableToHandleResponseFromServer("OAuth2CredentialSource", ioe);
+                }
+            } catch (Exception cause) {
+                throw log.mechCallbackHandlerFailedForUnknownReason("OAuth2CredentialSource", cause);
+            }
+        }
+
+        return null;
+    }
+
+    private SSLContext resolveSSLContext() {
+        if (!isHttps(tokenEndpointUri)) {
+            return null;
+        }
+        return sslContextSupplier == null ? null : sslContextSupplier.get();
+    }
+
+    private HttpURLConnection openConnection() throws IOException {
+        log.debugf("Opening connection to [%s]", tokenEndpointUri);
+        HttpURLConnection connection = (HttpURLConnection) tokenEndpointUri.openConnection();
+
+        if (isHttps(tokenEndpointUri)) {
+            HttpsURLConnection https = (HttpsURLConnection) connection;
+
+            https.setSSLSocketFactory(resolveSSLContext().getSocketFactory());
+            if (hostnameVerifierSupplier != null) {
+                https.setHostnameVerifier(checkNotNullParam("hostnameVerifier", hostnameVerifierSupplier.get()));
+            }
+        }
+
+        return connection;
+    }
+
+    private byte[] buildParameters(Map<String, String> parameters) {
+        ByteStringBuilder params = new ByteStringBuilder();
+
+        parameters.entrySet().stream().forEach(entry -> {
+            if (params.length() > 0) {
+                params.append('&');
+            }
+            params.append(entry.getKey()).append('=').append(entry.getValue());
+        });
+
+        return params.toArray();
+    }
+
+    private boolean isHttps(URL tokenEndpointUrl) {
+        return "https".equals(tokenEndpointUrl.getProtocol());
+    }
+
+    public static class Builder {
+
+        private final URL tokenEndpointUrl;
+        private Function<Builder, OAuth2CredentialSource> grantType;
+        private String scopes;
+        private Supplier<SSLContext> sslContextSupplier = new Supplier<SSLContext>() {
+            @Override
+            public SSLContext get()  {
+                AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+                try {
+                    return contextConfigurationClient.getSSLContext(tokenEndpointUrl.toURI(), AuthenticationContext.captureCurrent());
+                } catch (Exception cause) {
+                    throw log.failedToObtainSSLContext(cause);
+                }
+            }
+        };
+        private Supplier<HostnameVerifier> hostnameVerifierSupplier;
+
+        private Builder(URL tokenEndpointUrl) {
+            this.tokenEndpointUrl = checkNotNullParam("tokenEndpointUrl", tokenEndpointUrl);
+            this.grantType = builder -> new OAuth2CredentialSource("client_credentials", tokenEndpointUrl, builder.scopes, builder.sslContextSupplier, builder.hostnameVerifierSupplier);
+        }
+
+        /**
+         * The scopes to grant access.
+         *
+         * @param scopes the scopes to grant access.
+         * @return this instance
+         */
+        public Builder grantScopes(String scopes) {
+            this.scopes = checkNotNullParam("scopes", scopes);
+            return this;
+        }
+
+        /**
+         * <p>Configure OAuth2 Resource Owner Password Grant Type as defined by the OAuth2 specification.
+         *
+         * @param userName the resource owner's user name
+         * @param password the resource owner's password
+         * @return this instance.
+         */
+        public Builder useResourceOwnerPassword(String userName, String password) {
+            grantType = builder -> new OAuth2CredentialSource("password", tokenEndpointUrl, parameters -> {
+                parameters.put("username", userName);
+                parameters.put("password", password);
+            }, builder.scopes, builder.sslContextSupplier, builder.hostnameVerifierSupplier);
+            return this;
+        }
+
+        /**
+         * TThe {@link SSLContext} to be used in case connections to remote server require TLS/HTTPS.
+         *
+         * @param sslContext the SSLContext
+         * @return this instance
+         */
+        public Builder useSslContext(SSLContext sslContext) {
+            checkNotNullParam("sslContext", sslContext);
+            sslContextSupplier = () -> sslContext;
+            return this;
+        }
+
+        /**
+         * TThe {@link HostnameVerifier} to be used in case connections to remote server require TLS/HTTPS.
+         *
+         * @param hostnameVerifier the HostnameVerifier
+         * @return this instance
+         */
+        public Builder useSslHostnameVerifier(HostnameVerifier hostnameVerifier) {
+            checkNotNullParam("hostnameVerifier", hostnameVerifier);
+            this.hostnameVerifierSupplier = () -> hostnameVerifier;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link OAuth2CredentialSource} instance.
+         *
+         * @return a OAuth2 credential source
+         */
+        public OAuth2CredentialSource build() {
+            return grantType.apply(this);
+        }
+    }
+}

--- a/src/main/java/org/wildfly/security/mechanism/oauth2/OAuth2Client.java
+++ b/src/main/java/org/wildfly/security/mechanism/oauth2/OAuth2Client.java
@@ -61,8 +61,7 @@ public class OAuth2Client {
 
         assertTrue(credentialCallback.isCredentialTypeSupported(BearerTokenCredential.class));
 
-        BearerTokenCredential credential = credentialCallback.getCredential(BearerTokenCredential.class);
-        final String token = credential.getToken();
+        final String token = credentialCallback.applyToCredential(BearerTokenCredential.class, BearerTokenCredential::getToken);
 
         if (token == null) {
             throw ElytronMessages.log.mechNoTokenGiven(this.mechanismName);

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -224,6 +224,8 @@
             <xsd:element name="key-pair" type="key-pair-type"/>
             <xsd:element name="certificate" type="certificate-type"/>
             <xsd:element name="public-key-pem" type="xsd:string"/>
+            <xsd:element name="bearer-token" type="bearer-token-type"/>
+            <xsd:element name="oauth2-bearer-token" type="oauth2-bearer-token-type"/>
         </xsd:choice>
     </xsd:complexType>
 
@@ -322,6 +324,22 @@
         <xsd:attribute name="store" type="xsd:string"/>
         <xsd:attribute name="alias" type="xsd:string"/>
         <xsd:attribute name="clear-text" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="bearer-token-type">
+        <xsd:attribute name="value" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="oauth2-bearer-token-type">
+        <xsd:choice minOccurs="1">
+            <xsd:element name="resource-owner-credentials" type="resource-owner-credentials-type" minOccurs="0" maxOccurs="1"/>
+        </xsd:choice>
+        <xsd:attribute name="token-endpoint-uri" type="xsd:anyURI" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="resource-owner-credentials-type">
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+        <xsd:attribute name="password" type="xsd:string" use="required" />
     </xsd:complexType>
 
     <!-- Common types -->

--- a/src/test/java/org/wildfly/security/auth/realm/token/OAuth2TokenSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/token/OAuth2TokenSecurityRealmTest.java
@@ -190,24 +190,13 @@ public class OAuth2TokenSecurityRealmTest {
         assertFalse(realmIdentity.exists());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void failMissingSSLContext() throws Exception {
-        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+        TokenSecurityRealm.builder()
                 .validator(OAuth2IntrospectValidator.builder()
                     .clientId("wildfly-elytron")
                     .clientSecret("dont_tell_me")
                     .tokenIntrospectionUrl(new URL("https://as.test.org/oauth2/token/introspect")).build())
-                .build();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void failMissingHostnameverifier() throws Exception {
-        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
-                .validator(OAuth2IntrospectValidator.builder()
-                    .clientId("wildfly-elytron")
-                    .clientSecret("dont_tell_me")
-                    .tokenIntrospectionUrl(new URL("https://as.test.org/oauth2/token/introspect"))
-                    .useSslContext(SSLContext.getDefault()).build())
                 .build();
     }
 

--- a/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
@@ -1,0 +1,399 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.sasl.oauth2;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import java.net.Authenticator;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessController;
+import java.util.Arrays;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.realm.token.TokenSecurityRealm;
+import org.wildfly.security.auth.realm.token.validator.JwtValidator;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.auth.util.ElytronAuthenticator;
+import org.wildfly.security.credential.source.OAuth2CredentialSource;
+import org.wildfly.security.sasl.test.BaseTestCase;
+import org.wildfly.security.sasl.test.SaslServerBuilder;
+import org.wildfly.security.sasl.util.AbstractSaslParticipant;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
+import org.wildfly.security.util.CodePointIterator;
+
+
+/**
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class OAuth2SaslClientTest extends BaseTestCase {
+
+    private MockWebServer server;
+
+    @Before
+    public void onBefore() throws Exception {
+        System.setProperty("wildfly.config.url", getClass().getResource("wildfly-oauth2-test-config.xml").toExternalForm());
+        server = new MockWebServer();
+
+        server.setDispatcher(createTokenEndpoint());
+
+        server.start(50831);
+    }
+
+    @After
+    public void onAfter() throws Exception {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    public void testWithResourceOwnerCredentialsUsingMatchUserInfo() throws Exception {
+        URI serverUri = URI.create("protocol://test1.org");
+        SaslClient saslClient = createSaslClientFromConfiguration(serverUri);
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        do {
+            message = saslClient.evaluateChallenge(message);
+            if (message == null) break;
+            message = saslServer.evaluateResponse(message);
+        } while (message != null);
+
+        assertTrue(saslServer.isComplete());
+        assertTrue(saslClient.isComplete());
+    }
+
+    @Test
+    public void testWithClientCredentialsUsingConfiguration() throws Exception {
+        URI serverUri = URI.create("protocol://test2.org");
+        SaslClient saslClient = createSaslClientFromConfiguration(serverUri);
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        do {
+            message = saslClient.evaluateChallenge(message);
+            if (message == null) break;
+            message = saslServer.evaluateResponse(message);
+        } while (message != null);
+
+        assertTrue(saslServer.isComplete());
+        assertTrue(saslClient.isComplete());
+    }
+
+    @Test
+    public void failedWithBearerTokenFromConfiguration() throws Exception {
+        SaslClient saslClient = createSaslClientFromConfiguration(URI.create("protocol://test3.org"));
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        message = saslClient.evaluateChallenge(message);
+
+        try {
+            message = saslServer.evaluateResponse(message);
+        } catch (SaslException e) {
+            assertTrue(e.getCause() instanceof RealmUnavailableException);
+            RealmUnavailableException cause = (RealmUnavailableException) e.getCause();
+            assertTrue(cause.getMessage().contains("ELY01114"));
+        }
+    }
+
+    @Test
+    public void failedInvalidClientCredentialsUsingConfiguration() throws Exception {
+        URI serverUri = URI.create("protocol://test4.org");
+        SaslClient saslClient = createSaslClientFromConfiguration(serverUri);
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        try {
+            do {
+                message = saslClient.evaluateChallenge(message);
+                if (message == null) break;
+                message = saslServer.evaluateResponse(message);
+            } while (message != null);
+            fail("Expected bad response from server");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getCause().getMessage().contains("ELY05125"));
+        }
+    }
+
+    @Test
+    public void testWithResourceOwnerCredentials() throws Exception {
+        URI serverUri = URI.create("protocol://test5.org");
+        SaslClient saslClient = createSaslClientFromConfiguration(serverUri);
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        do {
+            message = saslClient.evaluateChallenge(message);
+            if (message == null) break;
+            message = saslServer.evaluateResponse(message);
+        } while (message != null);
+
+        assertTrue(saslServer.isComplete());
+        assertTrue(saslClient.isComplete());
+    }
+
+    @Test
+    public void testWithBearerTokenFromConfiguration() throws Exception {
+        SaslClient saslClient = createSaslClientFromConfiguration(URI.create("protocol://test5.org"));
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        do {
+            message = saslClient.evaluateChallenge(message);
+            if (message == null) break;
+            message = saslServer.evaluateResponse(message);
+        } while (message != null);
+
+        assertTrue(saslServer.isComplete());
+        assertTrue(saslClient.isComplete());
+    }
+
+    @Test
+    public void failedResourceOwnerCredentialsUsingConfiguration() throws Exception {
+        URI serverUri = URI.create("protocol://test6.org");
+        AuthenticationContext context = AuthenticationContext.getContextManager().get();
+        AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+        AuthenticationConfiguration authenticationConfiguration = contextConfigurationClient.getAuthenticationConfiguration(serverUri, context);
+        SaslClient saslClient = contextConfigurationClient.createSaslClient(serverUri, authenticationConfiguration, Arrays.asList(SaslMechanismInformation.Names.OAUTHBEARER));
+
+        assertNotNull("OAuth2SaslClient is null", saslClient);
+
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        try {
+            do {
+                message = saslClient.evaluateChallenge(message);
+                if (message == null) break;
+                message = saslServer.evaluateResponse(message);
+            } while (message != null);
+            fail("Expected bad response from server");
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getCause().getMessage().contains("ELY05125"));
+        }
+    }
+
+    @Test
+    public void testResourceOwnerCredentialsUsingAPI() throws Exception {
+        Authenticator.setDefault(new ElytronAuthenticator());
+        AuthenticationContext context = AuthenticationContext.empty()
+                .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.EMPTY
+                        .useCredentials(OAuth2CredentialSource.builder(new URL("http://localhost:50831/token"))
+                                .useResourceOwnerPassword("alice", "dont_tell_me")
+                                .build())
+                        .allowSaslMechanisms("OAUTHBEARER"))
+                .with(MatchRule.ALL.matchHost("localhost").matchPort(50831).matchPath("/token"), AuthenticationConfiguration.EMPTY
+                        .useName("elytron_client")
+                        .usePassword("dont_tell_me"));
+        AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+        AuthenticationConfiguration configuration = contextConfigurationClient.getAuthenticationConfiguration(URI.create("http://resourceserver.com"), context);
+        SaslClient saslClient = contextConfigurationClient.createSaslClient(URI.create("http://resourceserver.com"), configuration, Arrays.asList("OAUTHBEARER"));
+        SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                .setServerName("resourceserver.comn")
+                .setProtocol("imap")
+                .addRealm("oauth-realm", createSecurityRealmMock())
+                .setDefaultRealmName("oauth-realm")
+                .build();
+
+        byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+        do {
+            message = saslClient.evaluateChallenge(message);
+            if (message == null) break;
+            message = saslServer.evaluateResponse(message);
+        } while (message != null);
+
+        assertTrue(saslServer.isComplete());
+        assertTrue(saslClient.isComplete());
+    }
+
+    @Test
+    public void failedResourceOwnerCredentialsUsingAPI() throws Exception {
+        try {
+            Authenticator.setDefault(new ElytronAuthenticator());
+            AuthenticationContext context = AuthenticationContext.empty()
+                    .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.EMPTY
+                            .useCredentials(OAuth2CredentialSource.builder(new URL("http://localhost:50831/token"))
+                                    .useResourceOwnerPassword("unknown", "dont_tell_me")
+                                    .build())
+                            .allowSaslMechanisms("OAUTHBEARER"))
+                    .with(MatchRule.ALL.matchHost("localhost").matchPort(50831).matchPath("/token"), AuthenticationConfiguration.EMPTY
+                            .useName("elytron_client")
+                            .usePassword("dont_tell_me"));
+            AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+            AuthenticationConfiguration configuration = contextConfigurationClient.getAuthenticationConfiguration(URI.create("http://resourceserver.com"), context);
+            SaslClient saslClient = contextConfigurationClient.createSaslClient(URI.create("http://resourceserver.com"), configuration, Arrays.asList("OAUTHBEARER"));
+            SaslServer saslServer = new SaslServerBuilder(OAuth2SaslServerFactory.class, SaslMechanismInformation.Names.OAUTHBEARER)
+                    .setServerName("resourceserver.comn")
+                    .setProtocol("imap")
+                    .addRealm("oauth-realm", createSecurityRealmMock())
+                    .setDefaultRealmName("oauth-realm")
+                    .build();
+
+            byte[] message = AbstractSaslParticipant.NO_BYTES;
+
+            try {
+                do {
+                    message = saslClient.evaluateChallenge(message);
+                    if (message == null) break;
+                    message = saslServer.evaluateResponse(message);
+                } while (message != null);
+                fail("Expected bad response from server");
+            } catch (Exception e) {
+                e.printStackTrace();
+                assertTrue(e.getCause().getMessage().contains("ELY05125"));
+            }
+        } finally {
+            Authenticator.setDefault(null);
+        }
+    }
+
+    private SecurityRealm createSecurityRealmMock() throws MalformedURLException {
+        return TokenSecurityRealm.builder().validator(JwtValidator.builder().build()).principalClaimName("preferred_username").build();
+    }
+
+    private Dispatcher createTokenEndpoint() {
+        return new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest recordedRequest) throws InterruptedException {
+                String body = recordedRequest.getBody().readUtf8();
+                String authorizationHeader = recordedRequest.getHeader("Authorization");
+
+                if (authorizationHeader == null) {
+                    return new MockResponse().setResponseCode(401).addHeader("WWW-Authenticate", "Basic realm=realm\"test\"");
+                }
+
+                String clientIdAndSecret = CodePointIterator.ofString(authorizationHeader.substring("Basic".length() + 1)).base64Decode().asUtf8String().drainToString();
+
+                boolean resourceOwnerCredentials = body.contains("grant_type=password");
+                boolean clientCredentials = body.contains("grant_type=client_credentials");
+
+                if (resourceOwnerCredentials
+                        && clientIdAndSecret.equals("elytron-client:dont_tell_me")
+                        && (body.contains("username=alice") || body.contains("username=jdoe"))
+                        && body.contains("password=dont_tell_me")) {
+                    JsonObjectBuilder tokenBuilder = Json.createObjectBuilder();
+
+                    tokenBuilder.add("access_token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiYXV0aC5zZXJ2ZXIiLCJhdWQiOiJmb3JfbWUiLCJleHAiOjE3NjA5OTE2MzUsInByZWZlcnJlZF91c2VybmFtZSI6Impkb2UifQ.SoPW41_mOFnKXdkwVG63agWQ2k09dEnEtTBztnxHN64");
+
+                    return new MockResponse().setBody(tokenBuilder.build().toString());
+                } else if (clientCredentials
+                        && clientIdAndSecret.equals("elytron-client:dont_tell_me")) {
+                    JsonObjectBuilder tokenBuilder = Json.createObjectBuilder();
+
+                    tokenBuilder.add("access_token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiYXV0aC5zZXJ2ZXIiLCJhdWQiOiJmb3JfbWUiLCJleHAiOjE3NjA5OTE2MzUsInByZWZlcnJlZF91c2VybmFtZSI6Impkb2UifQ.SoPW41_mOFnKXdkwVG63agWQ2k09dEnEtTBztnxHN64");
+
+                    return new MockResponse().setBody(tokenBuilder.build().toString());
+                }
+
+                return new MockResponse().setResponseCode(400);
+            }
+        };
+    }
+
+    private SaslClient createSaslClientFromConfiguration(URI serverUri) throws SaslException {
+        AuthenticationContext context = AuthenticationContext.getContextManager().get();
+        AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+        AuthenticationConfiguration authenticationConfiguration = contextConfigurationClient.getAuthenticationConfiguration(serverUri, context);
+        return contextConfigurationClient.createSaslClient(serverUri, authenticationConfiguration, Arrays.asList(SaslMechanismInformation.Names.OAUTHBEARER));
+    }
+}

--- a/src/test/resources/org/wildfly/security/sasl/oauth2/wildfly-oauth2-test-config.xml
+++ b/src/test/resources/org/wildfly/security/sasl/oauth2/wildfly-oauth2-test-config.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2016 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <net-authenticator/>
+        <authentication-rules>
+            <rule use-configuration="test1.org">
+                <match-host name="test1.org"/>
+            </rule>
+            <rule use-configuration="test2.org">
+                <match-host name="test2.org"/>
+            </rule>
+            <rule use-configuration="test3.org">
+                <match-host name="test3.org"/>
+            </rule>
+            <rule use-configuration="test4.org">
+                <match-host name="test4.org"/>
+            </rule>
+            <rule use-configuration="test5.org">
+                <match-host name="test5.org"/>
+            </rule>
+            <rule use-configuration="test6">
+                <match-host name="test6.org"/>
+            </rule>
+            <rule use-configuration="authorization-server-a">
+                <match-protocol name="http"/>
+                <match-host name="localhost"/>
+                <match-port number="50831"/>
+            </rule>
+            <rule use-configuration="authorization-server-b">
+                <match-protocol name="http"/>
+                <match-host name="127.0.0.1"/>
+                <match-port number="50831"/>
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="test1.org">
+                <credentials>
+                    <oauth2-bearer-token token-endpoint-uri="http://localhost:50831/token">
+                        <resource-owner-credentials name="jdoe" password="dont_tell_me"/>
+                    </oauth2-bearer-token>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="test2.org">
+                <credentials>
+                    <oauth2-bearer-token token-endpoint-uri="http://localhost:50831/token"/>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="test3.org">
+                <credentials>
+                    <bearer-token value="invalid_token"/>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="test4.org">
+                <credentials>
+                    <oauth2-bearer-token token-endpoint-uri="http://127.0.0.1:50831/token"/>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="test5.org">
+                <credentials>
+                    <bearer-token value="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiYXV0aC5zZXJ2ZXIiLCJhdWQiOiJmb3JfbWUiLCJleHAiOjE3NjA5OTE2MzUsInByZWZlcnJlZF91c2VybmFtZSI6Impkb2UifQ.SoPW41_mOFnKXdkwVG63agWQ2k09dEnEtTBztnxHN64"/>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="test6">
+                <credentials>
+                    <oauth2-bearer-token token-endpoint-uri="http://localhost:50831/token">
+                        <resource-owner-credentials name="alice" password="bad_password"/>
+                    </oauth2-bearer-token>
+                </credentials>
+                <allow-sasl-mechanisms names="OAUTHBEARER"/>
+            </configuration>
+            <configuration name="authorization-server-a">
+                <set-user-name name="elytron-client"/>
+                <credentials>
+                    <clear-password password="dont_tell_me"/>
+                </credentials>
+            </configuration>
+            <configuration name="authorization-server-b">
+                <set-user-name name="elytron-client"/>
+                <credentials>
+                    <clear-password password="bad_secret"/>
+                </credentials>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
The OAuth2 changes have already been reviewed and approved, this PR adds two additional commits so that the configured Provider[] is used for PasswordFactory discovery.

There are a couple of places within the configuration parsing passwords and not using configured Provider[] these will be picked up under https://issues.jboss.org/browse/ELY-837