### PR TITLE
Drop deprecated DefaultSingleSignOnSessionFactory constructor.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1406,15 +1406,6 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6008, value = "Failed to logout participant [%s]")
     void warnHttpMechSsoFailedLogoutParticipant(String url, @Cause  Throwable cause);
 
-    @Message(id = 6009, value = "Alias [%s] must reference a RSA Private Key")
-    IllegalArgumentException httpMechSsoRSAPrivateKeyExpected(String keyAlias);
-
-    @Message(id = 6010, value = "Failed to obtain key [%s] from key store")
-    IllegalArgumentException httpMechSsoFailedObtainKeyFromKeyStore(String keyAlias, @Cause Throwable cause);
-
-    @Message(id = 6011, value = "Alias [%s] must reference a certificate")
-    IllegalArgumentException httpMechSsoCertificateExpected(String keyAlias);
-
     @Message(id = 6012, value = "Invalid logout message received for local session [%s]")
     IllegalStateException httpMechSsoInvalidLogoutMessage(String localSessionId);
 

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
@@ -22,12 +22,9 @@ import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.util.ByteIterator;
 
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
 import java.net.HttpURLConnection;
-import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
-import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
@@ -50,27 +47,6 @@ public class DefaultSingleSignOnSessionFactory implements SingleSignOnSessionFac
     private final SingleSignOnManager manager;
     private final KeyPair keyPair;
     private final Consumer<HttpsURLConnection> logoutConnectionConfigurator;
-
-    @Deprecated
-    public DefaultSingleSignOnSessionFactory(SingleSignOnManager manager, KeyStore keyStore, String keyAlias, String keyPassword, SSLContext sslContext) {
-        this(manager, getKeyPair(keyStore, keyAlias, keyPassword), connection -> {
-            if (sslContext != null) {
-                connection.setSSLSocketFactory(sslContext.getSocketFactory());
-            }
-        });
-    }
-
-    private static KeyPair getKeyPair(KeyStore store, String alias, String password) {
-        try {
-            if (!store.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
-                throw log.httpMechSsoRSAPrivateKeyExpected(alias);
-            }
-            KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry) store.getEntry(alias, (password != null) ? new KeyStore.PasswordProtection(password.toCharArray()) : null);
-            return new KeyPair(entry.getCertificate().getPublicKey(), entry.getPrivateKey());
-        } catch (GeneralSecurityException e) {
-            throw log.httpMechSsoFailedObtainKeyFromKeyStore(alias, e);
-        }
-    }
 
     public DefaultSingleSignOnSessionFactory(SingleSignOnManager manager, KeyPair keyPair) {
         this(manager, keyPair, connection -> {});


### PR DESCRIPTION
Now that https://github.com/wildfly-security/elytron-web/pull/55 was merged, this constructor is no longer referenced.