### PR TITLE
ELY-926  PKCS#12 support in CredentialStore with JDK-8005408

### DIFF
--- a/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -112,6 +112,7 @@ import org.wildfly.security.credential.store.impl.VaultCredentialStore;
 import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
 import org.wildfly.security.http.impl.ServerMechanismFactoryImpl;
 import org.wildfly.security.key.RSAParameterSpiImpl;
+import org.wildfly.security.key.RawSecretKeyFactory;
 import org.wildfly.security.keystore.PasswordKeyStoreSpi;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl;
@@ -157,6 +158,7 @@ public class WildFlyElytronProvider extends Provider {
         putCredentialStoreProviderImplementations();
         putAlgorithmParametersImplementations();
         put("Alg.Alias.Data.OID.1.2.840.113549.1.7.1", "Data");
+        putService(new Service(this, "SecretKeyFactory", "1.2.840.113549.1.7.1", RawSecretKeyFactory.class.getName(), Collections.emptyList(), Collections.emptyMap()));
     }
 
     private void putAlgorithmParametersImplementations() {

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -694,6 +694,11 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 2031, value = "LdapKeyStore failed to iterate aliases")
     IllegalStateException ldapKeyStoreFailedToIterateAliases(@Cause Throwable cause);
 
+    @Message(id = 2032, value = "keySpec must be SecretKeySpect, given: [%s]")
+    InvalidKeySpecException keySpecMustBeSecretKeySpec(String type);
+
+    @Message(id = 2033, value = "key must implement SecretKeySpec and keySpec must be SecretKeySpec, given key, keySpec: [%s]")
+    InvalidKeySpecException keyMustImplementSecretKeySpecAndKeySpecMustBeSecretKeySpec(String keyAndKeySpec);
 
     /* util package */
 

--- a/src/main/java/org/wildfly/security/key/RawSecretKeyFactory.java
+++ b/src/main/java/org/wildfly/security/key/RawSecretKeyFactory.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.key;
+
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactorySpi;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.jboss.logging.Logger;
+import org.wildfly.security._private.ElytronMessages;
+import org.wildfly.security.credential.store.CredentialStore;
+
+/**
+ * {@link SecretKeyFactorySpi} that returns the given {@link KeySpec} or {@link SecretKey} verbatim. Needed for the
+ * PKCS#12 {@link KeyStore} support in {@link CredentialStore}.
+ */
+public final class RawSecretKeyFactory extends SecretKeyFactorySpi {
+
+    ElytronMessages log = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security");
+
+    @Override
+    protected SecretKey engineGenerateSecret(KeySpec keySpec) throws InvalidKeySpecException {
+        if (keySpec instanceof SecretKeySpec) {
+            return (SecretKeySpec) keySpec;
+        }
+
+        throw log.keySpecMustBeSecretKeySpec(keySpec.getClass().getName());
+    }
+
+    @Override
+    protected KeySpec engineGetKeySpec(SecretKey key, Class<?> keySpec) throws InvalidKeySpecException {
+        if (SecretKeySpec.class.isAssignableFrom(keySpec) && key instanceof SecretKeySpec) {
+            return (SecretKeySpec) key;
+        }
+
+        throw log.keyMustImplementSecretKeySpecAndKeySpecMustBeSecretKeySpec(
+                key.getClass().getName() + ", " + keySpec.getName());
+    }
+
+    @Override
+    protected SecretKey engineTranslateKey(SecretKey key) throws InvalidKeyException {
+        return key;
+    }
+}

--- a/src/test/java/org/wildfly/security/key/RawSecretKeyFactoryTest.java
+++ b/src/test/java/org/wildfly/security/key/RawSecretKeyFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.key;
+
+import java.math.BigInteger;
+import java.security.GeneralSecurityException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPrivateKeySpec;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.Assert.assertThat;
+
+public class RawSecretKeyFactoryTest {
+
+    static final byte[] KEY_BYTES = "some key".getBytes();
+
+    RawSecretKeyFactory rawFactory = new RawSecretKeyFactory();
+
+    SecretKeySpec keySpec = new SecretKeySpec(KEY_BYTES, "DES");
+
+    @Test(expected = InvalidKeySpecException.class)
+    public void shouldComplainAboutNotGivenASecretKey() throws GeneralSecurityException {
+        rawFactory.engineGetKeySpec(keySpec, RSAPrivateKeySpec.class);
+    }
+
+    @Test(expected = InvalidKeySpecException.class)
+    public void shouldComplainAboutNotGivenASecretKeySpec() throws InvalidKeySpecException {
+        rawFactory.engineGenerateSecret(new RSAPrivateKeySpec(BigInteger.ONE, BigInteger.ONE));
+    }
+
+    @Test
+    public void shouldGenerateSecretKeyFromSecretKeySpec() throws InvalidKeySpecException {
+        assertThat(rawFactory.engineGenerateSecret(keySpec), sameInstance(keySpec));
+    }
+
+    @Test
+    public void shouldGenerateSecretKeySpecFromSecretKey() throws GeneralSecurityException {
+        assertThat(rawFactory.engineGetKeySpec(keySpec, SecretKeySpec.class), sameInstance(keySpec));
+    }
+}


### PR DESCRIPTION
Adds RawSecretKeyFactory and adds it as a service of
WildFlyElytronProvider so that Credential store implementation can use
PKCS#12 KeyStore type.

ELY-920 removed PKCS#12 test, after ELY-XXX this re-enables the removed
test. Also added reflection trickery to make JCE think that
WildFlyElytronProvider's JAR file has been verified.