### PR TITLE
[ELY-875] / [ELY-877] Ongoing SPNEGO Credential Delegation

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -787,6 +787,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 3030, value = "I/O operation failed: closed")
     IOException closed();
 
+    @Message(id = 3031, value = "Too many KerberosTicket instances in private credentials")
+    GeneralSecurityException tooManyKerberosTicketsFound();
+
     /* ssl package */
 
     @Message(id = 4001, value = "No algorithm found matching TLS/SSL protocol selection criteria")

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -61,7 +61,7 @@ import org.ietf.jgss.GSSCredential;
 import org.wildfly.common.Assert;
 import org.wildfly.security.FixedSecurityFactory;
 import org.wildfly.security.SecurityFactory;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.credential.source.CallbackHandlerCredentialSource;
 import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.auth.callback.CallbackUtil;
@@ -494,7 +494,7 @@ public abstract class AuthenticationConfiguration {
      * @return the new configuration
      */
     public final AuthenticationConfiguration useGSSCredential(GSSCredential credential) {
-        return credential == null ? this : useCredentials(getCredentialSource().with(IdentityCredentials.NONE.withCredential(new GSSCredentialCredential(credential))));
+        return credential == null ? this : useCredentials(getCredentialSource().with(IdentityCredentials.NONE.withCredential(new GSSKerberosCredential(credential))));
     }
 
     /**

--- a/src/main/java/org/wildfly/security/credential/GSSCredentialCredential.java
+++ b/src/main/java/org/wildfly/security/credential/GSSCredentialCredential.java
@@ -18,14 +18,17 @@
 
 package org.wildfly.security.credential;
 
+import javax.security.auth.kerberos.KerberosTicket;
+
 import org.ietf.jgss.GSSCredential;
 import org.wildfly.common.Assert;
 
 /**
- * A credential for holding a {@code GSSCredential}.
+ * A credential for holding a {@code GSSCredential} and optionally an associated {@link KerberosTicket}.
  */
 public final class GSSCredentialCredential implements Credential {
     private final GSSCredential gssCredential;
+    private final KerberosTicket kerberosTicket;
 
     /**
      * Construct a new instance.
@@ -33,8 +36,19 @@ public final class GSSCredentialCredential implements Credential {
      * @param gssCredential the GSS credential (may not be {@code null})
      */
     public GSSCredentialCredential(final GSSCredential gssCredential) {
+        this(gssCredential, null);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param gssCredential the GSS credential (may not be {@code null})
+     * @param kerberosTicket the associated Kerberos ticket which may be {@code null}.
+     */
+    public GSSCredentialCredential(final GSSCredential gssCredential, final KerberosTicket kerberosTicket) {
         Assert.checkNotNullParam("gssCredential", gssCredential);
         this.gssCredential = gssCredential;
+        this.kerberosTicket = kerberosTicket;
     }
 
     /**
@@ -44,6 +58,15 @@ public final class GSSCredentialCredential implements Credential {
      */
     public GSSCredential getGssCredential() {
         return gssCredential;
+    }
+
+    /**
+     * Get the associated kerberos ticket.
+     *
+     * @return the associated kerberos ticker or {@code null} if one is not associated.
+     */
+    public KerberosTicket getKerberosTicket() {
+        return kerberosTicket;
     }
 
     public GSSCredentialCredential clone() {

--- a/src/main/java/org/wildfly/security/credential/GSSKerberosCredential.java
+++ b/src/main/java/org/wildfly/security/credential/GSSKerberosCredential.java
@@ -26,7 +26,7 @@ import org.wildfly.common.Assert;
 /**
  * A credential for holding a {@code GSSCredential} and optionally an associated {@link KerberosTicket}.
  */
-public final class GSSCredentialCredential implements Credential {
+public final class GSSKerberosCredential implements Credential {
     private final GSSCredential gssCredential;
     private final KerberosTicket kerberosTicket;
 
@@ -35,7 +35,7 @@ public final class GSSCredentialCredential implements Credential {
      *
      * @param gssCredential the GSS credential (may not be {@code null})
      */
-    public GSSCredentialCredential(final GSSCredential gssCredential) {
+    public GSSKerberosCredential(final GSSCredential gssCredential) {
         this(gssCredential, null);
     }
 
@@ -45,7 +45,7 @@ public final class GSSCredentialCredential implements Credential {
      * @param gssCredential the GSS credential (may not be {@code null})
      * @param kerberosTicket the associated Kerberos ticket which may be {@code null}.
      */
-    public GSSCredentialCredential(final GSSCredential gssCredential, final KerberosTicket kerberosTicket) {
+    public GSSKerberosCredential(final GSSCredential gssCredential, final KerberosTicket kerberosTicket) {
         Assert.checkNotNullParam("gssCredential", gssCredential);
         this.gssCredential = gssCredential;
         this.kerberosTicket = kerberosTicket;
@@ -69,7 +69,7 @@ public final class GSSCredentialCredential implements Credential {
         return kerberosTicket;
     }
 
-    public GSSCredentialCredential clone() {
+    public GSSKerberosCredential clone() {
         return this;
     }
 

--- a/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
@@ -49,7 +49,7 @@ import org.ietf.jgss.GSSName;
 import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.auth.callback.IdentityCredentialCallback;
 import org.wildfly.security.auth.callback.ServerCredentialCallback;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpScope;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
@@ -98,14 +98,14 @@ public class SpnegoAuthenticationMechanism implements HttpServerAuthenticationMe
         }
 
         if (gssContext == null) { // init GSSContext
-            ServerCredentialCallback gssCredentialCallback = new ServerCredentialCallback(GSSCredentialCredential.class);
+            ServerCredentialCallback gssCredentialCallback = new ServerCredentialCallback(GSSKerberosCredential.class);
             final GSSCredential serviceGssCredential;
 
             try {
                 log.trace("Obtaining GSSCredential for the service from callback handler...");
                 callbackHandler.handle(new Callback[] { gssCredentialCallback });
-                serviceGssCredential = gssCredentialCallback.applyToCredential(GSSCredentialCredential.class, GSSCredentialCredential::getGssCredential);
-                kerberosTicket = gssCredentialCallback.applyToCredential(GSSCredentialCredential.class, GSSCredentialCredential::getKerberosTicket);
+                serviceGssCredential = gssCredentialCallback.applyToCredential(GSSKerberosCredential.class, GSSKerberosCredential::getGssCredential);
+                kerberosTicket = gssCredentialCallback.applyToCredential(GSSKerberosCredential.class, GSSKerberosCredential::getKerberosTicket);
             } catch (IOException | UnsupportedCallbackException e) {
                 throw log.mechCallbackHandlerFailedForUnknownReason(SPNEGO_NAME, e).toHttpAuthenticationException();
             }
@@ -168,7 +168,7 @@ public class SpnegoAuthenticationMechanism implements HttpServerAuthenticationMe
                     final GSSCredential gssCredential = gssContext.getCredDelegState() ? gssContext.getDelegCred() : null;
                     if (gssCredential != null) {
                         log.trace("Associating delegated GSSCredential with identity.");
-                        handleCallback(new IdentityCredentialCallback(new GSSCredentialCredential(gssCredential), true));
+                        handleCallback(new IdentityCredentialCallback(new GSSKerberosCredential(gssCredential), true));
                     } else {
                         log.trace("No GSSCredential delegated from client.");
                     }
@@ -245,7 +245,7 @@ public class SpnegoAuthenticationMechanism implements HttpServerAuthenticationMe
                 GSSCredential gssCredential = gssContext.getDelegCred();
                 if (gssCredential != null) {
                     log.trace("Associating delegated GSSCredential with identity.");
-                    handleCallback(new IdentityCredentialCallback(new GSSCredentialCredential(gssCredential), true));
+                    handleCallback(new IdentityCredentialCallback(new GSSKerberosCredential(gssCredential), true));
                 } else {
                     log.trace("No GSSCredential delegated from client.");
                 }
@@ -278,7 +278,7 @@ public class SpnegoAuthenticationMechanism implements HttpServerAuthenticationMe
                 try {
                     GSSCredential credential = gssContext.getDelegCred();
                     log.tracef("Credential delegation enabled, delegated credential = %s", credential);
-                    MechanismUtil.handleCallbacks(SPNEGO_NAME, callbackHandler, new IdentityCredentialCallback(new GSSCredentialCredential(credential), true));
+                    MechanismUtil.handleCallbacks(SPNEGO_NAME, callbackHandler, new IdentityCredentialCallback(new GSSKerberosCredential(credential), true));
                 } catch (UnsupportedCallbackException ignored) {
                     // ignored
                 } catch (AuthenticationMechanismException e) {

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslClient.java
@@ -38,7 +38,7 @@ import org.ietf.jgss.Oid;
 import org.wildfly.common.Assert;
 import org.wildfly.security.asn1.DERDecoder;
 import org.wildfly.security.auth.callback.CredentialCallback;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.AbstractSaslClient;
 import org.wildfly.security.sasl.util.StringPrep;
@@ -87,11 +87,11 @@ final class Gs2SaslClient extends AbstractSaslClient {
 
         // Attempt to obtain a credential
         GSSCredential credential = null;
-        CredentialCallback credentialCallback = new CredentialCallback(GSSCredentialCredential.class);
+        CredentialCallback credentialCallback = new CredentialCallback(GSSKerberosCredential.class);
 
         try {
             tryHandleCallbacks(credentialCallback);
-            credential = credentialCallback.applyToCredential(GSSCredentialCredential.class, GSSCredentialCredential::getGssCredential);
+            credential = credentialCallback.applyToCredential(GSSKerberosCredential.class, GSSKerberosCredential::getGssCredential);
         } catch (UnsupportedCallbackException e) {
             log.trace("Unable to obtain GSSCredential, ignored (act as the default initiator principal instead)", e);
         }

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
@@ -37,7 +37,7 @@ import org.wildfly.common.Assert;
 import org.wildfly.security.asn1.ASN1Exception;
 import org.wildfly.security.asn1.DEREncoder;
 import org.wildfly.security.auth.callback.CredentialCallback;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.sasl.util.AbstractSaslServer;
 import org.wildfly.security.util.ByteIterator;
 import org.wildfly.security.util.ByteStringBuilder;
@@ -77,11 +77,11 @@ final class Gs2SaslServer extends AbstractSaslServer {
 
         // Attempt to obtain a credential
         GSSCredential credential;
-        CredentialCallback credentialCallback = new CredentialCallback(GSSCredentialCredential.class);
+        CredentialCallback credentialCallback = new CredentialCallback(GSSKerberosCredential.class);
 
         try {
             tryHandleCallbacks(credentialCallback);
-            credential = credentialCallback.applyToCredential(GSSCredentialCredential.class, GSSCredentialCredential::getGssCredential);
+            credential = credentialCallback.applyToCredential(GSSKerberosCredential.class, GSSKerberosCredential::getGssCredential);
         } catch (UnsupportedCallbackException | IllegalStateException | SaslException e) {
             try {
                 String localNameStr = protocol + "@" + serverName;

--- a/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
+++ b/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
@@ -37,7 +37,7 @@ import org.ietf.jgss.MessageProp;
 import org.jboss.logging.Logger;
 import org.wildfly.common.Assert;
 import org.wildfly.security._private.ElytronMessages;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
@@ -82,9 +82,9 @@ class GssapiClient extends AbstractGssapiMechanism implements SaslClient {
         if (credObj instanceof GSSCredential) {
             log.trace("Using GSSCredential supplied in properties.");
             credential = (GSSCredential) credObj;
-        } else if (credObj instanceof GSSCredentialCredential) {
+        } else if (credObj instanceof GSSKerberosCredential) {
             log.trace("Using GSSCredential supplied in properties.");
-            credential = ((GSSCredentialCredential) credObj).getGssCredential();
+            credential = ((GSSKerberosCredential) credObj).getGssCredential();
         }
 
         // Better way to obtain the credential if we don't have one?

--- a/src/main/java/org/wildfly/security/sasl/util/SaslMechanismInformation.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SaslMechanismInformation.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.wildfly.security.credential.Credential;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.X509CertificateChainPublicCredential;
 import org.wildfly.security.evidence.AlgorithmEvidence;
@@ -222,7 +222,7 @@ public final class SaslMechanismInformation {
     static final Set<Class<? extends Credential>> JUST_X509 = singleton(X509CertificateChainPrivateCredential.class);
     static final Set<Class<? extends Credential>> X_509_PUBLIC_OR_PRIVATE = nSet(X509CertificateChainPublicCredential.class, X509CertificateChainPrivateCredential.class);
     static final Set<Class<? extends Credential>> JUST_PASSWORD = singleton(PasswordCredential.class);
-    static final Set<Class<? extends Credential>> JUST_GSS = singleton(GSSCredentialCredential.class);
+    static final Set<Class<? extends Credential>> JUST_GSS = singleton(GSSKerberosCredential.class);
 
     static final Set<Class<? extends Evidence>> JUST_PASSWORD_EVIDENCE = singleton(PasswordGuessEvidence.class);
 

--- a/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
+++ b/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
@@ -74,7 +74,7 @@ import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
 import org.wildfly.security.auth.realm.ldap.SimpleDirContextFactoryBuilder;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.util.RegexNameRewriter;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.gssapi.GssapiTestSuite;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -520,7 +520,7 @@ public class Gs2SuiteChild extends BaseTestCase {
             builder.setChannelBinding(bindingType, bindingData);
         }
         if (credential != null) {
-            builder.setCredential(new GSSCredentialCredential(credential));
+            builder.setCredential(new GSSKerberosCredential(credential));
         }
         try {
             return Subject.doAs(serverSubject, new PrivilegedExceptionAction<SaslServer>() {

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GSSSecurityFactorySuiteChild.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GSSSecurityFactorySuiteChild.java
@@ -25,7 +25,7 @@ import org.ietf.jgss.GSSCredential;
 import org.junit.Test;
 import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.auth.util.GSSCredentialSecurityFactory;
-import org.wildfly.security.credential.GSSCredentialCredential;
+import org.wildfly.security.credential.GSSKerberosCredential;
 
 /**
  * Testing of obtaining a {@link GSSCredential} from the {@link GSSSecurityFactorySuiteChild}.
@@ -36,7 +36,7 @@ public class GSSSecurityFactorySuiteChild {
 
     @Test
     public void testCreate() throws Exception {
-        SecurityFactory<GSSCredentialCredential> factory = GSSCredentialSecurityFactory.builder()
+        SecurityFactory<GSSKerberosCredential> factory = GSSCredentialSecurityFactory.builder()
                 .setPrincipal("sasl/test_server_1@WILDFLY.ORG")
                 .addMechanismOid(GSSCredentialSecurityFactory.KERBEROS_V5)
                 .addMechanismOid(GSSCredentialSecurityFactory.SPNEGO)
@@ -45,7 +45,7 @@ public class GSSSecurityFactorySuiteChild {
                 .setDebug(true)
                 .build();
 
-        GSSCredentialCredential credentialCredential = factory.create();
+        GSSKerberosCredential credentialCredential = factory.create();
         assertNotNull("credentialCredential", credentialCredential);
         GSSCredential credential = credentialCredential.getGssCredential();
         assertNotNull("credential", credential);


### PR DESCRIPTION
To receive a delegated credential a KerberosTicket is required, allow this to be optionally associated with the GSSCredentialCredential.

Within the SpnegoAuthenticationMechanism assume this ticket is available on the ACC, then associate any delegated credential with the identity.