### PR TITLE
[ELY-804] LdapRealm - rework for working referrals

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -864,8 +864,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 4024, value = "Invalid client mode, expected %s, got %s")
     IllegalArgumentException invalidClientMode(boolean expectedMode, boolean givenMode);
 
-    @Message(id = 4025, value = "DirContext tries to connect without SSLSocketFactory thread local setting")
-    IllegalStateException sslSocketFactoryThreadLocalNotSet();
+    @Message(id = 4025, value = "DirContext tries to connect without ThreadLocalSSLSocketFactory thread local setting")
+    IllegalStateException threadLocalSslSocketFactoryThreadLocalNotSet();
 
     @Message(id = 4026, value = "Could not create trust manager [%s]")
     IllegalStateException sslErrorCreatingTrustManager(String name, @Cause Throwable cause);

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialLoader.java
@@ -22,7 +22,9 @@ import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.SupportLevel;
 import org.wildfly.security.credential.Credential;
 
+import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
+import java.util.Collection;
 
 /**
  * Within LDAP credentials could be stored in different ways, splitting out a CredentialLoader allows different strategies to be
@@ -59,8 +61,21 @@ interface CredentialLoader {
      *
      * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param distinguishedName the distinguished name of the identity.
+     * @param attributes the identity attributes requested by {@link #addRequiredIdentityAttributes(Collection)}
      * @return An {@link IdentityCredentialLoader} for the specified identity identified by their distinguished name.
      */
-    IdentityCredentialLoader forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
+    IdentityCredentialLoader forIdentity(DirContext dirContext, String distinguishedName, Attributes attributes) throws RealmUnavailableException;
 
+    /**
+     * Construct set of LDAP attributes, which should be loaded as part of the identity from identity entry.
+     * @param attributes output collection of attributes names, into which should be added
+     */
+    default void addRequiredIdentityAttributes(Collection<String> attributes) {}
+
+    /**
+     * Construct set of LDAP attributes, which should be loaded as binary data.
+     * Should be subset of {@link #addRequiredIdentityAttributes(Collection<String>)} output.
+     * @param attributes output collection of attributes names, into which should be added
+     */
+    default void addBinaryIdentityAttributes(Collection<String> attributes) {}
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialPersister.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/CredentialPersister.java
@@ -2,7 +2,9 @@ package org.wildfly.security.auth.realm.ldap;
 
 import org.wildfly.security.auth.server.RealmUnavailableException;
 
+import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
+import java.util.Collection;
 
 /**
  * Within LDAP credentials could be stored in different ways, splitting out a CredentialPersister allows different strategies to
@@ -20,8 +22,9 @@ public interface CredentialPersister extends CredentialLoader {
      *
      * @param dirContext the {@link DirContext} to use to connect to LDAP.
      * @param distinguishedName the distinguished name of the identity.
+     * @param attributes the identity attributes requested by {@link #addRequiredIdentityAttributes(Collection)}
      * @return An {@link IdentityCredentialLoader} for the specified identity identified by their distinguished name.
      */
-    IdentityCredentialPersister forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
+    IdentityCredentialPersister forIdentity(DirContext dirContext, String distinguishedName, Attributes attributes) throws RealmUnavailableException;
 
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/DirectEvidenceVerifier.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/DirectEvidenceVerifier.java
@@ -23,6 +23,7 @@ import java.security.Provider;
 import java.util.function.Supplier;
 
 import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.ldap.LdapContext;
@@ -51,7 +52,7 @@ class DirectEvidenceVerifier implements EvidenceVerifier {
     }
 
     @Override
-    public IdentityEvidenceVerifier forIdentity(final DirContext dirContext, final String distinguishedName) throws RealmUnavailableException {
+    public IdentityEvidenceVerifier forIdentity(final DirContext dirContext, final String distinguishedName, Attributes attributes) throws RealmUnavailableException {
         return new IdentityEvidenceVerifier() {
             @Override
             public SupportLevel getEvidenceVerifySupport(final Class<? extends Evidence> evidenceType, final String algorithmName, final Supplier<Provider[]> providers) throws RealmUnavailableException {
@@ -85,5 +86,4 @@ class DirectEvidenceVerifier implements EvidenceVerifier {
 
         };
     }
-
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/EvidenceVerifier.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/EvidenceVerifier.java
@@ -22,7 +22,9 @@ import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.SupportLevel;
 import org.wildfly.security.evidence.Evidence;
 
+import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
+import java.util.Collection;
 
 /**
  * An individual evidence verifier to associate with an LDAP {@link SecurityRealm}, multiple verifiers
@@ -50,9 +52,22 @@ interface EvidenceVerifier {
      * be suitable for use with the supplied {@code distinguishedName}
      *
      * @param dirContext the {@link DirContext} to use to connect to LDAP.
-     * @param distinguishedName the distinguished name of the identity.
+     * @param distinguishedName the distinguished name of the identity entry.
+     * @param attributes the identity attributes requested by {@link #addRequiredIdentityAttributes(Collection)}.
      * @return An {@link IdentityEvidenceVerifier} for the specified identity identified by their distinguished name.
      */
-    IdentityEvidenceVerifier forIdentity(DirContext dirContext, String distinguishedName) throws RealmUnavailableException;
+    IdentityEvidenceVerifier forIdentity(DirContext dirContext, String distinguishedName, Attributes attributes) throws RealmUnavailableException;
 
+    /**
+     * Construct set of LDAP attributes, which should be loaded as part of the identity from identity entry.
+     * @param attributes output collection of attributes names, into which should be added
+     */
+    default void addRequiredIdentityAttributes(Collection<String> attributes) {}
+
+    /**
+     * Construct set of LDAP attributes, which should be loaded as binary data.
+     * Should be subset of {@link #addRequiredIdentityAttributes(Collection<String>)} output.
+     * @param attributes output collection of attributes names, into which should be added
+     */
+    default void addBinaryIdentityAttributes(Collection<String> attributes) {}
 }

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -20,6 +20,7 @@ package org.wildfly.security.auth.realm.ldap;
 
 import static org.wildfly.security._private.ElytronMessages.log;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.security.Principal;
 import java.security.Provider;
@@ -33,7 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,6 +99,8 @@ import org.wildfly.security.evidence.Evidence;
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRealm {
+
+    private final String ENV_BINARY_ATTRIBUTES = "java.naming.ldap.attributes.binary";
 
     private final Supplier<Provider[]> providers;
     private final ExceptionSupplier<DirContext, NamingException> dirContextSupplier;
@@ -201,7 +204,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         final DirContext dirContext;
         final Stream<SearchResult> resultStream;
         final LdapSearch ldapSearch = new LdapSearch(identityMapping.searchDn, identityMapping.searchRecursive, pageSize, identityMapping.iteratorFilter);
-        ldapSearch.setReturningAttributes(identityMapping.rdnIdentifier);
+        ldapSearch.setReturningAttributes(Collections.singleton(identityMapping.rdnIdentifier));
         try {
             dirContext = dirContextSupplier.get();
             resultStream = ldapSearch.search(dirContext);
@@ -294,7 +297,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
     private class LdapRealmIdentity implements ModifiableRealmIdentity {
 
         private final String name;
-        private LdapIdentity identity;
         private IdentityLock lock;
 
         LdapRealmIdentity(final String name, final IdentityLock lock) {
@@ -309,22 +311,29 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         @Override
         public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String algorithmName) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentialType", credentialType);
-            if (!exists()) {
-                return SupportLevel.UNSUPPORTED;
-            }
 
             if (LdapSecurityRealm.this.getCredentialAcquireSupport(credentialType, algorithmName) == SupportLevel.UNSUPPORTED) {
                 // If not supported in general then definitely not supported for a specific principal.
                 return SupportLevel.UNSUPPORTED;
             }
 
-            SupportLevel support = SupportLevel.UNSUPPORTED;
-
             DirContext dirContext = obtainContext();
             try {
+                Set<String> attributes = new HashSet<>();
+                Set<String> binaryAttributes = new HashSet<>();
+                for (CredentialLoader loader : credentialLoaders) {
+                    loader.addRequiredIdentityAttributes(attributes);
+                    loader.addBinaryIdentityAttributes(binaryAttributes);
+                }
+
+                LdapIdentity identity = getIdentity(dirContext, attributes, binaryAttributes);
+                if (identity == null) {
+                    return SupportLevel.UNSUPPORTED;
+                }
+                SupportLevel support = SupportLevel.UNSUPPORTED;
                 for (CredentialLoader loader : credentialLoaders) {
                     if (loader.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported()) {
-                        IdentityCredentialLoader icl = loader.forIdentity(dirContext, identity.getDistinguishedName());
+                        IdentityCredentialLoader icl = loader.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
 
                         SupportLevel temp = icl.getCredentialAcquireSupport(credentialType, algorithmName, providers);
                         if (temp != null && temp.isDefinitelySupported()) {
@@ -337,10 +346,10 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                         }
                     }
                 }
+                return support;
             } finally {
                 closeContext(dirContext);
             }
-            return support;
         }
 
         @Override
@@ -351,9 +360,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         @Override
         public <C extends Credential> C getCredential(final Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentialType", credentialType);
-            if (!exists()) {
-                return null;
-            }
 
             if (LdapSecurityRealm.this.getCredentialAcquireSupport(credentialType, algorithmName) == SupportLevel.UNSUPPORTED) {
                 // If not supported in general then definitely not supported for a specific principal.
@@ -362,9 +368,20 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
             DirContext dirContext = obtainContext();
             try {
+                Set<String> attributes = new HashSet<>();
+                Set<String> binaryAttributes = new HashSet<>();
+                for (CredentialLoader loader : credentialLoaders) {
+                    loader.addRequiredIdentityAttributes(attributes);
+                    loader.addBinaryIdentityAttributes(binaryAttributes);
+                }
+
+                LdapIdentity identity = getIdentity(dirContext, attributes, binaryAttributes);
+                if (identity == null) {
+                    return null;
+                }
                 for (CredentialLoader loader : credentialLoaders) {
                     if (loader.getCredentialAcquireSupport(credentialType, algorithmName).mayBeSupported()) {
-                        IdentityCredentialLoader icl = loader.forIdentity(dirContext, identity.getDistinguishedName());
+                        IdentityCredentialLoader icl = loader.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
 
                         Credential credential = icl.getCredential(credentialType, algorithmName, providers);
                         if (credentialType.isInstance(credential)) {
@@ -382,12 +399,19 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         public void setCredentials(final Collection<? extends Credential> credentials) throws RealmUnavailableException {
             Assert.checkNotNullParam("credentials", credentials);
 
-            if (!exists()) {
-                throw log.ldapRealmIdentityNotExists(name);
-            }
-
             DirContext dirContext = obtainContext();
             try {
+                Set<String> attributes = new HashSet<>();
+                Set<String> binaryAttributes = new HashSet<>();
+                for (CredentialPersister persister : credentialPersisters) {
+                    persister.addRequiredIdentityAttributes(attributes);
+                    persister.addBinaryIdentityAttributes(binaryAttributes);
+                }
+
+                LdapIdentity identity = getIdentity(dirContext, attributes, binaryAttributes);
+                if (identity == null) {
+                    throw log.ldapRealmIdentityNotExists(name);
+                }
 
                 // verify support
                 for (Credential credential : credentials) {
@@ -395,7 +419,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                     final String algorithmName = credential instanceof AlgorithmCredential ? ((AlgorithmCredential) credential).getAlgorithm() : null;
                     boolean supported = false;
                     for (CredentialPersister persister : credentialPersisters) {
-                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
+                        IdentityCredentialPersister icp = persister.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
                         if (icp.getCredentialPersistSupport(credentialType, algorithmName)) {
                             supported = true;
                         }
@@ -407,7 +431,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
                 // clear
                 for (CredentialPersister persister : credentialPersisters) {
-                    IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
+                    IdentityCredentialPersister icp = persister.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
                     icp.clearCredentials();
                 }
 
@@ -416,7 +440,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                     final Class<? extends Credential> credentialType = credential.getClass();
                     final String algorithmName = credential instanceof AlgorithmCredential ? ((AlgorithmCredential) credential).getAlgorithm() : null;
                     for (CredentialPersister persister : credentialPersisters) {
-                        IdentityCredentialPersister icp = persister.forIdentity(dirContext, identity.getDistinguishedName());
+                        IdentityCredentialPersister icp = persister.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
                         if (icp.getCredentialPersistSupport(credentialType, algorithmName)) {
                             icp.persistCredential(credential);
                             // next credential
@@ -447,35 +471,23 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override
         public org.wildfly.security.authz.Attributes getAttributes() throws RealmUnavailableException {
-            if (identity == null) {
-                identity = getIdentity();
-            }
             DirContext context = null;
             try {
                 context = dirContextSupplier.get();
-                DirContext identityContext = context;
-                Optional<SearchResult> optionalResult = Optional.empty();
 
-                if (identity != null && identity.distinguishedName != null) {
-                    LdapSearch search = new LdapSearch(identity.distinguishedName);
-                    search.setReturningAttributes(
-                            identityMapping.attributes.stream()
-                                    .map(AttributeMapping::getIdentityLdapName)
-                                    .filter(Objects::nonNull)
-                                    .toArray(String[]::new));
+                LdapIdentity identity = getIdentity(context,
+                        identityMapping.attributes.stream()
+                        .map(AttributeMapping::getIdentityLdapName)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toSet()),
+                        null);
 
-                    try (Stream<SearchResult> results = search.search(context)) {
-                        optionalResult = results.findFirst();
-                    }
-                    identityContext = search.getContext(); // context where was the identity found
-                }
+                SearchResult entry = identity != null ? identity.getEntry() : null;
+                DirContext identityContext = identity != null ? identity.getDirContext() : null;
 
-                // now we have identity entry or it does not exists in LDAP
-                SearchResult result = optionalResult.orElse(null);
                 MapAttributes attributes = new MapAttributes();
-
-                attributes.addAll(extractSimpleAttributes(result));
-                attributes.addAll(extractFilteredAttributes(result, context, identityContext));
+                attributes.addAll(extractSimpleAttributes(entry));
+                attributes.addAll(extractFilteredAttributes(entry, context, identityContext));
 
                 if (log.isDebugEnabled()) {
                     log.debugf("Obtaining authorization identity attributes for principal [%s]:", name);
@@ -503,17 +515,26 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         @Override
         public SupportLevel getEvidenceVerifySupport(final Class<? extends Evidence> evidenceType, final String algorithmName) throws RealmUnavailableException {
             Assert.checkNotNullParam("evidenceType", evidenceType);
-            if (!exists()) {
-                return SupportLevel.UNSUPPORTED;
-            }
-
-            SupportLevel response = SupportLevel.UNSUPPORTED;
 
             DirContext dirContext = obtainContext();
             try {
+
+                Set<String> attributes = new HashSet<>();
+                Set<String> binaryAttributes = new HashSet<>();
+                for (EvidenceVerifier verifier : evidenceVerifiers) {
+                    verifier.addRequiredIdentityAttributes(attributes);
+                    verifier.addBinaryIdentityAttributes(binaryAttributes);
+                }
+
+                LdapIdentity identity = getIdentity(dirContext, attributes, binaryAttributes);
+                if (identity == null) {
+                    return SupportLevel.UNSUPPORTED;
+                }
+
+                SupportLevel response = SupportLevel.UNSUPPORTED;
                 for (EvidenceVerifier verifier : evidenceVerifiers) {
                     if (verifier.getEvidenceVerifySupport(dirContext, evidenceType, algorithmName).mayBeSupported()) {
-                        final IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, identity.getDistinguishedName());
+                        final IdentityEvidenceVerifier iev = verifier.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
 
                         final SupportLevel support = iev.getEvidenceVerifySupport(evidenceType, algorithmName, providers);
                         if (support != null && support.isDefinitelySupported()) {
@@ -521,23 +542,20 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                             return support;
                         }
 
-                        if (support != null && support.compareTo(response) > 0) {
+                        if (support != null && response.compareTo(support) < 0) {
                             response = support;
                         }
                     }
                 }
+                return response;
             } finally {
                 closeContext(dirContext);
             }
-            return response;
         }
 
         @Override
         public boolean verifyEvidence(final Evidence evidence) throws RealmUnavailableException {
             Assert.checkNotNullParam("evidence", evidence);
-            if (!exists()) {
-                return false;
-            }
 
             final Class<? extends Evidence> evidenceType = evidence.getClass();
             final String algorithmName = evidence instanceof AlgorithmEvidence ? ((AlgorithmEvidence) evidence).getAlgorithm() : null;
@@ -549,9 +567,21 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
             DirContext dirContext = obtainContext();
             try {
+                Set<String> attributes = new HashSet<>();
+                Set<String> binaryAttributes = new HashSet<>();
                 for (EvidenceVerifier verifier : evidenceVerifiers) {
-                    if (verifier.getEvidenceVerifySupport(dirContext, evidenceType, algorithmName).mayBeSupported()) {
-                        IdentityEvidenceVerifier iev = verifier.forIdentity(dirContext, identity.getDistinguishedName());
+                    verifier.addRequiredIdentityAttributes(attributes);
+                    verifier.addBinaryIdentityAttributes(binaryAttributes);
+                }
+
+                LdapIdentity identity = getIdentity(dirContext, attributes, binaryAttributes);
+                if (identity == null) {
+                    return false;
+                }
+
+                for (EvidenceVerifier verifier : evidenceVerifiers) {
+                    if (verifier.getEvidenceVerifySupport(identity.getDirContext(), evidenceType, algorithmName).mayBeSupported()) {
+                        IdentityEvidenceVerifier iev = verifier.forIdentity(identity.getDirContext(), identity.getDistinguishedName(), identity.getEntry().getAttributes());
 
                         if (iev.verifyEvidence(evidence, providers)) {
                             return true;
@@ -566,17 +596,19 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override
         public boolean exists() throws RealmUnavailableException {
-            if (identity == null) {
-                identity = getIdentity();
+            DirContext dirContext = obtainContext();
+            try {
+                LdapIdentity identity = getIdentity(dirContext);
+                boolean exists = identity != null;
+
+                if (!exists) {
+                    log.debugf("Principal [%s] does not exists.", name);
+                }
+
+                return exists;
+            } finally {
+                closeContext(dirContext);
             }
-
-            boolean exists = identity != null;
-
-            if (!exists) {
-                log.debugf("Principal [%s] does not exists.", name);
-            }
-
-            return exists;
         }
 
         private LdapSearch createLdapSearchByDn() {
@@ -610,36 +642,31 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             return null;
         }
 
-        private LdapIdentity getIdentity() throws RealmUnavailableException {
+        private LdapIdentity getIdentity(DirContext dirContext) throws RealmUnavailableException {
+            return getIdentity(dirContext, null, null);
+        }
+
+        private LdapIdentity getIdentity(DirContext dirContext, Collection<String> returningAttributes, Collection<String> binaryAttributes) throws RealmUnavailableException {
             log.debugf("Trying to create identity for principal [%s].", name);
-            DirContext context;
-
-            try {
-                context = dirContextSupplier.get();
-            } catch (NamingException e) {
-                throw log.ldapRealmFailedObtainIdentityFromServer(name, e);
+            LdapSearch ldapSearch = createLdapSearchByDn();
+            if (ldapSearch == null) { // name is not a valid DN, search by name
+                ldapSearch = new LdapSearch(identityMapping.searchDn, identityMapping.searchRecursive, 0, identityMapping.filterName, name);
             }
-            try {
-                LdapSearch ldapSearch = createLdapSearchByDn();
-                if (ldapSearch == null) { // name is not a valid DN, search by name
-                    ldapSearch = new LdapSearch(identityMapping.searchDn, identityMapping.searchRecursive, 0, identityMapping.filterName, name);
-                }
 
-                ldapSearch.setReturningAttributes(); // no attributes needed
+            ldapSearch.setReturningAttributes(returningAttributes);
+            ldapSearch.setBinaryAttributes(binaryAttributes);
 
-                try (Stream<SearchResult> ldapSearchStream = ldapSearch.search(context);
-                        Stream<LdapIdentity> identityStream = ldapSearchStream
-                                .map(result -> new LdapIdentity(result.getNameInNamespace()))) {
-                    LdapIdentity identity = identityStream.findFirst().orElse(null);
-                    if (identity != null) {
-                        log.debugf("Identity for principal [%s] found at [%s].", name, identity.getDistinguishedName());
-                    } else {
-                        log.debugf("Identity for principal [%s] not found.", name);
-                    }
+            final LdapSearch ldapSearchFinal = ldapSearch;
+            try (Stream<SearchResult> resultsStream = ldapSearch.search(dirContext)) {
+                SearchResult result = resultsStream.findFirst().orElse(null);
+                if (result != null) {
+                    LdapIdentity identity = new LdapIdentity(name, ldapSearchFinal.getContext(), result.getNameInNamespace(), result);
+                    log.debugf("Identity for principal [%s] found at [%s].", name, identity.getDistinguishedName());
                     return identity;
+                } else {
+                    log.debugf("Identity for principal [%s] not found.", name);
+                    return null;
                 }
-            } finally {
-                closeContext(context);
             }
         }
 
@@ -728,7 +755,11 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         private void extractFilteredReferencedAttributesFromSearch(LdapSearch search, SearchResult referencedEntry, AttributeMapping mapping, DirContext context, DirContext identityContext, int depth, Collection<String> identityAttributeValues) {
             String referencedDn = referencedEntry != null ? referencedEntry.getNameInNamespace() : null;
 
-            search.setReturningAttributes(mapping.getLdapName(), mapping.getReference(), mapping.getRoleRecursionName());
+            Set<String> attributes = new HashSet<>();
+            attributes.add(mapping.getLdapName());
+            attributes.add(mapping.getReference());
+            attributes.add(mapping.getRoleRecursionName());
+            search.setReturningAttributes(attributes);
 
             try (Stream<SearchResult> entries = search.search(mapping.searchInIdentityContext() ? identityContext : context)) {
                 entries.forEach(entry -> {
@@ -792,14 +823,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override
         public void delete() throws RealmUnavailableException {
-            if (identity == null) {
-                identity = getIdentity();
-            }
-
-            if (identity == null) {
-                throw log.noSuchIdentity();
-            }
-
             DirContext context;
             try {
                 context = dirContextSupplier.get();
@@ -807,9 +830,12 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                 throw log.ldapRealmFailedDeleteIdentityFromServer(e);
             }
             try {
+                LdapIdentity identity = getIdentity(context);
+                if (identity == null) {
+                    throw log.noSuchIdentity();
+                }
                 log.debugf("Removing identity [%s] with DN [%s] from LDAP", name, identity.getDistinguishedName());
-                context.destroySubcontext(new LdapName(identity.getDistinguishedName()));
-                identity = null; // force reload
+                identity.getDirContext().destroySubcontext(new LdapName(identity.getDistinguishedName()));
             } catch (NamingException e) {
                 throw log.ldapRealmFailedDeleteIdentityFromServer(e);
             } finally {
@@ -845,15 +871,6 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         @Override public void setAttributes(org.wildfly.security.authz.Attributes attributes) throws RealmUnavailableException {
             log.debugf("Trying to set attributes for principal [%s].", name);
-
-            if (identity == null) {
-                identity = getIdentity();
-            }
-
-            if (identity == null) {
-                throw log.noSuchIdentity();
-            }
-
             DirContext context;
             try {
                 context = dirContextSupplier.get();
@@ -861,6 +878,11 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                 throw log.ldapRealmAttributesSettingFailed(name, e);
             }
             try {
+                LdapIdentity identity = getIdentity(context);
+                if (identity == null) {
+                    throw log.noSuchIdentity();
+                }
+
                 List<ModificationItem> modItems = new LinkedList<>();
                 LdapName identityLdapName = new LdapName(identity.getDistinguishedName());
                 String renameTo = null;
@@ -895,12 +917,12 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                 }
 
                 ModificationItem[] modItemsArray = modItems.toArray(new ModificationItem[modItems.size()]);
-                context.modifyAttributes(identityLdapName, modItemsArray);
+                identity.getDirContext().modifyAttributes(identityLdapName, modItemsArray);
 
                 if (renameTo != null && ! renameTo.equals(identityLdapName.getRdn(identityLdapName.size()-1).getValue())) {
                     LdapName newLdapName = new LdapName(identityLdapName.getRdns().subList(0, identityLdapName.size()-1));
                     newLdapName.add(new Rdn(identityMapping.rdnIdentifier, renameTo));
-                    context.rename(identityLdapName, newLdapName);
+                    identity.getDirContext().rename(identityLdapName, newLdapName);
                 }
 
             } catch (Exception e) {
@@ -910,16 +932,43 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             }
         }
 
-        private class LdapIdentity {
+        private class LdapIdentity implements Closeable {
 
+            private final String name;
+            private final DirContext dirContext;
             private final String distinguishedName;
+            private final SearchResult entry;
 
-            LdapIdentity(String distinguishedName) {
+            LdapIdentity(String name, DirContext dirContext, String distinguishedName, SearchResult entry) {
+                this.name = name;
+                this.dirContext = dirContext;
                 this.distinguishedName = distinguishedName;
+                this.entry = entry;
+            }
+
+            String getName() {
+                return this.name;
+            }
+
+            DirContext getDirContext() {
+                return this.dirContext;
             }
 
             String getDistinguishedName() {
                 return this.distinguishedName;
+            }
+
+            SearchResult getEntry() {
+                return this.entry;
+            }
+
+            @Override
+            public void close() throws IOException {
+                try {
+                    dirContext.close();
+                } catch (NamingException e) {
+                    log.debug("LdapSecurityRealm failed to close DirContext", e);
+                }
             }
         }
     }
@@ -933,7 +982,8 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         private final int pageSize;
         private final String filter;
         private final String[] filterArgs;
-        private String[] returningAttributes;
+        private Collection<String> returningAttributes;
+        private Collection<String> binaryAttributes;
         private DirContext context;
         private NamingEnumeration<SearchResult> result;
         private byte[] cookie;
@@ -959,7 +1009,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         public Stream<SearchResult> search(DirContext ctx) throws RealmUnavailableException {
-            log.debugf("Executing search [%s] in context [%s] with arguments [%s]. Returning attributes are [%s]", filter, searchDn, filterArgs, returningAttributes);
+            log.debugf("Executing search [%s] in context [%s] with arguments [%s]. Returning attributes are [%s]. Binary attributes are [%s].", filter, searchDn, filterArgs, returningAttributes, binaryAttributes);
             context = ctx;
             cookie = null;
             try {
@@ -1033,28 +1083,53 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         private NamingEnumeration<SearchResult> searchWithPagination() throws NamingException, IOException {
             Control[] controlsBackup = null;
+            Object binaryAttributesBackup = null;
+
+            // backup and set environment
             if (pageSize != 0 && context instanceof LdapContext) {
                 controlsBackup = ((LdapContext)context).getRequestControls();
                 ((LdapContext)context).setRequestControls(new Control[]{
                         new PagedResultsControl(pageSize, cookie, Control.CRITICAL)
                 });
             }
-            NamingEnumeration<SearchResult> results = context.search(new LdapName(searchDn), filter, filterArgs, createSearchControls(searchScope, returningAttributes));
+            if (binaryAttributes != null && binaryAttributes.size() != 0) { // set attributes which should be returned in binary form
+                binaryAttributesBackup = context.getEnvironment().get(ENV_BINARY_ATTRIBUTES);
+                context.addToEnvironment(ENV_BINARY_ATTRIBUTES, String.join(" ", binaryAttributes));
+            }
+
+            NamingEnumeration<SearchResult> results = context.search(new LdapName(searchDn), filter, filterArgs, createSearchControls());
+
+            // revert environment change
+            if (binaryAttributes != null && binaryAttributes.size() != 0) {
+                if (binaryAttributesBackup == null) {
+                    context.removeFromEnvironment(ENV_BINARY_ATTRIBUTES);
+                } else {
+                    context.addToEnvironment(ENV_BINARY_ATTRIBUTES, binaryAttributesBackup);
+                }
+            }
             if (pageSize != 0 && context instanceof LdapContext) {
                 ((LdapContext)context).setRequestControls(controlsBackup);
             }
             return results;
         }
 
-        private void setReturningAttributes(String... returningAttributes) {
+        private void setReturningAttributes(Collection<String> returningAttributes) {
             this.returningAttributes = returningAttributes;
         }
 
-        private SearchControls createSearchControls(int searchScope, String... returningAttributes) {
+        private void setBinaryAttributes(Collection<String> binaryAttributes) {
+            this.binaryAttributes = binaryAttributes;
+        }
+
+        private SearchControls createSearchControls() {
             SearchControls searchControls = new SearchControls();
             searchControls.setSearchScope(searchScope);
             searchControls.setTimeLimit(identityMapping.searchTimeLimit);
-            searchControls.setReturningAttributes(returningAttributes);
+            if (returningAttributes == null) {
+                searchControls.setReturningAttributes(new String[]{});
+            } else {
+                searchControls.setReturningAttributes(returningAttributes.toArray(new String[returningAttributes.size()]));
+            }
             return searchControls;
         }
 

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/ThreadLocalSSLSocketFactory.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/ThreadLocalSSLSocketFactory.java
@@ -43,7 +43,7 @@ public class ThreadLocalSSLSocketFactory extends SocketFactory {
     public static SocketFactory getDefault() {
         SocketFactory socketFactory = threadLocal.get();
         if (socketFactory == null) {
-            throw log.sslSocketFactoryThreadLocalNotSet();
+            throw log.threadLocalSslSocketFactoryThreadLocalNotSet();
         }
         return socketFactory;
     }


### PR DESCRIPTION
Current LdapRealm implementation fails to authenticated users through referrals.
As context.getAttributes() does not want to work correctly with referrals, only search works ok, I has changed way of obtaining attributes - they are obtained using identity search now.

Does not depend on related subsystem change: https://github.com/wildfly-security/elytron-subsystem/pull/382
(subsystem change is only tests extending)

https://issues.jboss.org/browse/ELY-804