### PR TITLE
[ELY-954] Coverity static analysis, Dereference null return value, OAuth2CredentialSource (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
+++ b/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
@@ -167,10 +167,11 @@ public class OAuth2CredentialSource implements CredentialSource {
         log.debugf("Opening connection to [%s]", tokenEndpointUri);
         HttpURLConnection connection = (HttpURLConnection) tokenEndpointUri.openConnection();
 
-        if (isHttps(tokenEndpointUri)) {
+        SSLContext sslContext = resolveSSLContext();
+        if (sslContext != null) {
             HttpsURLConnection https = (HttpsURLConnection) connection;
 
-            https.setSSLSocketFactory(resolveSSLContext().getSocketFactory());
+            https.setSSLSocketFactory(sslContext.getSocketFactory());
             if (hostnameVerifierSupplier != null) {
                 https.setHostnameVerifier(checkNotNullParam("hostnameVerifier", hostnameVerifierSupplier.get()));
             }


### PR DESCRIPTION
Wildfly Elytron: https://issues.jboss.org/browse/ELY-954
