### PR TITLE
[ELY-799] Elytron ExternalSaslServerFactory returns EXTERNAL mechanism name when Sasl.POLICY_PASS_CREDENTIALS provided

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClientFactory.java
@@ -68,6 +68,9 @@ public final class ExternalSaslClientFactory implements SaslClientFactory {
         if ("true".equals(props.get(Sasl.POLICY_NODICTIONARY))) {
             return WildFlySasl.NO_NAMES;
         }
+        if ("true".equals(props.get(Sasl.POLICY_PASS_CREDENTIALS))) {
+            return WildFlySasl.NO_NAMES;
+        }
         return Arrays2.of(SaslMechanismInformation.Names.EXTERNAL);
     }
 }

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServerFactory.java
@@ -63,6 +63,9 @@ public final class ExternalSaslServerFactory implements SaslServerFactory {
         if ("true".equals(props.get(Sasl.POLICY_NODICTIONARY))) {
             return WildFlySasl.NO_NAMES;
         }
+        if ("true".equals(props.get(Sasl.POLICY_PASS_CREDENTIALS))) {
+            return WildFlySasl.NO_NAMES;
+        }
         return Arrays2.of(SaslMechanismInformation.Names.EXTERNAL);
     }
 }

--- a/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
@@ -58,7 +58,7 @@ public class ExternalSaslClientTest extends BaseTestCase {
     private static final String[] MECHANISMS_WITHOUT_EXTERNAL = new String[] { "DIGEST-MD5", "TEST" };
 
     @Test
-    @Ignore("ELY-799")
+    @Ignore("ELY-788")
     public void testMechanismNames() throws Exception {
         SaslClientFactory factory = obtainSaslClientFactory(ExternalSaslClientFactory.class);
         assertNotNull("SaslServerFactory not registered", factory);

--- a/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
+++ b/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
@@ -69,7 +69,7 @@ public class ExternalSaslServerTest extends BaseTestCase {
     };
 
     @Test
-    @Ignore("ELY-799,ELY-788")
+    @Ignore("ELY-788")
     public void testMechanismNames() throws Exception {
         SaslServerFactory factory = obtainSaslServerFactory(ExternalSaslServerFactory.class);
         assertNotNull("SaslServerFactory not registered", factory);


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-799
