### PR TITLE
[ELY-903] LdapRealm - role recursion max depth + reference recursion

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -685,20 +685,20 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         }
 
         /**
-         * Obtains values of attribute given by mapping from given entry.
+         * Obtains attribute value by mapping from given entry and put it into given collection.
          *
          * @param entry LDAP entry, from which should be values obtained
          * @param mapping attribute mapping defining attribute, whose values should be obtained
-         * @param identityAttributeValues output collection for obtained values
-         * @return {@code true} if identityAttributeValues was changed.
+         * @param outputCollection output collection for obtained values
+         * @return {@code true} if {@code outputCollection} was changed.
          */
-        private boolean valuesFromAttribute(SearchResult entry, AttributeMapping mapping, Collection<String> identityAttributeValues) throws NamingException {
+        private boolean valuesFromAttribute(SearchResult entry, AttributeMapping mapping, Collection<String> outputCollection) throws NamingException {
             if (mapping.getLdapName() == null) {
                 String value = entry.getNameInNamespace();
                 if (mapping.getRdn() != null) {
                     value = extractRdn(mapping, value);
                 }
-                return identityAttributeValues.add(value);
+                return outputCollection.add(value);
             } else {
                 Attributes entryAttributes = entry.getAttributes();
                 javax.naming.directory.Attribute ldapAttribute = entryAttributes.get(mapping.getLdapName());
@@ -710,7 +710,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
                     if (mapping.getRdn() != null) {
                         values = values.map(val -> extractRdn(mapping, val)).filter(Objects::nonNull);
                     }
-                    return values.map(identityAttributeValues::add).filter(changed -> changed).count() != 0;
+                    return values.map(outputCollection::add).filter(changed -> changed).count() != 0;
                 } finally {
                     if (attributesEnum != null) {
                         try {
@@ -724,35 +724,40 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         private Map<String, Collection<String>> extractFilteredAttributes(SearchResult identityEntry, DirContext context, DirContext identityContext) {
             return extractAttributes(AttributeMapping::isFilteredOrReference, mapping -> {
-                Collection<String> identityAttributeValues = mapping.getRoleRecursionDepth() == 0 ? new ArrayList<>() : new HashSet<>();
-                extractFilteredAttributesRecursion(identityEntry, mapping, context, identityContext, 0, identityAttributeValues);
-                return identityAttributeValues;
+                Collection<String> values = mapping.getRoleRecursionDepth() == 0 ? new ArrayList<>() : new HashSet<>();
+                final String searchDn = mapping.getSearchDn() != null ? mapping.getSearchDn() : identityMapping.searchDn;
+
+                List<SearchResult> toSearch = new LinkedList<>();
+                toSearch.add(identityEntry);
+
+                for (int depth = 0; depth <= mapping.getRoleRecursionDepth() && ! toSearch.isEmpty(); depth++) {
+                    List<SearchResult> toSearchInNextLevel = new LinkedList<>();
+                    for(SearchResult entry : toSearch) {
+                        final String entryDn = entry != null ? entry.getNameInNamespace() : null;
+                        if (mapping.getReference() != null && entry != null) { // reference
+                            forEachAttributeValue(entry, mapping.getReference(), value -> {
+                                LdapSearch search = new LdapSearch(value);
+                                extractFilteredAttributesFromSearch(search, entry, mapping, context, identityContext, values, toSearchInNextLevel);
+                            });
+                        } else if (mapping.getReference() == null) { // filter
+                            if (depth == 0) { // roles of identity
+                                LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), name, entryDn);
+                                extractFilteredAttributesFromSearch(search, entry, mapping, context, identityContext, values, toSearchInNextLevel);
+                            } else if (entry != null) { // roles of role
+                                forEachAttributeValue(entry, mapping.getRoleRecursionName(), roleName -> {
+                                    LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), roleName, entryDn);
+                                    extractFilteredAttributesFromSearch(search, entry, mapping, context, identityContext, values, toSearchInNextLevel);
+                                });
+                            }
+                        }
+                    }
+                    toSearch = toSearchInNextLevel;
+                }
+                return values;
             });
         }
 
-        private void extractFilteredAttributesRecursion(SearchResult entry, AttributeMapping mapping, DirContext context, DirContext identityContext, int depth, Collection<String> identityAttributeValues) {
-            final String entryDn = entry != null ? entry.getNameInNamespace() : null;
-            final String searchDn = mapping.getSearchDn() != null ? mapping.getSearchDn() : identityMapping.searchDn;
-
-            if (mapping.getReference() != null && entry != null) { // reference
-                forEachAttributeValue(entry, mapping.getReference(), value -> {
-                    LdapSearch search = new LdapSearch(value);
-                    extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
-                });
-            } else if (mapping.getReference() == null) { // filter
-                if (depth == 0) { // roles of identity
-                    LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), name, entryDn);
-                    extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
-                } else if (entry != null) { // roles of role
-                    forEachAttributeValue(entry, mapping.getRoleRecursionName(), roleName -> {
-                        LdapSearch search = new LdapSearch(searchDn, mapping.getRecursiveSearch(), 0, mapping.getFilter(), roleName, entryDn);
-                        extractFilteredReferencedAttributesFromSearch(search, entry, mapping, context, identityContext, depth, identityAttributeValues);
-                    });
-                }
-            }
-        }
-
-        private void extractFilteredReferencedAttributesFromSearch(LdapSearch search, SearchResult referencedEntry, AttributeMapping mapping, DirContext context, DirContext identityContext, int depth, Collection<String> identityAttributeValues) {
+        private void extractFilteredAttributesFromSearch(LdapSearch search, SearchResult referencedEntry, AttributeMapping mapping, DirContext context, DirContext identityContext, Collection<String> identityAttributeValues, Collection<SearchResult> toSearchInNextLevel) {
             String referencedDn = referencedEntry != null ? referencedEntry.getNameInNamespace() : null;
 
             Set<String> attributes = new HashSet<>();
@@ -763,14 +768,12 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
             try (Stream<SearchResult> entries = search.search(mapping.searchInIdentityContext() ? identityContext : context)) {
                 entries.forEach(entry -> {
-                    boolean changed;
                     try {
-                        changed = valuesFromAttribute(entry, mapping, identityAttributeValues);
+                        if (valuesFromAttribute(entry, mapping, identityAttributeValues)) {
+                            toSearchInNextLevel.add(entry);
+                        }
                     } catch (Exception cause) {
                         throw ElytronMessages.log.ldapRealmFailedObtainAttributes(referencedDn, cause);
-                    }
-                    if (mapping.getRoleRecursionDepth() > depth && changed) {
-                        extractFilteredAttributesRecursion(entry, mapping, context, identityContext, depth+1, identityAttributeValues);
                     }
                 });
             } catch (Exception cause) {

--- a/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/RoleMappingSuiteChild.java
@@ -32,6 +32,7 @@ import org.wildfly.security.permission.PermissionVerifier;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
 
@@ -39,7 +40,7 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
     public void testRoleMappingWithMemberOf() throws Exception {
         assertAttributes("userWithMemberOfRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
-            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDN");
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "roleByMemberOf");
         }, AttributeMapping.fromIdentity().from("memberOf").extractRdn("CN").to(RoleDecoder.KEY_ROLES).build());
     }
 
@@ -47,8 +48,16 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
     public void testRoleMappingWithMemberOfAttribute() throws Exception {
         assertAttributes("userWithMemberOfRoles", attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
-            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "RoleFromBaseDNDescription");
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "roleByMemberOfDescription");
         }, AttributeMapping.fromReference("memberOf").from("description").to(RoleDecoder.KEY_ROLES).build());
+    }
+
+    @Test
+    public void testRoleMappingWithMemberOfRecursive() throws Exception {
+        assertAttributes("userWithMemberOfRoles", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "roleByMemberOfDescription", "roleOfRoleByMemberOfDescription");
+        }, AttributeMapping.fromReference("memberOf").roleRecursion(3).from("description").to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test
@@ -90,6 +99,14 @@ public class RoleMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
             assertEquals("Expected a single attribute.", 1, attributes.size());
             assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "R1", "R2","R3");
         }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(10).to(RoleDecoder.KEY_ROLES).build());
+    }
+
+    @Test
+    public void testRecursiveRolesMoreWaysToOneRole() throws Exception {
+        assertAttributes("ranvir", attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get(RoleDecoder.KEY_ROLES), "MWR1", "MWR2","MWR3");
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").from("cn").roleRecursion(1).to(RoleDecoder.KEY_ROLES).build());
     }
 
     @Test

--- a/src/test/resources/ldap/elytron-role-mapping-tests.ldif
+++ b/src/test/resources/ldap/elytron-role-mapping-tests.ldif
@@ -40,20 +40,6 @@ objectClass: groupOfNames
 cn: Manager
 member: uid=userWithRdnAttribute,dc=elytron,dc=wildfly,dc=org
 
-dn: uid=userWithMemberOfRoles,dc=elytron,dc=wildfly,dc=org
-objectClass: top
-objectClass: groupMember
-objectClass: inetOrgPerson
-objectClass: uidObject
-objectClass: person
-objectClass: organizationalPerson
-cn: userWithMemberOfRoles
-sn: userWithMemberOfRoles
-uid: userWithMemberOfRoles
-memberOf: cn=RoleFromBaseDN,dc=elytron,dc=wildfly,dc=org
-userPassword:: cGxhaW5QYXNzd29yZA==
-# Password plainPassword
-
 dn: uid=userWithRoles,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: inetOrgPerson
@@ -76,6 +62,7 @@ uid: userWithRdnAttribute
 userPassword:: cGxhaW5QYXNzd29yZA==
 # Password plainPassword
 
+
 # Recursive roles
 dn: uid=jduke,dc=elytron,dc=wildfly,dc=org
 objectclass: top
@@ -91,6 +78,7 @@ objectclass: top
 objectclass: groupOfNames
 cn: R1
 member: uid=jduke,dc=elytron,dc=wildfly,dc=org
+member: cn=R3,dc=elytron,dc=wildfly,dc=org
 description: the R1 group
 
 dn: cn=R2,dc=elytron,dc=wildfly,dc=org
@@ -107,7 +95,41 @@ cn: R3
 member: cn=R2,dc=elytron,dc=wildfly,dc=org
 description: the R3 group
 
-# Recursive roles by name
+
+# Recursive roles with more (short and long) ways to one role
+dn: uid=ranvir,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: person
+objectclass: inetOrgPerson
+uid: ranvir
+cn: Ranvir
+sn: Ran
+userPassword: Password3
+
+dn: cn=MWR1,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: MWR1
+member: uid=ranvir,dc=elytron,dc=wildfly,dc=org
+description: the MWR1 group
+
+dn: cn=MWR2,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: MWR2
+member: cn=MWR1,dc=elytron,dc=wildfly,dc=org
+member: uid=ranvir,dc=elytron,dc=wildfly,dc=org
+description: the MWR2 group
+
+dn: cn=MWR3,dc=elytron,dc=wildfly,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: MWR3
+member: cn=MWR2,dc=elytron,dc=wildfly,dc=org
+description: the MWR3 group
+
+
+# Recursive roles by name (attribute "description")
 dn: uid=falith,dc=elytron,dc=wildfly,dc=org
 objectclass: top
 objectclass: person
@@ -135,3 +157,33 @@ objectclass: organizationalRole
 cn: RN3
 description: RN2
 description: hybridUser
+
+
+# Recursive memberOf
+dn: uid=userWithMemberOfRoles,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: groupMember
+objectClass: inetOrgPerson
+objectClass: uidObject
+objectClass: person
+objectClass: organizationalPerson
+cn: userWithMemberOfRolesCn
+sn: userWithMemberOfRolesSn
+uid: userWithMemberOfRolesUid
+memberOf: cn=roleByMemberOf,dc=elytron,dc=wildfly,dc=org
+userPassword:: cGxhaW5QYXNzd29yZA==
+# Password plainPassword
+
+dn: cn=roleByMemberOf,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectclass: organizationalRole
+objectClass: groupMember
+cn: roleByMemberOfCn
+memberOf: cn=roleOfRoleByMemberOf,dc=elytron,dc=wildfly,dc=org
+description: roleByMemberOfDescription
+
+dn: cn=roleOfRoleByMemberOf,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectclass: organizationalRole
+cn: roleOfRoleByMemberOfCn
+description: roleOfRoleByMemberOfDescription


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-903
(no subsystem part)

* depth first role recursive search (using recursion) replaced by breadth first search (using queue and cycle) to ensure correct max recursion depth
* fixed/test covered references (memberOf) with role recursion