### PR TITLE
[ELY-835] Automatic Outflow Preparaton

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -597,6 +597,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1148, value = "A SecurityDomain has already been associated with the specified ClassLoader")
     IllegalStateException classLoaderSecurityDomainExists();
 
+    @Message(id = 1149, value = "Can not use SecurityIdentity with SecurityIdentity from same SecurityDomain")
+    IllegalArgumentException cantWithSameSecurityDomainDomain();
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")


### PR DESCRIPTION
This PR contains the Elytron side of automatic outflow.

First the SecurityIdentity has a withSecurityIdentity method added allowing for additional SecurityIdentities to be associated that will also be used for any run calls.

Secondly the anonymousIdentity initialisation is now lazy to allow for any securityIdentityTransformer to be initialised between domain creation and first use.

As outflowing the identity is two lines of code, one of which requiring to be backed by a PrivilegedAction the code handling the flow will live within the subsystem.