### PR TITLE
[ELY-689] Remove entry from cache of KeyStoreCredentialStore after successful removal of other entries

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -655,6 +655,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     }
                 }
             }
+            cache.remove(credentialAlias);
             // done!
         } catch (KeyStoreException e) {
             throw log.cannotRemoveCredentialFromStore(e);

--- a/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
+++ b/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
@@ -24,6 +24,7 @@ import java.security.Security;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -204,6 +205,9 @@ public class KeystorePasswordStoreTest {
 
         // remove test
         cs.remove(passwordAlias2, PasswordCredential.class);
+
+        Set<String> aliases = cs.getAliases();
+        Assert.assertFalse("Alias \"" + passwordAlias2 + "\" should be removed.", aliases.contains(passwordAlias2));
 
         if (!cs.exists("db-password", PasswordCredential.class)) {
             Assert.fail("'db-password'" + " has to exist");


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-689
https://issues.jboss.org/browse/JBEAP-6630