### PR TITLE
[ELY-876] Support for PKCS12 KeyStore format in KeyStoreCredentialStore

### DIFF
--- a/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -156,6 +156,7 @@ public class WildFlyElytronProvider extends Provider {
         putSaslMechanismImplementations();
         putCredentialStoreProviderImplementations();
         putAlgorithmParametersImplementations();
+        put("Alg.Alias.Data.OID.1.2.840.113549.1.7.1", "Data");
     }
 
     private void putAlgorithmParametersImplementations() {

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -127,6 +127,9 @@ import org.wildfly.security.x500.X500;
  * </ul>
  */
 public final class KeyStoreCredentialStore extends CredentialStoreSpi {
+
+    private static final String DATA_OID = "1.2.840.113549.1.7.1";
+
     /**
      * The name of this credential store implementation.
      */
@@ -174,7 +177,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 final KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getAlgorithm());
                 final X509EncodedKeySpec keySpec = keyFactory.getKeySpec(keyFactory.translateKey(publicKey), X509EncodedKeySpec.class);
                 final byte[] encoded = keySpec.getEncoded();
-                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(encoded, "xxx"));
+                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(encoded, DATA_OID));
             } else if (credentialClass == KeyPairCredential.class) {
                 final KeyPair keyPair = credential.castAndApply(KeyPairCredential.class, KeyPairCredential::getKeyPair);
                 final PublicKey publicKey = keyPair.getPublic();
@@ -190,7 +193,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 encoder.writeEncoded(publicSpec.getEncoded());
                 encoder.writeEncoded(privateSpec.getEncoded());
                 encoder.endSequence();
-                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), "xxx"));
+                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), DATA_OID));
             } else if (credentialClass == X509CertificateChainPublicCredential.class) {
                 final X509Certificate[] x509Certificates = credential.castAndApply(X509CertificateChainPublicCredential.class, X509CertificateChainPublicCredential::getCertificateChain);
                 final ByteStringBuilder b = new ByteStringBuilder();
@@ -201,13 +204,13 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     encoder.writeEncoded(x509Certificate.getEncoded());
                 }
                 encoder.endSequence();
-                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), "xxx"));
+                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), DATA_OID));
             } else if (credentialClass == X509CertificateChainPrivateCredential.class) {
                 @SuppressWarnings("ConstantConditions")
                 X509CertificateChainPrivateCredential cred = (X509CertificateChainPrivateCredential) credential;
                 entry = new KeyStore.PrivateKeyEntry(cred.getPrivateKey(), cred.getCertificateChain());
             } else if (credentialClass == BearerTokenCredential.class) {
-                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(credential.castAndApply(BearerTokenCredential.class, c -> c.getToken().getBytes(StandardCharsets.UTF_8)), "xxx"));
+                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(credential.castAndApply(BearerTokenCredential.class, c -> c.getToken().getBytes(StandardCharsets.UTF_8)), DATA_OID));
             } else if (credentialClass == PasswordCredential.class) {
                 final Password password = credential.castAndApply(PasswordCredential.class, PasswordCredential::getPassword);
                 final String algorithm = password.getAlgorithm();
@@ -307,7 +310,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                         }
                     }
                 }
-                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), "xxx"));
+                entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(b.toArray(), DATA_OID));
             } else {
                 throw log.unsupportedCredentialType(credentialClass);
             }

--- a/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
+++ b/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.credential.store.impl;
+
+import java.io.File;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStore.CredentialSourceProtectionParameter;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class KeyStoreCredentialStoreTest {
+
+    @Parameter
+    public String keyStoreFormat;
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private final char[] keyStorePassword = "The quick brown fox jumped over the lazy dog".toCharArray();
+
+    private PasswordFactory passwordFactory;
+
+    private String providerName;
+
+    private char[] secretPassword;
+
+    private PasswordCredential storedCredential;
+
+    private CredentialSourceProtectionParameter storeProtection;
+
+    @Parameters(name = "format={0}")
+    public static Iterable<Object[]> keystoreFormats() {
+        return Arrays.asList(new Object[] {"JCEKS"}, new Object[] {"PKCS12"});
+    }
+
+    @Before
+    public void installWildFlyElytronProvider() throws Exception {
+        final WildFlyElytronProvider provider = new WildFlyElytronProvider();
+
+        providerName = provider.getName();
+
+        Security.addProvider(provider);
+
+        passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+        final Password password = passwordFactory.generatePassword(new ClearPasswordSpec(keyStorePassword));
+        final Credential credential = new PasswordCredential(password);
+        final CredentialSource credentialSource = IdentityCredentials.NONE.withCredential(credential);
+
+        storeProtection = new CredentialStore.CredentialSourceProtectionParameter(credentialSource);
+
+        secretPassword = "this is a password".toCharArray();
+
+        final Password secret = passwordFactory.generatePassword(new ClearPasswordSpec(secretPassword));
+
+        storedCredential = new PasswordCredential(secret);
+    }
+
+    @After
+    public void removeWildFlyElytronProvider() {
+        Security.removeProvider(providerName);
+    }
+
+    @Test
+    public void shouldSupportKeyStoreFormat() throws Exception {
+        final KeyStoreCredentialStore originalStore = new KeyStoreCredentialStore();
+
+        final File keyStoreFile = new File(tmp.getRoot(), "keystore");
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("location", keyStoreFile.getAbsolutePath());
+        attributes.put("keyStoreType", keyStoreFormat);
+
+        originalStore.initialize(attributes, storeProtection);
+
+        originalStore.store("key", storedCredential, null);
+
+        originalStore.flush();
+
+        assertTrue(keyStoreFile.exists());
+
+        final KeyStoreCredentialStore retrievalStore = new KeyStoreCredentialStore();
+        attributes.put("modifiable", "false");
+
+        retrievalStore.initialize(attributes, storeProtection);
+
+        final PasswordCredential retrievedCredential = retrievalStore.retrieve("key", PasswordCredential.class, null,
+                null, null);
+
+        final ClearPasswordSpec retrievedPassword = passwordFactory.getKeySpec(retrievedCredential.getPassword(),
+                ClearPasswordSpec.class);
+
+        assertArrayEquals(secretPassword, retrievedPassword.getEncodedPassword());
+    }
+}


### PR DESCRIPTION
Support for `PKCS12` KeyStore in format in SunJCE provider requires that
the algorithm id is one of the known OIDs registered with one of the
security providers. Using an unknown OID results in
`java.security.NoSuchAlgorithmException`.

It seems fitting that the algorithm id of `SecretKey` stored in the
underlying KeyStore would be PKCS#7 data (`1.2.840.113549.1.7.1`).

`WildFlyElytronProvider` was extended to add PKCS#7 Data OID as one of
the algorithm identifiers it provides an alias for, which would in turn
be picked up by the `PKCS12` KeyStore implementation.

`KeyStoreCredentialStore` is now using this PKCS#7 Data OID to specify
`SecretKey` type instead of `xxx`.