### PR TITLE
[ELY-856][ELY-794] LdapRealm - memberOf + username wildcard

### DIFF
--- a/src/test/java/org/wildfly/security/ldap/AttributeMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/AttributeMappingSuiteChild.java
@@ -33,7 +33,7 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("firstName"), "My First Name");
-        }, AttributeMapping.fromAttribute("cn").to("firstName").build());
+        }, AttributeMapping.fromIdentity().from("cn").to("firstName").build());
     }
 
     @Test
@@ -41,7 +41,7 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name");
-        }, AttributeMapping.fromAttribute("cn").build());
+        }, AttributeMapping.fromIdentity().from("cn").build());
     }
 
     @Test
@@ -50,7 +50,7 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
             assertEquals("Expected two attributes.", 2, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name");
             assertAttributeValue(attributes.get("lastName"), "My Last Name");
-        }, AttributeMapping.fromAttribute("cn").build(), AttributeMapping.fromAttribute("sn").to("lastName").build());
+        }, AttributeMapping.fromIdentity().from("cn").build(), AttributeMapping.fromIdentity().from("sn").to("lastName").build());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected one attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("CN"), "My First Name", "My Last Name");
-        }, AttributeMapping.fromAttribute("cn").build(), AttributeMapping.fromAttribute("sn").to("CN").build());
+        }, AttributeMapping.fromIdentity().from("cn").build(), AttributeMapping.fromIdentity().from("sn").to("CN").build());
     }
 
     @Test
@@ -66,8 +66,8 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("userWithRdnAttribute", attributes -> {
             assertEquals("Expected one attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("businessArea"), "Finance", "cn=Manager,ou=Sales,dc=elytron,dc=wildfly,dc=org");
-        }, AttributeMapping.fromFilterDn("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build()
-         , AttributeMapping.fromFilterDn("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Sales,dc=elytron,dc=wildfly,dc=org").to("businessArea").build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build()
+         , AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").searchDn("ou=Sales,dc=elytron,dc=wildfly,dc=org").to("businessArea").build());
     }
 
     @Test
@@ -76,8 +76,8 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
             assertEquals("Expected one attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("roles"), "Manager", "Manager");
             assertEquals("Expected two roles.", 2, attributes.get("roles").size());
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "cn").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").to("roles").build()
-         , AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "cn").searchDn("ou=Sales,dc=elytron,dc=wildfly,dc=org").to("roles").build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").to("roles").build()
+         , AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").searchDn("ou=Sales,dc=elytron,dc=wildfly,dc=org").to("roles").build());
     }
 
     @Test
@@ -85,7 +85,7 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("userWithAttributes", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("myDn"), "uid=userWithAttributes,dc=elytron,dc=wildfly,dc=org");
-        }, AttributeMapping.fromDn().to("myDn").build());
+        }, AttributeMapping.fromIdentity().to("myDn").build());
     }
 
     @Test
@@ -93,6 +93,6 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
         assertAttributes("jduke", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("roles"), "R1", "R2");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "cn").roleRecursion(1).to("roles").build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(1).to("roles").build());
     }
 }

--- a/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
@@ -33,6 +33,6 @@ public class GroupMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes(attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))", "CN").to("Groups").build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={1}))").from("CN").to("Groups").build());
     }
 }

--- a/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
@@ -67,12 +67,12 @@ public class ModifiabilitySuiteChild {
             .identityMapping()
                 .setSearchDn("dc=elytron,dc=wildfly,dc=org")
                 .setRdnIdentifier("uid")
-                .map(AttributeMapping.fromAttribute("uid").to("userName").build(), // mapping ldap attributes to elytron attributes
-                     AttributeMapping.fromAttribute("cn").to("firstName").build(),
-                     AttributeMapping.fromAttribute("sn").to("lastName").build(),
-                     AttributeMapping.fromAttribute("description").to("description").build(),
-                     AttributeMapping.fromAttribute("telephoneNumber").to("phones").build(),
-                     AttributeMapping.fromFilterDn("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build())
+                .map(AttributeMapping.fromIdentity().from("uid").to("userName").build(), // mapping ldap attributes to elytron attributes
+                     AttributeMapping.fromIdentity().from("cn").to("firstName").build(),
+                     AttributeMapping.fromIdentity().from("sn").to("lastName").build(),
+                     AttributeMapping.fromIdentity().from("description").to("description").build(),
+                     AttributeMapping.fromIdentity().from("telephoneNumber").to("phones").build(),
+                     AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build())
                 .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
                 .setNewIdentityAttributes(attributes)
                 .setIteratorFilter("(uid=*)")

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
@@ -34,7 +34,15 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithMemberOfRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, AttributeMapping.fromAttribute("memberOf").extractRdn("CN").to(RoleDecoder.KEY_ROLES).build());
+        }, AttributeMapping.fromIdentity().from("memberOf").extractRdn("CN").to(RoleDecoder.KEY_ROLES).build());
+    }
+
+    @Test
+    public void testRoleMappingWithMemberOfAttribute() throws Exception {
+        assertAttributes("userWithMemberOfRoles", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDNDescription");
+        }, AttributeMapping.fromReference("memberOf").from("description").to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test
@@ -42,7 +50,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").searchDn("ou=Roles,dc=elytron,dc=wildfly,dc=org").to(RoleDecoder.KEY_ROLES).build()) ;
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("CN").searchDn("ou=Roles,dc=elytron,dc=wildfly,dc=org").to(RoleDecoder.KEY_ROLES).build()) ;
     }
 
     @Test
@@ -50,7 +58,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromRolesOu", "RoleFromBaseDN");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES).build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("CN").to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test
@@ -58,6 +66,6 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
         assertAttributes("userWithRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))", "CN").to(RoleDecoder.KEY_ROLES).searchRecursively(false).build());
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("CN").to(RoleDecoder.KEY_ROLES).searchRecursively(false).build());
     }
 }

--- a/src/test/resources/ldap/elytron-role-mapping-tests.ldif
+++ b/src/test/resources/ldap/elytron-role-mapping-tests.ldif
@@ -5,6 +5,7 @@ objectClass: top
 objectClass: groupOfNames
 cn: RoleFromBaseDN
 member: uid=userWithRoles,dc=elytron,dc=wildfly,dc=org
+description: RoleFromBaseDNDescription
 
 dn: ou=Roles,dc=elytron,dc=wildfly,dc=org
 objectclass: top


### PR DESCRIPTION
Subsystem part: https://github.com/wildfly-security/elytron-subsystem/pull/347

LdapRealm:
* [ELY-856] added "reference" param (alternative to filter - use value in user LDAP attribute as DN of entry, from where is loaded value of identity attribute - for "memberOf")
* refactored AttributeMapping builder to keep simple
* fixed search identity by DN - added "recursive-search" checking
* fixed role-recursion: prevent cycling when groups contains each other (before recursion-limit, no multiple occurences of the same role) (as Picketbox support it)
* [ELY-794] changed wildcards in attribute filter: {0} for username, {1} for user DN (to be identical with Picketbox)