### PR TITLE
[ELY-862] IdentityCredentials immutable (return clones)

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/IdentityCredentials.java
+++ b/src/main/java/org/wildfly/security/auth/server/IdentityCredentials.java
@@ -389,7 +389,7 @@ public abstract class IdentityCredentials implements Iterable<Credential>, Crede
 
         public <C extends Credential> C getCredential(final Class<C> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) {
             Assert.checkNotNullParam("credentialType", credentialType);
-            return credential.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential) : null;
+            return credential.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential.clone()) : null;
         }
 
         public IdentityCredentials withCredential(final Credential credential) {
@@ -479,8 +479,8 @@ public abstract class IdentityCredentials implements Iterable<Credential>, Crede
 
         public <C extends Credential> C getCredential(final Class<C> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) {
             Assert.checkNotNullParam("credentialType", credentialType);
-            return credential1.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential1) :
-                   credential2.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential2) : null;
+            return credential1.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential1.clone()) :
+                   credential2.matches(credentialType, algorithmName, parameterSpec) ? credentialType.cast(credential2.clone()) : null;
         }
 
         public IdentityCredentials withCredential(final Credential credential) {
@@ -653,7 +653,7 @@ public abstract class IdentityCredentials implements Iterable<Credential>, Crede
         }
 
         public <C extends Credential> C getCredential(final Class<C> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) {
-            return credentialType.cast(map.get(new Key(credentialType, algorithmName, parameterSpec)));
+            return credentialType.cast(map.get(new Key(credentialType, algorithmName, parameterSpec)).clone());
         }
 
         public IdentityCredentials withoutMatching(final Credential credential) {


### PR DESCRIPTION
Fix for https://github.com/wildfly-security/elytron-subsystem/pull/390#issuecomment-279170070

> [8:30 PM] Honza Kalina: about IdentityCredentials.One.getCredential(), should not it create new copy of credential? Currently when I obtain credential from AuthenticationContext and destroy it after, on next obtaining I obtains destroyed credential...
> [9:49 PM] David M. Lloyd: I don't have a certain opinion.  If we create a copy, it becomes impossible to destroy the original.  On the other hand, we really don't want SIs to be mutable
> [9:49 PM] David M. Lloyd: I guess overall copying is better
> [10:02 PM] Darran Lofthouse: Sounds reasonable for the AC to copy, the caller to the AC has no idea where it came from and if accessed through a CBH there is no client side callback to say it is finished and clean up everything we used to client side has to clean up I think.