### PR TITLE
Add support for renegotiation in the client cert mechanism

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -326,6 +327,16 @@ public class HttpAuthenticator {
         @Override
         public boolean resumeRequest() {
             return httpExchangeSpi.resumeRequest();
+        }
+
+        @Override
+        public boolean isAuthenticationRequired() {
+            return required;
+        }
+
+        @Override
+        public Certificate[] renegotiateForClientCertAuth() {
+            return httpExchangeSpi.renegotiateForClientCertAuth();
         }
 
     }

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -244,4 +244,12 @@ public interface HttpExchangeSpi extends HttpServerScopes {
          return false;
      }
 
+    /**
+     * Attempts to renegotiate the HTTPS connection to get a client certificate, and returns the renegotiated
+     * certificate
+     * @return the certificates if successful, null otherwise
+     */
+    default java.security.cert.Certificate[] renegotiateForClientCertAuth() {
+        return null;
+    }
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -27,8 +27,6 @@ import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
-import org.wildfly.security.auth.server.SecurityIdentity;
-
 /**
  * Server side representation of a HTTP request.
  *
@@ -115,7 +113,6 @@ public interface HttpServerRequest extends HttpServerScopes {
      *
      * If this form is called no response is expected from this mechanism.
      *
-     * @param securityIdentity the {@link SecurityIdentity} established as a result of this authentication.
      */
     default void authenticationComplete() {
         authenticationComplete(null);
@@ -251,4 +248,16 @@ public interface HttpServerRequest extends HttpServerScopes {
      */
     boolean resumeRequest();
 
+    /**
+     *
+     * @return <code>true</code> If this request requires authentication to proceed
+     */
+    boolean isAuthenticationRequired();
+
+    /**
+     * Attempts to renegotiate the HTTPS connection to get a client certificate, and returns the renegotiated
+     * certificate
+     * @return the certificates if successful, null otherwise
+     */
+    java.security.cert.Certificate[] renegotiateForClientCertAuth();
 }

--- a/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLSession;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -159,5 +160,15 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     @Override
     public boolean resumeRequest() {
         return delegate.resumeRequest();
+    }
+
+    @Override
+    public boolean isAuthenticationRequired() {
+        return delegate.isAuthenticationRequired();
+    }
+
+    @Override
+    public Certificate[] renegotiateForClientCertAuth() {
+        return delegate.renegotiateForClientCertAuth();
     }
 }

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -27,6 +27,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -251,6 +252,16 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
         @Override
         public boolean resumeRequest() {
             return wrapped.resumeRequest();
+        }
+
+        @Override
+        public boolean isAuthenticationRequired() {
+            return wrapped.isAuthenticationRequired();
+        }
+
+        @Override
+        public Certificate[] renegotiateForClientCertAuth() {
+            return wrapped.renegotiateForClientCertAuth();
         }
 
 


### PR DESCRIPTION
This does not work in practice yet, due to the SSLEngine wrapping