### PR TITLE
[ELY-910] - Remove participant from SSO when remote logout failed

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1403,7 +1403,7 @@ public interface ElytronMessages extends BasicLogger {
     String usernameOrPasswordMissing();
 
     @LogMessage(level = WARN)
-    @Message(id = 6008, value = "Failed to logout participant [%s]")
+    @Message(id = 6008, value = "Failed to logout participant [%s]. Participant will be removed from list of participants but its local session may still be active.")
     void warnHttpMechSsoFailedLogoutParticipant(String url, @Cause  Throwable cause);
 
     @Message(id = 6012, value = "Invalid logout message received for local session [%s]")

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
@@ -21,7 +21,6 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.net.URI;
 import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -93,8 +92,8 @@ public class DefaultSingleSignOn implements SingleSignOn {
     }
 
     @Override
-    public Collection<Map.Entry<String, URI>> getParticipants() {
-        return Collections.unmodifiableCollection(this.entry.getParticipants().values());
+    public Map<String, Map.Entry<String, URI>> getParticipants() {
+        return Collections.unmodifiableMap(this.entry.getParticipants());
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
@@ -28,7 +28,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -108,8 +107,8 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
 
             scope.registerForNotification(notification -> {
                 HttpScope sessionScope = notification.getScope(Scope.SESSION);
-
                 Map<String, Map.Entry<String, URI>> logoutTargets = Collections.emptyMap();
+
                 try (SingleSignOn target = this.context.getSingleSignOnManager().find(id)) {
                     if (target != null) {
                         Map.Entry<String, URI> localParticipant = target.removeParticipant(applicationId);
@@ -122,7 +121,7 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
                                 log.debugf("Destroying SSO [%s]. SSO is not associated with participants", target.getId());
                                 target.invalidate();
                             } else if (notification.isOfType(INVALIDATED)) {
-                                logoutTargets = new HashMap<>(participants);
+                                logoutTargets = participants;
                             }
                         }
                     }

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
@@ -65,7 +65,7 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
         this.context = checkNotNullParam("context", context);
         this.request = checkNotNullParam("request", request);
         checkNotNullParam("mechanismName", mechanismName);
-        this.ssoFactory = identity -> context.getSingleSignOnManagerManager().create(mechanismName, identity);
+        this.ssoFactory = identity -> context.getSingleSignOnManager().create(mechanismName, identity);
     }
 
     public DefaultSingleSignOnSession(SingleSignOnSessionContext context, HttpServerRequest request, SingleSignOn sso) {
@@ -110,7 +110,7 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
                 HttpScope sessionScope = notification.getScope(Scope.SESSION);
 
                 Map<String, Map.Entry<String, URI>> logoutTargets = Collections.emptyMap();
-                try (SingleSignOn target = this.context.getSingleSignOnManagerManager().find(id)) {
+                try (SingleSignOn target = this.context.getSingleSignOnManager().find(id)) {
                     if (target != null) {
                         Map.Entry<String, URI> localParticipant = target.removeParticipant(applicationId);
                         if (localParticipant != null) {
@@ -162,13 +162,13 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
                         } catch (Exception cause) {
                             log.warnHttpMechSsoFailedLogoutParticipant(remoteURI.toString(), cause);
                             // failed to logout participant, remove it from the list of participants
-                            try (SingleSignOn target = context.getSingleSignOnManagerManager().find(id)) {
+                            try (SingleSignOn target = context.getSingleSignOnManager().find(id)) {
                                 target.removeParticipant(participantId);
                             }
                         }
                     });
 
-                    try (SingleSignOn target = this.context.getSingleSignOnManagerManager().find(id)) {
+                    try (SingleSignOn target = this.context.getSingleSignOnManager().find(id)) {
                         if (target != null) {
                             // If all logout requests were successful, then there should be no participants, and we can invalidate the SSO
                             if (target.getParticipants().isEmpty()) {

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
@@ -161,20 +161,18 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
                             connection.getInputStream().close();
                         } catch (Exception cause) {
                             log.warnHttpMechSsoFailedLogoutParticipant(remoteURI.toString(), cause);
-                            // failed to logout participant, remove it from the list of participants
-                            try (SingleSignOn target = context.getSingleSignOnManager().find(id)) {
-                                target.removeParticipant(participantId);
-                            }
                         }
                     });
 
                     try (SingleSignOn target = this.context.getSingleSignOnManager().find(id)) {
                         if (target != null) {
                             // If all logout requests were successful, then there should be no participants, and we can invalidate the SSO
-                            if (target.getParticipants().isEmpty()) {
+                            if (!target.getParticipants().isEmpty()) {
+                                log.debugf("Destroying SSO [%s]. Participant list not empty.", target.getId());
+                            } else {
                                 log.debugf("Destroying SSO [%s]. SSO is no longer associated with any participants", target.getId());
-                                target.invalidate();
                             }
+                            target.invalidate();
                         }
                     }
                 }

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
@@ -76,7 +76,7 @@ public class DefaultSingleSignOnSessionFactory implements SingleSignOnSessionFac
     }
 
     @Override
-    public SingleSignOnManager getSingleSignOnManagerManager() {
+    public SingleSignOnManager getSingleSignOnManager() {
         return this.manager;
     }
 

--- a/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
@@ -18,7 +18,6 @@
 package org.wildfly.security.http.util.sso;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.Map;
 
 import org.wildfly.security.auth.server.SecurityIdentity;
@@ -53,8 +52,8 @@ public interface ImmutableSingleSignOn {
     SecurityIdentity getIdentity();
 
     /**
-     * Returns the participants associated with this single sign-on entry
+     * Returns the participants associated with this single sign-on entry.
      * @return an unmodifiable mapping of application identifier to a tuple of the session identifier and request URI
      */
-    Collection<Map.Entry<String, URI>> getParticipants();
+    Map<String, Map.Entry<String, URI>> getParticipants();
 }

--- a/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSessionContext.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSessionContext.java
@@ -24,7 +24,7 @@ import java.net.HttpURLConnection;
  * @author Paul Ferraro
  */
 public interface SingleSignOnSessionContext {
-    SingleSignOnManager getSingleSignOnManagerManager();
+    SingleSignOnManager getSingleSignOnManager();
 
     String createLogoutParameter(String sessionId);
     String verifyLogoutParameter(String logoutRequest);


### PR DESCRIPTION
[NOTE] It also fixes tests a test failure when we have a cluster and logout fail for one or more nodes. E.g.: when one node is down or failed to process the logout request.