### PR TITLE
[ELY-933] Add possibility to disable creation of CS storage from scratch

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1739,6 +1739,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 9529, value = "This credential store type requires a store-wide protection parameter")
     CredentialStoreException protectionParameterRequired();
 
+    @Message(id = 9530, value = "Automatic storage creation for the Credential Store is disabled \"%s\"")
+    CredentialStoreException automaticStorageCreationDisabled(String location);
+
     /* X.500 exceptions */
 
     @Message(id = 10000, value = "X.509 certificate extension with OID %s already exists")

--- a/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -77,6 +77,7 @@ public class XmlConfigurationTest {
             "            </protection-parameter-credentials>\n" +
             "            <attributes>\n" +
             "                <attribute name=\"keyStoreType\" value=\"JCEKS\"/>\n" +
+            "                <attribute name=\"create\" value=\"true\"/>\n" +
             "            </attributes>\n" +
             "        </credential-store>\n" +
             "    </credential-stores>\n" +

--- a/src/test/java/org/wildfly/security/credential/store/CredentialStoreBuilder.java
+++ b/src/test/java/org/wildfly/security/credential/store/CredentialStoreBuilder.java
@@ -119,6 +119,7 @@ public class CredentialStoreBuilder {
 
         final Map<String, String> map = new HashMap<>();
         map.put("location", file);
+        map.put("create", Boolean.TRUE.toString());
         if (type != null) map.put("keyStoreType", type);
         storeImpl.initialize(
             map,

--- a/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
+++ b/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
@@ -146,6 +146,7 @@ public class KeystorePasswordStoreTest {
 
         csAttributes.put("location", stores.get("ONE"));
         csAttributes.put("keyStoreType", "JCEKS");
+        csAttributes.put("create", Boolean.TRUE.toString());
 
         String passwordAlias1 = "db1-password1";
         String passwordAlias2 = "db1-password2";

--- a/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
+++ b/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
@@ -120,6 +120,7 @@ public class KeyStoreCredentialStoreTest {
 
         final Map<String, String> attributes = new HashMap<>();
         attributes.put("location", keyStoreFile.getAbsolutePath());
+        attributes.put("create", Boolean.TRUE.toString());
         attributes.put("keyStoreType", keyStoreFormat);
 
         originalStore.initialize(attributes, storeProtection);


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-933

This PR will change the default behaviour of KeyStoreCredentialStore to not automatically create new storage file. 
We should enforce this at implementation level rather than on subsystem level as custom implementers might have a different reasons to resolve this as we do.