### PR TITLE
[ELY-869][ELY-760][ELY-881] LdapRealm fixes

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -383,7 +383,7 @@ public interface ElytronMessages extends BasicLogger {
     void warnInvalidAliasForMissingMechanismDatabaseEntry(String value, String name);
 
     @Message(id = 1078, value = "Ldap-backed realm failed to obtain identity \"%s\" from server")
-    RuntimeException ldapRealmFailedObtainIdentityFromServer(String identity, @Cause Throwable cause);
+    RealmUnavailableException ldapRealmFailedObtainIdentityFromServer(String identity, @Cause Throwable cause);
 
     @Message(id = 1079, value = "Ldap-backed realm failed to obtain attributes for entry [%s]")
     RuntimeException ldapRealmFailedObtainAttributes(String dn, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/auth/realm/AggregateSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/AggregateSecurityRealm.java
@@ -154,7 +154,7 @@ public final class AggregateSecurityRealm implements SecurityRealm {
         }
 
         public AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {
-            return authorizationIdentity.exists() ? authorizationIdentity.getAuthorizationIdentity() : AuthorizationIdentity.EMPTY;
+            return authorizationIdentity.getAuthorizationIdentity();
         }
 
         public void dispose() {

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/AttributeMapping.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 
 import org.wildfly.common.Assert;
 
+import javax.naming.directory.DirContext;
+
 /**
  * Definition of a mapping from LDAP to an Elytron attribute.
  *
@@ -30,6 +32,7 @@ public class AttributeMapping {
 
     public static final String DEFAULT_FILTERED_NAME = "filtered";
     public static final String DEFAULT_DN_NAME = "dn";
+    public static final String DEFAULT_ROLE_RECURSION_ATTRIBUTE = "CN";
 
     private final String ldapName;
     private final String searchDn;
@@ -39,6 +42,7 @@ public class AttributeMapping {
     private final String name;
     private final String rdn;
     private final int roleRecursionDepth;
+    private final String roleRecursionName;
 
     String getLdapName() {
         return ldapName;
@@ -81,13 +85,19 @@ public class AttributeMapping {
         return roleRecursionDepth;
     }
 
+    String getRoleRecursionName() {
+        return roleRecursionName;
+    }
+
     boolean isFilteredOrReference() {
         return filter != null || reference != null;
     }
 
     /**
      * Determine which context should be used to search filtered/referenced entry.
-     * Has effect if the identity is behind referral, on different server.
+     * Has effect if the identity is behind referral, in different context.
+     * If {@code true}, attribute will be searched in context, where was the identity found.
+     * {@link DirContext} of the LdapRealm will be used otherwise.
      */
     boolean searchInIdentityContext() {
         return reference != null;
@@ -145,6 +155,7 @@ public class AttributeMapping {
         private String name;
         private String rdn;
         private int roleRecursionDepth;
+        private String roleRecursionName;
 
         /**
          * Set type of RDN, whose value will be used as identity attribute value.
@@ -168,6 +179,23 @@ public class AttributeMapping {
         public Builder from(String ldapName) {
             Assert.checkNotNullParam("ldapName", ldapName);
             this.ldapName = ldapName.toUpperCase(Locale.ROOT);
+            return this;
+        }
+
+        /**
+         * Set name of the attribute in LDAP from where are {0} in role recursion obtained.
+         * Wildcard {0} is in filter replaced by user name usually. When role recursion is used,
+         * roles of roles are searched using the same filter, but {0} is replaced by
+         * role name - obtained from role entry attribute specified by this method.
+         *
+         * If not specified, attribute specified in {@link #from(String)} is used.
+         *
+         * @param roleRecursionName the name of the attribute in LDAP which will replace {0} in filter while role recursion
+         * @return this builder
+         */
+        public Builder roleRecursionName(String roleRecursionName) {
+            Assert.checkNotNullParam("roleRecursionName", roleRecursionName);
+            this.roleRecursionName = roleRecursionName.toUpperCase(Locale.ROOT);
             return this;
         }
 
@@ -222,11 +250,14 @@ public class AttributeMapping {
             if (name == null) {
                 name = ldapName != null ? ldapName : (filter != null ? DEFAULT_FILTERED_NAME : DEFAULT_DN_NAME);
             }
-            return new AttributeMapping(searchDn, recursiveSearch, filter, reference, ldapName, name, rdn, roleRecursionDepth);
+            if (roleRecursionName == null) {
+                roleRecursionName = ldapName != null ? ldapName : DEFAULT_ROLE_RECURSION_ATTRIBUTE;
+            }
+            return new AttributeMapping(searchDn, recursiveSearch, filter, reference, ldapName, name, rdn, roleRecursionDepth, roleRecursionName);
         }
     }
 
-    AttributeMapping(String searchDn, boolean recursiveSearch, String filter,  String reference, String ldapName, String name, String rdn, int roleRecursionDepth) {
+    AttributeMapping(String searchDn, boolean recursiveSearch, String filter,  String reference, String ldapName, String name, String rdn, int roleRecursionDepth, String roleRecursionName) {
         this.searchDn = searchDn;
         this.recursiveSearch = recursiveSearch;
         this.filter = filter;
@@ -235,6 +266,7 @@ public class AttributeMapping {
         this.name = name;
         this.rdn = rdn;
         this.roleRecursionDepth = roleRecursionDepth;
+        this.roleRecursionName = roleRecursionName;
     }
 
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -364,7 +364,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             try {
                 for (CredentialLoader loader : credentialLoaders) {
                     if (loader.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported()) {
-                        IdentityCredentialLoader icl = loader.forIdentity(dirContext, this.identity.getDistinguishedName());
+                        IdentityCredentialLoader icl = loader.forIdentity(dirContext, identity.getDistinguishedName());
 
                         Credential credential = icl.getCredential(credentialType, algorithmName, providers);
                         if (credentialType.isInstance(credential)) {
@@ -395,7 +395,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                     final String algorithmName = credential instanceof AlgorithmCredential ? ((AlgorithmCredential) credential).getAlgorithm() : null;
                     boolean supported = false;
                     for (CredentialPersister persister : credentialPersisters) {
-                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, this.identity.getDistinguishedName());
+                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
                         if (icp.getCredentialPersistSupport(credentialType, algorithmName)) {
                             supported = true;
                         }
@@ -407,7 +407,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
                 // clear
                 for (CredentialPersister persister : credentialPersisters) {
-                    IdentityCredentialPersister icp = persister.forIdentity(dirContext, this.identity.getDistinguishedName());
+                    IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
                     icp.clearCredentials();
                 }
 
@@ -416,7 +416,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                     final Class<? extends Credential> credentialType = credential.getClass();
                     final String algorithmName = credential instanceof AlgorithmCredential ? ((AlgorithmCredential) credential).getAlgorithm() : null;
                     for (CredentialPersister persister : credentialPersisters) {
-                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, this.identity.getDistinguishedName());
+                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
                         if (icp.getCredentialPersistSupport(credentialType, algorithmName)) {
                             icp.persistCredential(credential);
                             // next credential
@@ -442,10 +442,62 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override
         public AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {
-            if (!exists()) {
-                return AuthorizationIdentity.EMPTY;
+            return AuthorizationIdentity.basicIdentity(getAttributes());
+        }
+
+        @Override
+        public org.wildfly.security.authz.Attributes getAttributes() throws RealmUnavailableException {
+            if (identity == null) {
+                identity = getIdentity();
             }
-            return AuthorizationIdentity.basicIdentity(this.identity.attributes);
+            DirContext context = null;
+            try {
+                context = dirContextSupplier.get();
+                DirContext identityContext = context;
+                Optional<SearchResult> optionalResult = Optional.empty();
+
+                if (identity != null && identity.distinguishedName != null) {
+                    LdapSearch search = new LdapSearch(identity.distinguishedName);
+                    search.setReturningAttributes(
+                            identityMapping.attributes.stream()
+                                    .map(AttributeMapping::getIdentityLdapName)
+                                    .filter(Objects::nonNull)
+                                    .toArray(String[]::new));
+
+                    try (Stream<SearchResult> results = search.search(context)) {
+                        optionalResult = results.findFirst();
+                    }
+                    identityContext = search.getContext(); // context where was the identity found
+                }
+
+                // now we have identity entry or it does not exists in LDAP
+                SearchResult result = optionalResult.orElse(null);
+                MapAttributes attributes = new MapAttributes();
+
+                attributes.addAll(extractSimpleAttributes(result));
+                attributes.addAll(extractFilteredAttributes(result, context, identityContext));
+
+                if (log.isDebugEnabled()) {
+                    log.debugf("Obtaining authorization identity attributes for principal [%s]:", name);
+
+                    if (attributes.isEmpty()) {
+                        log.debugf("Identity [%s] does not have any attributes.", name);
+                    } else {
+                        log.debugf("Identity [%s] attributes are:", name);
+                        attributes.keySet().forEach(key -> {
+                            org.wildfly.security.authz.Attributes.Entry values = attributes.get(key);
+                            values.forEach(value -> log.debugf("    Attribute [%s] value [%s].", key, value));
+                        });
+                    }
+                }
+
+                return attributes.asReadOnly();
+
+            } catch (NamingException e) {
+                throw log.ldapRealmFailedObtainIdentityFromServer(name, e);
+            } finally {
+                closeContext(context);
+            }
         }
 
         @Override
@@ -461,7 +513,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             try {
                 for (EvidenceVerifier verifier : evidenceVerifiers) {
                     if (verifier.getEvidenceVerifySupport(dirContext, evidenceType, algorithmName).mayBeSupported()) {
-                        final IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, this.identity.getDistinguishedName());
+                        final IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, identity.getDistinguishedName());
 
                         final SupportLevel support = iev.getEvidenceVerifySupport(evidenceType, algorithmName, providers);
                         if (support != null && support.isDefinitelySupported()) {
@@ -499,7 +551,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             try {
                 for (EvidenceVerifier verifier : evidenceVerifiers) {
                     if (verifier.getEvidenceVerifySupport(dirContext, evidenceType, algorithmName).mayBeSupported()) {
-                        IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, this.identity.getDistinguishedName());
+                        IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, identity.getDistinguishedName());
 
                         if (iev.verifyEvidence(evidence, providers)) {
                             return true;
@@ -514,20 +566,20 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override
         public boolean exists() throws RealmUnavailableException {
-            if (this.identity == null) {
-                this.identity = getIdentity();
+            if (identity == null) {
+                identity = getIdentity();
             }
 
-            boolean exists = this.identity != null;
+            boolean exists = identity != null;
 
             if (!exists) {
-                log.debugf("Principal [%s] does not exists.", this.name);
+                log.debugf("Principal [%s] does not exists.", name);
             }
 
             return exists;
         }
 
-        private LdapSearch searchIdentityByDn() {
+        private LdapSearch createLdapSearchByDn() {
             if ( ! name.regionMatches(true, 0, identityMapping.rdnIdentifier, 0, identityMapping.rdnIdentifier.length())) {
                 return null;
             } // equal sign not checked here as whitespaces can be between yet
@@ -559,60 +611,33 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         private LdapIdentity getIdentity() throws RealmUnavailableException {
-            log.debugf("Trying to create identity for principal [%s].", this.name);
+            log.debugf("Trying to create identity for principal [%s].", name);
             DirContext context;
 
             try {
                 context = dirContextSupplier.get();
             } catch (NamingException e) {
-                throw log.ldapRealmFailedObtainIdentityFromServer(this.name, e);
+                throw log.ldapRealmFailedObtainIdentityFromServer(name, e);
             }
             try {
-                LdapSearch ldapSearch = searchIdentityByDn();
-                if (ldapSearch == null) { // not found by DN, search by name
+                LdapSearch ldapSearch = createLdapSearchByDn();
+                if (ldapSearch == null) { // name is not a valid DN, search by name
                     ldapSearch = new LdapSearch(identityMapping.searchDn, identityMapping.searchRecursive, 0, identityMapping.filterName, name);
                 }
 
-                ldapSearch.setReturningAttributes(
-                        identityMapping.attributes.stream()
-                                .map(AttributeMapping::getIdentityLdapName)
-                                .filter(Objects::nonNull)
-                                .toArray(String[]::new));
+                ldapSearch.setReturningAttributes(); // no attributes needed
 
-                final LdapSearch search = ldapSearch;
                 try (
                     Stream<LdapIdentity> identityStream = ldapSearch.search(context)
-                            .map(result -> {
-                                MapAttributes identityAttributes = new MapAttributes();
-
-                                identityAttributes.addAll(extractSimpleAttributes(result));
-                                identityAttributes.addAll(extractFilteredAttributes(result, context, search.getContext()));
-
-                                return new LdapIdentity(result.getNameInNamespace(), identityAttributes.asReadOnly());
-                            })
+                            .map(result -> new LdapIdentity(result.getNameInNamespace()))
                 ) {
-                    Optional<LdapIdentity> optional = identityStream.findFirst();
-
-                    if (optional.isPresent()) {
-                        LdapIdentity identity = optional.get();
-
-                        if (log.isDebugEnabled()) {
-                            log.debugf("Successfully created identity for principal [%s].", this.name);
-
-                            if (identity.attributes.isEmpty()) {
-                                log.debugf("Identity [%s] does not have any attributes.", this.name);
-                            } else {
-                                log.debugf("Identity [%s] attributes are:", this.name);
-                                identity.attributes.keySet().forEach(key -> {
-                                    org.wildfly.security.authz.Attributes.Entry values = identity.attributes.get(key);
-                                    values.forEach(value -> log.debugf("    Attribute [%s] value [%s].", key, value));
-                                });
-                            }
-                        }
-                        return identity;
+                    LdapIdentity identity = identityStream.findFirst().orElse(null);
+                    if (identity != null) {
+                        log.debugf("Identity for principal [%s] found at [%s].", name, identity.getDistinguishedName());
+                    } else {
+                        log.debugf("Identity for principal [%s] not found.", name);
                     }
-
-                    return null;
+                    return identity;
                 }
             } finally {
                 closeContext(context);
@@ -680,19 +705,19 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         private void extractFilteredAttributesRecursion(SearchResult entry, AttributeMapping mapping, DirContext context, DirContext identityContext, int depth, Collection<String> identityAttributeValues) {
-            final String entryDn = entry.getNameInNamespace();
+            final String entryDn = entry != null ? entry.getNameInNamespace() : null;
             final String searchDn = mapping.getSearchDn() != null ? mapping.getSearchDn() : identityMapping.searchDn;
 
-            if (mapping.getReference() != null) { // reference
+            if (mapping.getReference() != null && entry != null) { // reference
                 forEachAttributeValue(entry, mapping.getReference(), value -> {
                     LdapSearch search = new LdapSearch(value);
                     extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
                 });
-            } else { // filter
+            } else if (mapping.getReference() == null) { // filter
                 if (depth == 0) { // roles of identity
-                    LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), this.name, entryDn);
+                    LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), name, entryDn);
                     extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
-                } else { // roles of role
+                } else if (entry != null) { // roles of role
                     forEachAttributeValue(entry, mapping.getRoleRecursionName(), roleName -> {
                         LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), roleName, entryDn);
                         extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
@@ -702,7 +727,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         private void extractFilteredReferencedAttributesFromSearch(LdapSearch search, SearchResult referencedEntry, AttributeMapping mapping, DirContext context, DirContext identityContext, int depth, Collection<String> identityAttributeValues) {
-            String referencedDn = referencedEntry.getNameInNamespace();
+            String referencedDn = referencedEntry != null ? referencedEntry.getNameInNamespace() : null;
 
             search.setReturningAttributes(mapping.getLdapName(), mapping.getReference(), mapping.getRoleRecursionName());
 
@@ -724,14 +749,13 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         private Map<String, Collection<String>> extractSimpleAttributes(SearchResult identityEntry) {
-            String principalDn = identityEntry.getNameInNamespace();
-
+            if (identityEntry == null) return Collections.emptyMap();
             return extractAttributes(mapping -> !mapping.isFilteredOrReference(), mapping -> {
                 Collection<String> identityAttributeValues = new ArrayList<>();
                 try {
                     valuesFromAttribute(identityEntry, mapping, identityAttributeValues);
                 } catch (Exception cause) {
-                    throw ElytronMessages.log.ldapRealmFailedObtainAttributes(principalDn, cause);
+                    throw ElytronMessages.log.ldapRealmFailedObtainAttributes(identityEntry.getNameInNamespace(), cause);
                 }
                 return identityAttributeValues;
             });
@@ -821,7 +845,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         @Override public void setAttributes(org.wildfly.security.authz.Attributes attributes) throws RealmUnavailableException {
-            log.debugf("Trying to set attributes for principal [%s].", this.name);
+            log.debugf("Trying to set attributes for principal [%s].", name);
 
             if (identity == null) {
                 identity = getIdentity();
@@ -835,7 +859,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             try {
                 context = dirContextSupplier.get();
             } catch (Exception e) {
-                throw log.ldapRealmAttributesSettingFailed(this.name, e);
+                throw log.ldapRealmAttributesSettingFailed(name, e);
             }
             try {
                 List<ModificationItem> modItems = new LinkedList<>();
@@ -845,13 +869,13 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                 for(AttributeMapping mapping : identityMapping.attributes) {
                     if (mapping.getFilter() != null || mapping.getReference() != null || mapping.getRdn() != null) { // read-only mapping
                         if (attributes.size(mapping.getName()) != 0) {
-                            log.ldapRealmDoesNotSupportSettingFilteredAttribute(mapping.getName(), this.name);
+                            log.ldapRealmDoesNotSupportSettingFilteredAttribute(mapping.getName(), name);
                         }
                     } else if (identityMapping.rdnIdentifier.equalsIgnoreCase(mapping.getLdapName())) { // entry rename
                         if (attributes.size(mapping.getName()) == 1) {
                             renameTo = attributes.get(mapping.getName(), 0);
                         } else {
-                            throw log.ldapRealmRequiresExactlyOneRdnAttribute(mapping.getName(), this.name);
+                            throw log.ldapRealmRequiresExactlyOneRdnAttribute(mapping.getName(), name);
                         }
                     } else { // standard ldap attributes
                         if (attributes.size(mapping.getName()) == 0) {
@@ -867,7 +891,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
                 for(org.wildfly.security.authz.Attributes.Entry entry : attributes.entries()) {
                     if (identityMapping.attributes.stream().filter(mp -> mp.getName().equals(entry.getKey())).count() == 0) {
-                        throw log.ldapRealmCannotSetAttributeWithoutMapping(entry.getKey(), this.name);
+                        throw log.ldapRealmCannotSetAttributeWithoutMapping(entry.getKey(), name);
                     }
                 }
 
@@ -881,39 +905,22 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                 }
 
             } catch (Exception e) {
-                throw log.ldapRealmAttributesSettingFailed(this.name, e);
+                throw log.ldapRealmAttributesSettingFailed(name, e);
             } finally {
                 closeContext(context);
             }
         }
 
-        @Override
-        public org.wildfly.security.authz.Attributes getAttributes() throws RealmUnavailableException {
-            if (identity == null) {
-                identity = getIdentity();
-            }
-            if (identity == null) {
-                throw log.noSuchIdentity();
-            }
-            return identity.getAttributes().asReadOnly();
-        }
-
         private class LdapIdentity {
 
             private final String distinguishedName;
-            private final org.wildfly.security.authz.Attributes attributes;
 
-            LdapIdentity(String distinguishedName, org.wildfly.security.authz.Attributes attributes) {
+            LdapIdentity(String distinguishedName) {
                 this.distinguishedName = distinguishedName;
-                this.attributes = attributes;
             }
 
             String getDistinguishedName() {
                 return this.distinguishedName;
-            }
-
-            org.wildfly.security.authz.Attributes getAttributes() {
-                return this.attributes;
             }
         }
     }
@@ -930,7 +937,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         private String[] returningAttributes;
         private DirContext context;
         private NamingEnumeration<SearchResult> result;
-        private byte[] cookie = null;
+        private byte[] cookie;
 
         public LdapSearch(String searchDn, boolean searchRecursive, int pageSize, String filter, String... filterArgs) {
             this(searchDn, searchRecursive ? SearchControls.SUBTREE_SCOPE : SearchControls.ONELEVEL_SCOPE, pageSize, filter, filterArgs);
@@ -953,8 +960,9 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         public Stream<SearchResult> search(DirContext ctx) throws RealmUnavailableException {
-            log.debugf("Executing search [%s] in context [%s] with arguments [%s]. Returning attributes are [%s]", this.filter, this.searchDn, this.filterArgs, this.returningAttributes);
+            log.debugf("Executing search [%s] in context [%s] with arguments [%s]. Returning attributes are [%s]", filter, searchDn, filterArgs, returningAttributes);
             context = ctx;
+            cookie = null;
             try {
                 result = searchWithPagination();
                 return StreamSupport.stream(new Spliterators.AbstractSpliterator<SearchResult>(Long.MAX_VALUE, Spliterator.NONNULL) {
@@ -1032,7 +1040,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                         new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
                 });
             }
-            NamingEnumeration<SearchResult> results = context.search(searchDn, filter, filterArgs, createSearchControls(searchScope, returningAttributes));
+            NamingEnumeration<SearchResult> results = context.search(new LdapName(searchDn), filter, filterArgs, createSearchControls(searchScope, returningAttributes));
             if (pageSize != 0 && context instanceof LdapContext) {
                 ((LdapContext)context).setRequestControls(controlsBackup);
             }

--- a/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
@@ -67,12 +67,17 @@ public abstract class AbstractAttributeMappingSuiteChild {
                                         .setRdnIdentifier("uid")
                                         .map(expectedAttributes)
                                         .build()
-                                        .build()).build();
+                                .build()
+                ).build();
 
         builder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.from(new LoginPermission()));
 
         SecurityDomain securityDomain = builder.build();
 
+        assertAttributes(securityDomain, principalName, handler);
+    }
+
+    protected void assertAttributes(SecurityDomain securityDomain, String principalName, AssertResultHandler handler) throws RealmUnavailableException {
         ServerAuthenticationContext serverAuthenticationContext = securityDomain.createNewAuthenticationContext();
 
         serverAuthenticationContext.setAuthenticationName(principalName);
@@ -83,10 +88,6 @@ public abstract class AbstractAttributeMappingSuiteChild {
 
         SecurityIdentity securityIdentity = serverAuthenticationContext.getAuthorizedIdentity();
         Attributes attributes = securityIdentity.getAttributes();
-
-        if (expectedAttributes.length == 0) {
-            assertTrue("No attributes expected.", attributes.isEmpty());
-        }
 
         assertFalse("No attributes found for principal [" + principalName + "].", attributes.isEmpty());
 

--- a/src/test/java/org/wildfly/security/ldap/AttributeMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/AttributeMappingSuiteChild.java
@@ -87,12 +87,4 @@ public class AttributeMappingSuiteChild extends AbstractAttributeMappingSuiteChi
             assertAttributeValue(attributes.get("myDn"), "uid=userWithAttributes,dc=elytron,dc=wildfly,dc=org");
         }, AttributeMapping.fromIdentity().to("myDn").build());
     }
-
-    @Test
-    public void testRecursiveRoles() throws Exception {
-        assertAttributes("jduke", attributes -> {
-            assertEquals("Expected a single attribute.", 1, attributes.size());
-            assertAttributeValue(attributes.get("roles"), "R1", "R2");
-        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(1).to("roles").build());
-    }
 }

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
@@ -68,4 +68,29 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
         }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("CN").to(RoleDecoder.KEY_ROLES).searchRecursively(false).build());
     }
+
+    @Test
+    public void testRecursiveRoles() throws Exception {
+        assertAttributes("jduke", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "R1", "R2");
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(1).to(RoleDecoder.KEY_ROLES).build());
+    }
+
+
+    @Test
+    public void testRecursiveRolesCycle() throws Exception {
+        assertAttributes("jduke", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "R1", "R2","R3");
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(10).to(RoleDecoder.KEY_ROLES).build());
+    }
+
+    @Test
+    public void testRecursiveRolesByName() throws Exception {
+        assertAttributes("falith", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RN1", "RN2");
+        }, AttributeMapping.fromFilter("description={0}").from("cn").roleRecursionName("cn").roleRecursion(1).to(RoleDecoder.KEY_ROLES).build());
+    }
 }

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
@@ -21,8 +21,14 @@ package org.wildfly.security.ldap;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.auth.realm.AggregateSecurityRealm;
+import org.wildfly.security.auth.realm.LegacyPropertiesSecurityRealm;
 import org.wildfly.security.auth.realm.ldap.AttributeMapping;
+import org.wildfly.security.auth.realm.ldap.LdapSecurityRealmBuilder;
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.authz.RoleDecoder;
+import org.wildfly.security.permission.PermissionVerifier;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -92,5 +98,34 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RN1", "RN2");
         }, AttributeMapping.fromFilter("description={0}").from("cn").roleRecursionName("cn").roleRecursion(1).to(RoleDecoder.KEY_ROLES).build());
+    }
+
+    @Test
+    public void testAuthorizationWithDifferentAuthenticationRealm() throws Exception {
+        SecurityDomain.Builder builder = SecurityDomain.builder()
+            .setDefaultRealmName("default")
+            .addRealm("default",
+                new AggregateSecurityRealm(
+                    LegacyPropertiesSecurityRealm.builder() // authentication realm
+                        .setUsersStream(this.getClass().getResourceAsStream("/org/wildfly/security/auth/realm/nonldap.properties"))
+                        .setPlainText(true)
+                        .build(),
+                    LdapSecurityRealmBuilder.builder() // authorization realm
+                        .setDirContextSupplier(LdapTestSuite.dirContextFactory.create())
+                        .identityMapping()
+                            .setSearchDn("dc=elytron,dc=wildfly,dc=org")
+                            .searchRecursive()
+                            .setRdnIdentifier("uid")
+                            .map(AttributeMapping.fromFilter("description={0}").from("cn").roleRecursionName("cn").roleRecursion(2).to(RoleDecoder.KEY_ROLES).build())
+                            .build()
+                        .build()
+                )
+            ).build();
+        builder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.from(new LoginPermission()));
+
+        assertAttributes(builder.build(), "hybridUser", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RN3");
+        });
     }
 }

--- a/src/test/resources/ldap/elytron-role-mapping-tests.ldif
+++ b/src/test/resources/ldap/elytron-role-mapping-tests.ldif
@@ -134,3 +134,4 @@ objectclass: top
 objectclass: organizationalRole
 cn: RN3
 description: RN2
+description: hybridUser

--- a/src/test/resources/ldap/elytron-role-mapping-tests.ldif
+++ b/src/test/resources/ldap/elytron-role-mapping-tests.ldif
@@ -106,3 +106,31 @@ objectclass: groupOfNames
 cn: R3
 member: cn=R2,dc=elytron,dc=wildfly,dc=org
 description: the R3 group
+
+# Recursive roles by name
+dn: uid=falith,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: person
+objectclass: inetOrgPerson
+uid: falith
+cn: Falith
+sn: Fall
+userPassword: Password2
+
+dn: cn=RN1,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: organizationalRole
+cn: RN1
+description: falith
+
+dn: cn=RN2,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: organizationalRole
+cn: RN2
+description: RN1
+
+dn: cn=RN3,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: organizationalRole
+cn: RN3
+description: RN2

--- a/src/test/resources/org/wildfly/security/auth/realm/nonldap.properties
+++ b/src/test/resources/org/wildfly/security/auth/realm/nonldap.properties
@@ -1,0 +1,3 @@
+# Used in {@link org.wildfly.security.ldap.RoleMappingSuiteChild.testAuthorizationIdentityWithoutExistingUserEntity}
+#$REALM_NAME=NonLdapRealm$
+hybridUser=password


### PR DESCRIPTION
* [ELY-881] Fix of {0} behavior on role-recursion
 * setting of attribute to be considered role name (to be passed on place of {0} on roles of role search)
* [ELY-869] allowed obtaining authorization identity without existing identity entry (aggregate realm + ldap realm as authorization realm only)
* [ELY-760] attributes should not be obtained before successful authentication (now it is part of obtaining of authorization identity)

https://issues.jboss.org/browse/ELY-881
https://issues.jboss.org/browse/ELY-869
https://issues.jboss.org/browse/ELY-760

Subsystem part: https://github.com/wildfly-security/elytron-subsystem/pull/369
(backward compatible - subsystem PR can be merged later)