### PR TITLE
[ELY-921] Update session scope implementation to check if the session exists before returning the ID.

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpScope.java
+++ b/src/main/java/org/wildfly/security/http/HttpScope.java
@@ -31,9 +31,9 @@ import java.util.function.Consumer;
 public interface HttpScope {
 
     /**
-     * Get the ID of this scope or (@code null} if IDs are not supported for this scope.
+     * Get the ID of this scope or (@code null} if IDs are not supported for this scope or the scope doesn't currently exist.
      *
-     * @return the ID of this scope or (@code null} if IDs are not supported for this scope.
+     * @return the ID of this scope or (@code null} if IDs are not supported for this scope or the scope doesn't currently exist..
      */
     default String getID() {
         return null;

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -223,15 +223,15 @@ class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMechanis
 
     private boolean attemptReAuthentication(HttpServerRequest request) throws HttpAuthenticationException {
         if (log.isTraceEnabled()) {
-            if (getSessionScope(request, false) != null) {
+            HttpScope sessionScope = getSessionScope(request, false);
+            if (sessionScope != null && sessionScope.exists()) {
                 log.tracef("Trying to re-authenticate session %s using FormAuthenticationMechanism. Request URI: [%s], Context path: [%s]",
-                        getSessionScope(request, false).getID(), request.getRequestURI(), this.contextPath);
+                        sessionScope.getID(), request.getRequestURI(), this.contextPath);
             } else {
-                log.tracef("Unable to re-authenticate using FormAuthenticationMechanism. There is no session attached to the following request. " +
+                log.tracef("Trying to re-authenticate using FormAuthenticationMechanism. There is no session attached to the following request. " +
                         "Request URI: [%s], Context path: [%s]", request.getRequestURI(), this.contextPath);
             }
         }
-
 
         IdentityCache identityCache = createIdentityCache(request, false);
         if (identityCache != null) {


### PR DESCRIPTION
Also updated TRACE logging to check the session actually exists before reporting it's status.

The TRACE logging is still slightly questionable as it assumes the cache is session based but accurate enough for our current implementation, main point being this clears the NPE a user would experience just by enabling TRACE logging making any problem they are trying to debug far worse.
