### PR TITLE
[ELY-751] (Reopen) Coverity static analysis: Explicit null dereferenced in LdapKeyStore (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
+++ b/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
@@ -103,7 +103,7 @@ public class LdapKeyStore extends KeyStore {
                     filterAlias, filterCertificate, filterIterate, createPath, createRdn, createAttributes, aliasAttribute,
                     certificateAttribute, certificateType, certificateChainAttribute, certificateChainEncoding,
                     keyAttribute, keyType);
-            return new LdapKeyStore(spi, EmptyProvider.getInstance(), "LdapRealm");
+            return new LdapKeyStore(spi, EmptyProvider.getInstance(), "LdapKeyStore");
         }
 
         /**


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-751 (Reopen)

Replaced "LdapRealm" -> "LdapKeyStore"
