### PR TITLE
[ELY-972] audit logging on unvalid credential

### DIFF
--- a/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
+++ b/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
@@ -29,6 +29,7 @@ import javax.json.Json;
 import javax.json.JsonObjectBuilder;
 
 import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.auth.server.event.SecurityAuthenticationFailedEvent;
 import org.wildfly.security.auth.server.event.SecurityDefiniteOutcomeEvent;
 import org.wildfly.security.auth.server.event.SecurityEvent;
 import org.wildfly.security.auth.server.event.SecurityEventVisitor;
@@ -83,6 +84,19 @@ public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, Strin
     private void handleDefiniteOutcomeEvent(SecurityDefiniteOutcomeEvent event, JsonObjectBuilder objectBuilder) {
         handleUnknownEvent(event, objectBuilder);
         objectBuilder.add("success", event.isSuccessful());
+    }
+
+    @Override
+    public String handleAuthenticationFailedEvent(SecurityAuthenticationFailedEvent event, Void param) {
+        checkNotNullParam("event", event);
+        JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
+        handleAuthenticationFailedEvent(event, objectBuilder);
+        return objectBuilder.build().toString();
+    }
+
+    private void handleAuthenticationFailedEvent(SecurityAuthenticationFailedEvent event, JsonObjectBuilder objectBuilder) {
+        handleDefiniteOutcomeEvent(event, objectBuilder);
+        objectBuilder.add("principal", event.getPrincipal() != null ? event.getPrincipal().toString() : null);
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1785,7 +1785,7 @@ public final class ServerAuthenticationContext {
                 return;
             }
             SecurityRealm.safeHandleRealmEvent(getRealmInfo().getSecurityRealm(), new RealmFailedAuthenticationEvent(realmIdentity, null, null));
-            SecurityDomain.safeHandleSecurityEvent(capturedIdentity.getSecurityDomain(), new SecurityAuthenticationFailedEvent(capturedIdentity));
+            SecurityDomain.safeHandleSecurityEvent(capturedIdentity.getSecurityDomain(), new SecurityAuthenticationFailedEvent(capturedIdentity, realmIdentity.getRealmIdentityPrincipal()));
             realmIdentity.dispose();
         }
 
@@ -2144,7 +2144,7 @@ public final class ServerAuthenticationContext {
                 return;
             }
             SecurityRealm.safeHandleRealmEvent(getRealmInfo().getSecurityRealm(), new RealmFailedAuthenticationEvent(realmIdentity, null, null));
-            SecurityDomain.safeHandleSecurityEvent(authorizedIdentity.getSecurityDomain(), new SecurityAuthenticationFailedEvent(authorizedIdentity));
+            SecurityDomain.safeHandleSecurityEvent(authorizedIdentity.getSecurityDomain(), new SecurityAuthenticationFailedEvent(authorizedIdentity, realmIdentity.getRealmIdentityPrincipal()));
             realmIdentity.dispose();
         }
 

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
@@ -19,6 +19,8 @@ package org.wildfly.security.auth.server.event;
 
 import org.wildfly.security.auth.server.SecurityIdentity;
 
+import java.security.Principal;
+
 /**
  * An event to represent a failed authentication.
  *
@@ -26,13 +28,20 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  */
 public final class SecurityAuthenticationFailedEvent extends SecurityAuthenticationEvent {
 
+    private final Principal principal;
+
     /**
      * Constructor for a new instance.
      *
      * @param securityIdentity the {@link SecurityIdentity} that failed authentication.
      */
-    public SecurityAuthenticationFailedEvent(SecurityIdentity securityIdentity) {
+    public SecurityAuthenticationFailedEvent(SecurityIdentity securityIdentity, Principal principal) {
         super(securityIdentity, false);
+        this.principal = principal;
+    }
+
+    public Principal getPrincipal() {
+        return principal;
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-972

* emiting AuthenticationFailedEvent on unvalid credential/principal
* information about principal written by user into AuthenticationFailedEvent (because SecurityIdentity is anonymous in that phase)
* refac: consolidation of `if( ! stateRef.compareAndSet` vs `if(stateRef.compareAndSet` between individual parts of SAC - to be comparable better