### PR TITLE
[ELY-869] properties realm - users in roles file only

### DIFF
--- a/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
@@ -206,6 +206,25 @@ public class LegacyPropertiesSecurityRealmTest {
     }
 
     @Test
+    public void testGroups() throws Exception {
+        SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
+                .setUsersStream(this.getClass().getResourceAsStream("users.properties"))
+                .setGroupsStream(this.getClass().getResourceAsStream("groups.properties"))
+                .setGroupsAttribute("groups")
+                .build();
+
+        RealmIdentity elytronIdentity = realm.getRealmIdentity(new NamePrincipal("elytron"));
+        assertTrue(elytronIdentity.getAuthorizationIdentity().getAttributes().get("groups").contains("role1"));
+        assertTrue(elytronIdentity.getAuthorizationIdentity().getAttributes().get("groups").contains("role2"));
+        elytronIdentity.dispose();
+
+        RealmIdentity rolemanIdentity = realm.getRealmIdentity(new NamePrincipal("roleman"));
+        assertTrue(rolemanIdentity.getAuthorizationIdentity().getAttributes().get("groups").contains("role3"));
+        assertTrue(rolemanIdentity.getAuthorizationIdentity().getAttributes().get("groups").contains("role4"));
+        rolemanIdentity.dispose();
+    }
+
+    @Test
     public void testPlainFileSpecialChars() throws Exception {
         SecurityRealm realm = LegacyPropertiesSecurityRealm.builder()
                 .setUsersStream(this.getClass().getResourceAsStream("clear-special.properties"))

--- a/src/test/resources/org/wildfly/security/auth/realm/groups.properties
+++ b/src/test/resources/org/wildfly/security/auth/realm/groups.properties
@@ -1,0 +1,2 @@
+elytron=role1,role2
+roleman=role3,role4


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-869

* Loading users from groups file when they dont exist in users file.
* Allowed property realm without users file.