### PR TITLE
[ELY-37] Security Events / Listeners / Audit Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>${version.org.jboss.logmanager}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
             <version>${version.org.jboss.modules}</version>
@@ -392,12 +398,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <version>${version.org.jboss.logmanager}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>log4j-jboss-logmanager</artifactId>

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -92,6 +92,7 @@ import org.wildfly.security.util.DecodeException;
 public interface ElytronMessages extends BasicLogger {
 
     ElytronMessages log = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security");
+    ElytronMessages audit = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.audit");
     ElytronMessages xmlLog = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.xml");
     ElytronMessages tls = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.tls");
 
@@ -1791,4 +1792,14 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 10013, value = "Certificate serial number too large (cannot exceed 20 octets)")
     IllegalArgumentException serialNumberTooLarge();
+
+    /* Audit Exceptions */
+
+    @Message(id = 11000, value = "Partial SecurityEvent written.")
+    IOException partialSecurityEventWritten(@Cause IOException cause);
+
+    @LogMessage(level = Logger.Level.FATAL)
+    @Message(id = 11001, value = "Endpoint unable to handle SecurityEvent priority=%s, message=%s")
+    void endpointUnavaiable(String priority, String message, @Cause Throwable cause);
+
 }

--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -63,6 +63,7 @@ import org.jboss.logging.annotations.Param;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.client.config.ConfigurationXMLStreamReader;
 import org.wildfly.security.asn1.ASN1Exception;
+import org.wildfly.security.audit.EventPriority;
 import org.wildfly.security.auth.callback.FastUnsupportedCallbackException;
 import org.wildfly.security.auth.permission.RunAsPrincipalPermission;
 import org.wildfly.security.auth.realm.CacheableSecurityRealm;
@@ -1801,5 +1802,8 @@ public interface ElytronMessages extends BasicLogger {
     @LogMessage(level = Logger.Level.FATAL)
     @Message(id = 11001, value = "Endpoint unable to handle SecurityEvent priority=%s, message=%s")
     void endpointUnavaiable(String priority, String message, @Cause Throwable cause);
+
+    @Message(id = 11002, value = "Invalid EventPriority '%s' passed to AuditEndpoint.")
+    IllegalArgumentException invalidEventPriority(EventPriority eventPriority);
 
 }

--- a/src/main/java/org/wildfly/security/audit/AuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/AuditEndpoint.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.wildfly.common.function.ExceptionBiConsumer;
+
+/**
+ * An endpoint that recieves audit messages.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@FunctionalInterface
+public interface AuditEndpoint extends ExceptionBiConsumer<EventPriority, String, IOException>, Closeable {
+
+    /**
+     * Close the endpoint and stop handling further events immediately.
+     *
+     * @throws IOException if an error occurs closing the endpoint.
+     */
+    default void close() throws IOException {};
+
+}

--- a/src/main/java/org/wildfly/security/audit/AuditLogger.java
+++ b/src/main/java/org/wildfly/security/audit/AuditLogger.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.wildfly.security.auth.server.event.SecurityEvent;
+
+/**
+ * The audit logger implementation.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class AuditLogger implements Consumer<SecurityEvent> {
+
+    private final BiConsumer<EventPriority, String> auditEndpoint;
+    private final Function<SecurityEvent, EventPriority> priorityMapper;
+    private final Function<SecurityEvent, String> messageFormatter;
+
+    /**
+     *
+     */
+    AuditLogger(Builder builder) {
+        auditEndpoint = checkNotNullParam("auditEndpoint", builder.auditEndpoint);
+        priorityMapper = checkNotNullParam("priorityMapper", builder.priorityMapper);
+        messageFormatter = checkNotNullParam("messageFormatter", builder.messageFormatter);
+    }
+
+    @Override
+    public void accept(SecurityEvent t) {
+        EventPriority priority = priorityMapper.apply(t);
+        if (priority == EventPriority.OFF) return;
+
+        auditEndpoint.accept(priority, messageFormatter.apply(t));
+    }
+
+    public static class Builder {
+
+        private BiConsumer<EventPriority, String> auditEndpoint;
+        private Function<SecurityEvent, EventPriority> priorityMapper;
+        private Function<SecurityEvent, String> messageFormatter;
+
+        Builder() {
+        }
+
+        /**
+         * Set the endpoint to receive the resulting audit messages.
+         *
+         * @param auditEndpoint the endpoint to receive the resulting audit messages.
+         * @return this builder.
+         */
+        public Builder setAuditEndpoint(BiConsumer<EventPriority, String> auditEndpoint) {
+            this.auditEndpoint = checkNotNullParam("auditEndpoint", auditEndpoint);
+
+            return this;
+        }
+
+        /**
+         * Set the priority mapper to assign a priority to the messages.
+         *
+         * @param priorityMapper the priority mapper to assign a priority to the messages.
+         * @return this builder.
+         */
+        public Builder setPriorityMapper(Function<SecurityEvent, EventPriority> priorityMapper) {
+            this.priorityMapper = checkNotNullParam("priorityMapper", priorityMapper);
+
+            return this;
+        }
+
+        /**
+         * Set the message formatter to convert the messages to formatted Strings.
+         *
+         * @param messageFormatter the message formatter to convert the messages to formatted Strings.
+         * @return this builder.
+         */
+        public Builder setMessageFormatter(Function<SecurityEvent, String> messageFormatter) {
+            this.messageFormatter = checkNotNullParam("messageFormatter", messageFormatter);
+
+            return this;
+        }
+
+        public Consumer<SecurityEvent> build() {
+            return new AuditLogger(this);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/audit/EventPriority.java
+++ b/src/main/java/org/wildfly/security/audit/EventPriority.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+/**
+ * The priority level of an event.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public enum EventPriority {
+
+    EMERGENCY,
+
+    ALERT,
+
+    CRITICAL,
+
+    ERROR,
+
+    WARNING,
+
+    NOTICE,
+
+    INFORMATIONAL,
+
+    DEBUG,
+
+    OFF;
+
+}

--- a/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.audit;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.function.Supplier;
+
+/**
+ * An audit endpoint to record all audit events to a local file.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class FileAuditEndpoint implements AuditEndpoint {
+
+    private static final byte[] LINE_TERMINATOR = System.lineSeparator().getBytes(StandardCharsets.UTF_8);
+
+    private volatile boolean accepting = true;
+
+    private final Supplier<DateFormat> dateFormatSupplier;
+    private final boolean syncOnAccept;
+
+    private final FileDescriptor fileDescriptor;
+    private final OutputStream outputStream;
+
+    /**
+     *
+     */
+    FileAuditEndpoint(Builder builder) throws IOException {
+        this.dateFormatSupplier = builder.dateFormatSupplier;
+        this.syncOnAccept = builder.syncOnAccept;
+
+        FileOutputStream fos = new FileOutputStream(builder.location.toFile(), true);
+        this.fileDescriptor = fos.getFD();
+        this.outputStream = new BufferedOutputStream(fos);
+    }
+
+    @Override
+    public void accept(EventPriority t, String u) throws IOException {
+        if (!accepting) return;
+
+        synchronized(this) {
+            if (!accepting) return; // We may have been waiting to get in here.
+
+            boolean started = false;
+
+            try {
+                outputStream.write(dateFormatSupplier.get().format(new Date()).getBytes(StandardCharsets.UTF_8));
+                started = true;
+                outputStream.write(',');
+                outputStream.write(t.toString().getBytes(StandardCharsets.UTF_8));
+                outputStream.write(',');
+                outputStream.write(u.getBytes(StandardCharsets.UTF_8));
+                outputStream.write(LINE_TERMINATOR);
+            } catch (IOException e) {
+                throw started ? audit.partialSecurityEventWritten(e) : e;
+            }
+
+            if (syncOnAccept) {
+                outputStream.flush();
+                fileDescriptor.sync();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        accepting = false;
+
+        synchronized (this) {
+            outputStream.flush();
+            fileDescriptor.sync();
+            outputStream.close();
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Supplier<DateFormat> dateFormatSupplier = SimpleDateFormat::new;
+        private Path location = new File("audit.log").toPath();
+        private boolean syncOnAccept = true;
+
+        Builder() {
+        }
+
+        /**
+         * Set the {@link Supplier<DateFormat>} to obtain the formatter for dates.
+         *
+         * @param dateFormatSupplier the {@link Supplier<DateFormat>} to obtain the formatter for dates.
+         * @return this builder.
+         */
+        public Builder setDateFormatSupplier(Supplier<DateFormat> dateFormatSupplier) {
+            this.dateFormatSupplier = checkNotNullParam("dateFormatSupplier", dateFormatSupplier);
+
+            return this;
+        }
+
+        /**
+         * Set the location to write the audit events to.
+         *
+         * @param location the location to write the audit events to.
+         * @return this builder.
+         */
+        public Builder setLocation(Path location) {
+            this.location = checkNotNullParam("location", location);
+
+            return this;
+        }
+
+        /**
+         * Sets if the output should be flushed and system buffers forces to sychronize on each event accepted.
+         *
+         * @param syncOnAccept should the output be flushed and system buffers forces to sychronize on each event accepted.
+         * @return this builder.
+         */
+        public Builder setSyncOnAccept(boolean syncOnAccept) {
+            this.syncOnAccept = syncOnAccept;
+
+            return this;
+        }
+
+        public AuditEndpoint build() throws IOException {
+            return new FileAuditEndpoint(this);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
+++ b/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
@@ -1,0 +1,151 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import java.security.Permission;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.function.Supplier;
+
+import javax.json.Json;
+import javax.json.JsonObjectBuilder;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.auth.server.event.SecurityDefiniteOutcomeEvent;
+import org.wildfly.security.auth.server.event.SecurityEvent;
+import org.wildfly.security.auth.server.event.SecurityEventVisitor;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckEvent;
+
+/**
+ * A formatter for security events that converts the event to a JSON String.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, String> {
+
+    private final Supplier<DateFormat> dateFormatSupplier;
+
+    /**
+     *
+     */
+    JsonSecurityEventFormatter(Builder builder) {
+        this.dateFormatSupplier = builder.dateFormatSupplier;
+    }
+
+    @Override
+    public String handleUnknownEvent(SecurityEvent event, Void param) {
+        checkNotNullParam("event", event);
+        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        handleUnknownEvent(event, objectBuilder);
+        return objectBuilder.build().toString();
+    }
+
+    private void handleUnknownEvent(SecurityEvent event, JsonObjectBuilder objectBuilder) {
+        DateFormat dateFormat = dateFormatSupplier.get();
+
+        objectBuilder.add("event", event.getClass().getSimpleName());
+        objectBuilder.add("event-time", dateFormat.format(Date.from(event.getInstant())));
+
+        JsonObjectBuilder securityIdentityBuilder = Json.createObjectBuilder();
+        SecurityIdentity securityIdentity = event.getSecurityIdentity();
+        securityIdentityBuilder.add("name", securityIdentity.getPrincipal().getName());
+        securityIdentityBuilder.add("creation-time", dateFormat.format(Date.from(securityIdentity.getCreationTime())));
+
+        objectBuilder.add("security-identity", securityIdentityBuilder);
+    }
+
+    @Override
+    public String handleDefiniteOutcomeEvent(SecurityDefiniteOutcomeEvent event, Void param) {
+        checkNotNullParam("event", event);
+        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        handleDefiniteOutcomeEvent(event, objectBuilder);
+        return objectBuilder.build().toString();
+    }
+
+    private void handleDefiniteOutcomeEvent(SecurityDefiniteOutcomeEvent event, JsonObjectBuilder objectBuilder) {
+        handleUnknownEvent(event, objectBuilder);
+        objectBuilder.add("success", event.isSuccessful());
+    }
+
+    @Override
+    public String handlePermissionCheckEvent(SecurityPermissionCheckEvent event, Void param) {
+        checkNotNullParam("event", event);
+        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        handlePermissionCheckEvent(event, objectBuilder);
+        return objectBuilder.build().toString();
+    }
+
+    private void handlePermissionCheckEvent(SecurityPermissionCheckEvent event, JsonObjectBuilder objectBuilder) {
+        handleDefiniteOutcomeEvent(event, objectBuilder);
+
+        Permission permission = event.getPermission();
+        JsonObjectBuilder permissionBuilder = Json.createObjectBuilder();
+        permissionBuilder.add("type", permission.getClass().getName());
+        permissionBuilder.add("actions", permission.getActions());
+        permissionBuilder.add("name", permission.getName());
+
+        objectBuilder.add("permission", permissionBuilder);
+    }
+
+    /**
+     * Create a new builder.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Supplier<DateFormat> dateFormatSupplier = SimpleDateFormat::new;
+
+        Builder() {
+        }
+
+        /**
+         * Set a {@link Supplier<DateFormat>} to format any dates in the resulting output.
+         *
+         * @param dateFormatSupplier a {@link Supplier<DateFormat>} to format any dates in the resulting output.
+         * @return {@code this} builder.
+         */
+        public Builder setDateFormatSupplier(Supplier<DateFormat> dateFormatSupplier) {
+            this.dateFormatSupplier = checkNotNullParam("dateFormatSupplier", dateFormatSupplier);
+
+            return this;
+        }
+
+        /**
+         * Build a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into JSON formatted
+         * Strings.
+         *
+         * Once built the Builder can continue to be configured to create additional instances.
+         *
+         * @return a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into JSON formatted
+         *         Strings.
+         */
+        public SecurityEventVisitor<?, String> build() {
+            return new JsonSecurityEventFormatter(this);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/audit/SimpleSecurityEventFormatter.java
+++ b/src/main/java/org/wildfly/security/audit/SimpleSecurityEventFormatter.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import java.security.Permission;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.function.Supplier;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.auth.server.event.SecurityDefiniteOutcomeEvent;
+import org.wildfly.security.auth.server.event.SecurityEvent;
+import org.wildfly.security.auth.server.event.SecurityEventVisitor;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckEvent;
+
+/**
+ * A formatter for security events that converts the event to a simple String.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SimpleSecurityEventFormatter extends SecurityEventVisitor<Void, String> {
+
+    private final Supplier<DateFormat> dateFormatSupplier;
+
+    /**
+     *
+     */
+    SimpleSecurityEventFormatter(Builder builder) {
+        this.dateFormatSupplier = builder.dateFormatSupplier;
+    }
+
+    @Override
+    public String handleUnknownEvent(SecurityEvent event, Void param) {
+        checkNotNullParam("event", event);
+        StringBuilder stringBuilder = new StringBuilder('{');
+        handleUnknownEvent(event, stringBuilder);
+        return stringBuilder.append('}').toString();
+    }
+
+    private void handleUnknownEvent(SecurityEvent event, StringBuilder stringBuilder) {
+        DateFormat dateFormat = dateFormatSupplier.get();
+        stringBuilder.append("event=").append(event.getClass().getSimpleName());
+        stringBuilder.append(",event-time=").append(dateFormat.format(Date.from(event.getInstant())));
+
+        SecurityIdentity securityIdentity = event.getSecurityIdentity();
+        stringBuilder.append(",security-identity=[name=").append(securityIdentity.getPrincipal().getName());
+        stringBuilder.append(",creation-time=").append(dateFormat.format(Date.from(securityIdentity.getCreationTime()))).append(']');
+    }
+
+
+    @Override
+    public String handleDefiniteOutcomeEvent(SecurityDefiniteOutcomeEvent event, Void param) {
+        checkNotNullParam("event", event);
+        StringBuilder stringBuilder = new StringBuilder('{');
+        handleDefiniteOutcomeEvent(event, stringBuilder);
+        return stringBuilder.append('}').toString();
+    }
+
+    private void handleDefiniteOutcomeEvent(SecurityDefiniteOutcomeEvent event, StringBuilder stringBuilder) {
+        handleUnknownEvent(event, stringBuilder);
+        stringBuilder.append(",success=").append(event.isSuccessful());
+    }
+
+    @Override
+    public String handlePermissionCheckEvent(SecurityPermissionCheckEvent event, Void param) {
+        checkNotNullParam("event", event);
+        StringBuilder stringBuilder = new StringBuilder('{');
+        handlePermissionCheckEvent(event, stringBuilder);
+        return stringBuilder.append('}').toString();
+    }
+
+    private void handlePermissionCheckEvent(SecurityPermissionCheckEvent event, StringBuilder stringBuilder) {
+        handleDefiniteOutcomeEvent(event, stringBuilder);
+
+        Permission permission = event.getPermission();
+        stringBuilder.append(",permission=[type=").append(permission.getClass().getName());
+        stringBuilder.append(",actions=").append(permission.getActions());
+        stringBuilder.append(",name=").append(permission.getName()).append(']');
+    }
+
+    /**
+     * Create a new builder.
+     *
+     * @return a new builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Supplier<DateFormat> dateFormatSupplier = SimpleDateFormat::new;
+
+        Builder() {
+        }
+
+        /**
+         * Set a {@link Supplier<DateFormat>} to format any dates in the resulting output.
+         *
+         * @param dateFormatSupplier a {@link Supplier<DateFormat>} to format any dates in the resulting output.
+         * @return {@code this} builder.
+         */
+        public Builder setDateFormatSupplier(Supplier<DateFormat> dateFormatSupplier) {
+            this.dateFormatSupplier = checkNotNullParam("dateFormatSupplier", dateFormatSupplier);
+
+            return this;
+        }
+
+        /**
+         * Build a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into a simple String
+         *
+         * Once built the Builder can continue to be configured to create additional instances.
+         *
+         * @return a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into a simple String
+         *         Strings.
+         */
+        public SecurityEventVisitor<Void, String> build() {
+            return new SimpleSecurityEventFormatter(this);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/audit/SyslogAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/SyslogAuditEndpoint.java
@@ -1,0 +1,164 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security._private.ElytronMessages.audit;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.handlers.SyslogHandler;
+import org.jboss.logmanager.handlers.SyslogHandler.Facility;
+import org.jboss.logmanager.handlers.SyslogHandler.Protocol;
+
+/**
+ * An {@link AuditEndpoint} that logs to syslog.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SyslogAuditEndpoint implements AuditEndpoint {
+
+    private volatile boolean accepting = true;
+
+    private final SyslogHandler syslogHandler;
+
+    /**
+     *
+     */
+    SyslogAuditEndpoint(Builder builder) throws IOException {
+        syslogHandler = new SyslogHandler(checkNotNullParam("serverAddress", builder.serverAddress), builder.port, Facility.SECURITY,
+                null, builder.tcp ? Protocol.TCP : Protocol.UDP, checkNotNullParam("hostName", builder.hostName));
+
+    }
+
+    @Override
+    public void accept(EventPriority t, String u) throws IOException {
+        if (!accepting) return;
+
+        synchronized(this) {
+            if (!accepting) return;
+
+            syslogHandler.doPublish(new ExtLogRecord(toLevel(t), u, SyslogAuditEndpoint.class.getName()));
+        }
+    }
+
+    private static Level toLevel(EventPriority eventPriority) {
+        switch (eventPriority) {
+            case ALERT:
+            case EMERGENCY:
+            case CRITICAL:
+            case ERROR:
+                return Level.SEVERE;
+            case WARNING:
+                return Level.WARNING;
+            case INFORMATIONAL:
+                return Level.INFO;
+            case OFF:
+                throw audit.invalidEventPriority(eventPriority);
+            default:
+                return Level.FINEST;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        accepting = false;
+
+        synchronized(this) {
+            syslogHandler.close();
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private InetAddress serverAddress;
+        private int port;
+        private boolean tcp = true;
+        private String hostName;
+
+        Builder() {
+        }
+
+        /**
+         * Set the server address syslog messages should be sent to.
+         *
+         * @param serverAddress the server address syslog messages should be sent to.
+         * @return this builder.
+         */
+        public Builder setServerAddress(InetAddress serverAddress) {
+            this.serverAddress = checkNotNullParam("serverAddress", serverAddress);
+
+            return this;
+        }
+
+        /**
+         * Set the port the syslog server is listening on.
+         *
+         * @param port the port the syslog server is listening on.
+         * @return this builder.
+         */
+        public Builder setPort(int port) {
+            this.port = port;
+
+            return this;
+        }
+
+        /**
+         * Set if the communication should be using TCP.
+         *
+         * @param tcp if the communication should be using TCP.
+         * @return this builder.
+         */
+        public Builder setTcp(boolean tcp) {
+            this.tcp = tcp;
+
+            return this;
+        }
+
+        /**
+         * Set the host name that should be sent within the syslog messages.
+         *
+         * @param hostName the host name that should be sent within the syslog messages.
+         * @return this builder.
+         */
+        public Builder setHostName(String hostName) {
+            this.hostName = checkNotNullParam("hostName", hostName);
+
+            return this;
+        }
+
+        /**
+         * Build a new {@link AuditEndpoint} configured to pass all messages using Syslog.
+         *
+         * @return a new {@link AuditEndpoint} configured to pass all messages using Syslog.
+         * @throws IOException if an error occurs initialising the endpoint.
+         */
+        public AuditEndpoint build() throws IOException {
+            return new SyslogAuditEndpoint(this);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wildfly/security/audit/package-info.java
+++ b/src/main/java/org/wildfly/security/audit/package-info.java
@@ -19,6 +19,24 @@
 /**
  * Audit logging related resources.
  *
+ * Audit logging registers with the {@link org.wildfly.security.auth.server.SecurityDomain} by registering a
+ * {@link java.util.function.Consumer<SecurityEvent>} to receive the emitted events.
+ *
+ * The audit logging framework is comprised of three core components.
+ * <ol>
+ * <li>Priority Mapper</li>
+ * <li>Event Formatter</li>
+ * <li>Audit Endpoint</li>
+ * </ol>
+ *
+ * The priority mapper takes an incoming security event and maps it to one of nine priority levels including a level 'OFF' to
+ * cause the event to be immediately discarded.
+ *
+ * The event formatter takes a security event and converts it to a formatted String ready to be recorded.
+ *
+ * The audit endpoint is the final component and takes the resulting priority and formatted String to be logged according to the
+ * endpoint's configuration.
+ *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 package org.wildfly.security.audit;

--- a/src/main/java/org/wildfly/security/audit/package-info.java
+++ b/src/main/java/org/wildfly/security/audit/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Audit logging related resources.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+package org.wildfly.security.audit;

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -588,7 +588,7 @@ public final class SecurityDomain {
         this.securityEventListener.accept(securityEvent);
     }
 
-    static void safeHandlerSecurityEvent(final SecurityDomain domain, final SecurityEvent event) {
+    static void safeHandleSecurityEvent(final SecurityDomain domain, final SecurityEvent event) {
         checkNotNullParam("domain", domain);
         checkNotNullParam("event", event);
         try {

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -48,6 +49,7 @@ import org.wildfly.security.auth.SupportLevel;
 import org.wildfly.security.auth.principal.AnonymousPrincipal;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.principal.RealmNestedPrincipal;
+import org.wildfly.security.auth.server.event.SecurityEvent;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.authz.PermissionMapper;
 import org.wildfly.security.authz.RoleDecoder;
@@ -88,6 +90,7 @@ public final class SecurityDomain {
     private final Map<String, RoleMapper> categoryRoleMappers;
     private final UnaryOperator<SecurityIdentity> securityIdentityTransformer;
     private final Predicate<SecurityDomain> trustedSecurityDomain;
+    private final Consumer<SecurityEvent> securityEventListener;
 
     SecurityDomain(Builder builder, final LinkedHashMap<String, RealmInfo> realmMap) {
         this.realmMap = realmMap;
@@ -99,6 +102,7 @@ public final class SecurityDomain {
         this.postRealmPrincipalRewriter = builder.postRealmRewriter;
         this.securityIdentityTransformer = builder.securityIdentityTransformer;
         this.trustedSecurityDomain = builder.trustedSecurityDomain;
+        this.securityEventListener = builder.securityEventListener;
         final Map<String, RoleMapper> originalRoleMappers = builder.categoryRoleMappers;
         final Map<String, RoleMapper> copiedRoleMappers;
         if (originalRoleMappers.isEmpty()) {
@@ -578,6 +582,22 @@ public final class SecurityDomain {
         return this == domain || trustedSecurityDomain.test(domain);
     }
 
+    void handleSecurityEvent(final SecurityEvent securityEvent) {
+        // If visibility of this method is increased double check the
+        // event does relate to this security domain.
+        this.securityEventListener.accept(securityEvent);
+    }
+
+    static void safeHandlerSecurityEvent(final SecurityDomain domain, final SecurityEvent event) {
+        checkNotNullParam("domain", domain);
+        checkNotNullParam("event", event);
+        try {
+            domain.handleSecurityEvent(event);
+        } catch (Exception e) {
+            log.eventHandlerFailed(e);
+        }
+    }
+
     /**
      * A builder for creating new security domains.
      */
@@ -595,6 +615,7 @@ public final class SecurityDomain {
         private Map<String, RoleMapper> categoryRoleMappers = emptyMap();
         private UnaryOperator<SecurityIdentity> securityIdentityTransformer = UnaryOperator.identity();
         private Predicate<SecurityDomain> trustedSecurityDomain = domain -> false;
+        private Consumer<SecurityEvent> securityEventListener = e -> {};
 
         Builder() {
         }
@@ -786,6 +807,17 @@ public final class SecurityDomain {
         public Builder setTrustedSecurityDomainPredicate(final Predicate<SecurityDomain> trustedSecurityDomain) {
             Assert.checkNotNullParam("trustedSecurityDomain", trustedSecurityDomain);
             this.trustedSecurityDomain = trustedSecurityDomain;
+            return this;
+        }
+
+        /**
+         * Set the security event listener that will consume all {@link SecurityEvent} instances emitted but the domain.
+         *
+         * @param securityEventListener the security event listener that will consume all {@link SecurityEvent} instances emitted but the domain.
+         * @return this builder
+         */
+        public Builder setSecurityEventListener(final Consumer<SecurityEvent> securityEventListener) {
+            this.securityEventListener = Assert.checkNotNullParam("securityEventListener", securityEventListener);
             return this;
         }
 

--- a/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
@@ -45,6 +45,8 @@ import org.wildfly.security.ParametricPrivilegedExceptionAction;
 import org.wildfly.security.auth.permission.ChangeRoleMapperPermission;
 import org.wildfly.security.auth.principal.AnonymousPrincipal;
 import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckFailedEvent;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckSuccessfulEvent;
 import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.authz.PermissionMappable;
@@ -678,8 +680,10 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
     }
 
     public boolean implies(final Permission permission) {
-        // TODO: authorization audit goes here
-        return verifier.implies(permission);
+        final boolean result = verifier.implies(permission);
+        SecurityDomain.safeHandleSecurityEvent(securityDomain,
+                result ? new SecurityPermissionCheckSuccessfulEvent(this, permission) : new SecurityPermissionCheckFailedEvent(this, permission));
+        return result;
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationEvent.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A security authentication event.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class SecurityAuthenticationEvent extends SecurityDefiniteOutcomeEvent {
+
+    /**
+     * Create a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} at the time of authentication.
+     * @param successful was the authentication process successful.
+     */
+    SecurityAuthenticationEvent(SecurityIdentity securityIdentity, boolean successful) {
+        super(securityIdentity, successful);
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handleAuthenticationEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An event to represent a failed authentication.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class SecurityAuthenticationFailedEvent extends SecurityAuthenticationEvent {
+
+    /**
+     * Constructor for a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} that failed authentication.
+     */
+    public SecurityAuthenticationFailedEvent(SecurityIdentity securityIdentity) {
+        super(securityIdentity, false);
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handleAuthenticationFailedEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationSuccessfulEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationSuccessfulEvent.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An event to represent a successful authentication.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class SecurityAuthenticationSuccessfulEvent extends SecurityAuthenticationEvent {
+
+    /**
+     * Constructor for a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} that successfully authenticated.
+     */
+    public SecurityAuthenticationSuccessfulEvent(SecurityIdentity securityIdentity) {
+        super(securityIdentity, true);
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handleAuthenticationSuccessfulEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityDefiniteOutcomeEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityDefiniteOutcomeEvent.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A {@link SecurityEvent} that has a definite outcome of being successful or not.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class SecurityDefiniteOutcomeEvent extends SecurityEvent {
+
+    private final boolean successful;
+    /**
+     * @param securityIdentity
+     */
+    SecurityDefiniteOutcomeEvent(SecurityIdentity securityIdentity, boolean successful) {
+        super(securityIdentity);
+        this.successful = successful;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityEvent.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.server.event;
+
+import java.time.Instant;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * Base class for security events emitted from a {@link SecurityDomain}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class SecurityEvent {
+
+    private final Instant instant = Instant.now();
+
+    private final SecurityIdentity securityIdentity;
+
+    /**
+     * Constructor for a new instance.
+     *
+     * @param securityIdentity the current {@link SecurityIdentity} for the event.
+     */
+    SecurityEvent(SecurityIdentity securityIdentity) {
+        this.securityIdentity = securityIdentity;
+    }
+
+    /**
+     * Get the {@link SecurityIdentity} that was active at the time this event was triggered.
+     *
+     * @return the {@link SecurityIdentity} that was active at the time this event was triggered.
+     */
+    public SecurityIdentity getSecurityIdentity() {
+        return securityIdentity;
+    }
+
+    /**
+     * Obtain the {@link Instant} this event was created.
+     *
+     * @return the {@link Instant} this event was created.
+     */
+    public Instant getInstant() {
+        return instant;
+    }
+
+    /**
+     * Accept the given visitor, calling the method which is most applicable to this event type.
+     *
+     * @param visitor the visitor
+     * @param param the parameter to pass to the visitor {@code handleXxx} method
+     * @param <P> the visitor parameter type
+     * @param <R> the visitor return type
+     * @return the value returned from the visitor {@code handleXxx} method
+     */
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handleUnknownEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityEvent.java
@@ -18,8 +18,11 @@
 
 package org.wildfly.security.auth.server.event;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.time.Instant;
 
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 
 /**
@@ -39,7 +42,7 @@ public abstract class SecurityEvent {
      * @param securityIdentity the current {@link SecurityIdentity} for the event.
      */
     SecurityEvent(SecurityIdentity securityIdentity) {
-        this.securityIdentity = securityIdentity;
+        this.securityIdentity = checkNotNullParam("securityIdentity", securityIdentity);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityEventVisitor.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityEventVisitor.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+/**
+ * An abstract class to be extended by visitor implementations for handling SecurityEvents.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class SecurityEventVisitor<P, R> {
+
+    protected SecurityEventVisitor() {
+    }
+
+    /**
+     * Handle any unhandled security event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handleUnknownEvent(final SecurityEvent event, final P param) {
+        return null;
+    }
+
+    /**
+     * Handle a security definite outcome event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handleDefiniteOutcomeEvent(final SecurityDefiniteOutcomeEvent event, final P param) {
+        return handleUnknownEvent(event, param);
+    }
+
+    /**
+     * Handle a security authentication event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handleAuthenticationEvent(final SecurityAuthenticationEvent event, final P param) {
+        return handleDefiniteOutcomeEvent(event, param);
+    }
+
+    /**
+     * Handle a security authentication successful event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handleAuthenticationSuccessfulEvent(final SecurityAuthenticationSuccessfulEvent event, final P param) {
+        return handleAuthenticationEvent(event, param);
+    }
+
+    /**
+     * Handle a security authentication failed event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handleAuthenticationFailedEvent(final SecurityAuthenticationFailedEvent event, final P param) {
+        return handleAuthenticationEvent(event, param);
+    }
+
+    /**
+     * Handle a security permission check event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handlePermissionCheckEvent(final SecurityPermissionCheckEvent event, final P param) {
+        return handleDefiniteOutcomeEvent(event, param);
+    }
+
+    /**
+     * Handle a security permission check successful event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handlePermissionCheckSuccessfulEvent(final SecurityPermissionCheckSuccessfulEvent event, final P param) {
+        return handlePermissionCheckEvent(event, param);
+    }
+
+    /**
+     * Handle a security permission check failed event.
+     *
+     * @param event the security event
+     * @param param the visitor parameter
+     * @return the visitor return value
+     */
+    public R handlePermissionCheckFailedEvent(final SecurityPermissionCheckFailedEvent event, final P param) {
+        return handlePermissionCheckEvent(event, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckEvent.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import java.security.Permission;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * A security event relating to a permission check.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class SecurityPermissionCheckEvent extends SecurityDefiniteOutcomeEvent {
+
+    private final Permission permission;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} the permission check was against.
+     * @param successful was the permission check successful.
+     * @param permission the {@link Permission} that was checked.
+     */
+    public SecurityPermissionCheckEvent(SecurityIdentity securityIdentity, Permission permission, boolean successful) {
+        super(securityIdentity, successful);
+        this.permission = permission;
+    }
+
+    /**
+     * Obtain the {@link Permission} this event related to.
+     *
+     * @return the {@link Permission} this event related to.
+     */
+    public Permission getPermission() {
+        return permission;
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handlePermissionCheckEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckFailedEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckFailedEvent.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import java.security.Permission;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An event to represent a failed permission check.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class SecurityPermissionCheckFailedEvent extends SecurityPermissionCheckEvent {
+
+    /**
+     * Construct a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} the permisson check was against.
+     * @param permission the {@link Permission} that was checked.
+     */
+    public SecurityPermissionCheckFailedEvent(SecurityIdentity securityIdentity, Permission permission) {
+        super(securityIdentity, permission, false);
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handlePermissionCheckFailedEvent(this, param);
+    }
+
+}

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckSuccessfulEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityPermissionCheckSuccessfulEvent.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.server.event;
+
+import java.security.Permission;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * An event to represent a successful permission check.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class SecurityPermissionCheckSuccessfulEvent extends SecurityPermissionCheckEvent {
+
+    /**
+     * Construct a new instance.
+     *
+     * @param securityIdentity the {@link SecurityIdentity} the permisson check was against.
+     * @param permission the {@link Permission} that was checked.
+     */
+    public SecurityPermissionCheckSuccessfulEvent(SecurityIdentity securityIdentity, Permission permission) {
+        super(securityIdentity, permission, true);
+    }
+
+    @Override
+    public <P, R> R accept(SecurityEventVisitor<P, R> visitor, P param) {
+        return visitor.handlePermissionCheckSuccessfulEvent(this, param);
+    }
+
+}

--- a/src/test/java/org/wildfly/security/audit/JsonSecurityEventFormatterTest.java
+++ b/src/test/java/org/wildfly/security/audit/JsonSecurityEventFormatterTest.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.FilePermission;
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.event.SecurityAuthenticationSuccessfulEvent;
+import org.wildfly.security.auth.server.event.SecurityEvent;
+import org.wildfly.security.auth.server.event.SecurityEventVisitor;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckFailedEvent;
+
+/**
+ * Test case to test the JsonSecurityEventFormatter
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class JsonSecurityEventFormatterTest {
+
+    private static SecurityEventVisitor<?, String> jsonFormatter;
+    private static SecurityDomain securityDomain;
+
+    @BeforeClass
+    public static void createDomain() {
+        jsonFormatter = JsonSecurityEventFormatter.builder().build();
+        securityDomain = SecurityDomain.builder()
+                .addRealm("Simple", new SimpleMapBackedSecurityRealm()).build()
+                .setDefaultRealmName("Simple")
+                .build();
+    }
+
+    private JsonObject baseTest(SecurityEvent event) {
+        String formatted = event.accept(jsonFormatter, null);
+
+        System.out.println(formatted);
+
+        JsonReader reader = Json.createReader(new StringReader(formatted));
+        JsonObject jsonObject = reader.readObject();
+
+        assertNotNull("Event Time", jsonObject.getString("event-time"));
+
+        JsonObject securityIdentity = jsonObject.getJsonObject("security-identity");
+        assertEquals("Name", "anonymous", securityIdentity.getString("name"));
+        assertNotNull("Creation Time", securityIdentity.getString("creation-time"));
+
+        return jsonObject;
+    }
+
+    @Test
+    public void testAuthenticationSuccessful() {
+        JsonObject jsonObject = baseTest(new SecurityAuthenticationSuccessfulEvent(securityDomain.getCurrentSecurityIdentity()));
+
+        assertEquals("Expected Event", "SecurityAuthenticationSuccessfulEvent", jsonObject.getString("event"));
+        assertEquals("Success", true, jsonObject.getBoolean("success"));
+    }
+
+    @Test
+    public void testPermissionCheckFailed() {
+        JsonObject jsonObject = baseTest(new SecurityPermissionCheckFailedEvent(securityDomain.getCurrentSecurityIdentity(), new FilePermission("/etc", "read")));
+
+        assertEquals("Expected Event", "SecurityPermissionCheckFailedEvent", jsonObject.getString("event"));
+        assertEquals("Success", false, jsonObject.getBoolean("success"));
+
+        JsonObject permission = jsonObject.getJsonObject("permission");
+        assertEquals("Permission Type", "java.io.FilePermission", permission.getString("type"));
+        assertEquals("Permission Actions", "read", permission.getString("actions"));
+        assertEquals("Permission Name", "/etc", permission.getString("name"));
+    }
+}

--- a/src/test/java/org/wildfly/security/audit/SimpleSecurityEventFormatterTest.java
+++ b/src/test/java/org/wildfly/security/audit/SimpleSecurityEventFormatterTest.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FilePermission;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.event.SecurityAuthenticationSuccessfulEvent;
+import org.wildfly.security.auth.server.event.SecurityEvent;
+import org.wildfly.security.auth.server.event.SecurityEventVisitor;
+import org.wildfly.security.auth.server.event.SecurityPermissionCheckFailedEvent;
+
+/**
+ * Test case to test the SimpleSecurityEventFormatter
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SimpleSecurityEventFormatterTest {
+
+    private static SecurityEventVisitor<?, String> simpleFormatter;
+    private static SecurityDomain securityDomain;
+
+    @BeforeClass
+    public static void createDomain() {
+        simpleFormatter = SimpleSecurityEventFormatter.builder().build();
+        securityDomain = SecurityDomain.builder()
+                .addRealm("Simple", new SimpleMapBackedSecurityRealm()).build()
+                .setDefaultRealmName("Simple")
+                .build();
+    }
+
+    private String baseTest(SecurityEvent event) {
+        String formatted = event.accept(simpleFormatter, null);
+
+        System.out.println(formatted);
+
+        assertTrue("Event Time", formatted.contains("event-time="));
+        assertTrue("Security Identity", formatted.contains("security-identity="));
+        assertTrue("Identity Name", formatted.contains("name=anonymous"));
+        assertTrue("Identity Creation Time", formatted.contains("creation-time="));
+
+        return formatted;
+    }
+
+    @Test
+    public void testAuthenticationSuccessful() {
+        String formatted = baseTest(new SecurityAuthenticationSuccessfulEvent(securityDomain.getCurrentSecurityIdentity()));
+
+        assertTrue("Event", formatted.contains("event=SecurityAuthenticationSuccessfulEvent"));
+        assertTrue("Success", formatted.contains("success=true"));
+    }
+
+    @Test
+    public void testPermissionCheckFailed() {
+        String formatted = baseTest(new SecurityPermissionCheckFailedEvent(securityDomain.getCurrentSecurityIdentity(), new FilePermission("/etc", "read")));
+
+        assertTrue("Event", formatted.contains("event=SecurityPermissionCheckFailedEvent"));
+        assertTrue("Success", formatted.contains("success=false"));
+
+        assertTrue("Permission", formatted.contains("permission="));
+        assertTrue("Permission Type", formatted.contains("type=java.io.FilePermission"));
+        assertTrue("Permission Actions", formatted.contains("actions=read"));
+        assertTrue("Permission Name", formatted.contains("name=/etc"));
+    }
+}


### PR DESCRIPTION
This pull request adds a small set of security events to the security domain.
It adds formatters to convert those events to Strings.
Two audit log endpoints so we can log to file or sent to syslog.
A general AuditLogger to combine the various components.

Once we have an initial solution in place we will need to follow up with: -

1. Completing the set of audit events to be emitted from the domain.
2. Implement the rules and Function that can take an event and map it to a priority (including OFF)
3. Enhance the file audit log for rotation on start up, rotation by time, and rotation by size.
4. Implement our on Syslog client.
5. Performance improvements e.g. non-blocking mode, ThreadLocal managed DateFormat.
6. Allow containers and applications to pass SecurityEvents through the SecurityDomain, i.e. container authorization decisions.

For now I borrowed the Syslog implementation from Logging Processor but we should probably have out own.
 
The following PR adds resources to the Elytron subsystem to configure audit logging: -
  https://github.com/wildfly-security/elytron-subsystem/pull/414

Locally I have a WildFly instance running simultaneously logging to the local file and sending events to a remote syslog server.