### PR TITLE
[ELY-621] Client-Cert SSL Session Re-negotiation Support

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -18,16 +18,16 @@
 
 package org.wildfly.security.http;
 
-import static org.wildfly.security.http.HttpConstants.SECURITY_IDENTITY;
-
 import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
 import static org.wildfly.security.http.HttpConstants.OK;
+import static org.wildfly.security.http.HttpConstants.SECURITY_IDENTITY;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -163,6 +163,11 @@ public class HttpAuthenticator {
         @Override
         public SSLSession getSSLSession() {
             return httpExchangeSpi.getSSLSession();
+        }
+
+        @Override
+        public Certificate[] getPeerCertificates() {
+            return httpExchangeSpi.getPeerCertificates(required);
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -21,6 +21,7 @@ package org.wildfly.security.http;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,6 +62,13 @@ public interface HttpServerRequest extends HttpServerScopes {
      *         exists.
      */
     SSLSession getSSLSession();
+
+    /**
+     * Get the peer certificates established on the connection.
+     *
+     * @return the peer certificates established on the connection or {@code null} if none available.
+     */
+    Certificate[] getPeerCertificates();
 
     /**
      * Notification from the mechanism to state no authentication is in progress whilst evaluating the current request.

--- a/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
@@ -18,16 +18,18 @@
 
 package org.wildfly.security.http;
 
-import org.wildfly.common.Assert;
-
-import javax.net.ssl.SSLSession;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.net.ssl.SSLSession;
+
+import org.wildfly.common.Assert;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -69,6 +71,11 @@ public class HttpServerRequestWrapper implements HttpServerRequest {
     @Override
     public SSLSession getSSLSession() {
         return delegate.getSSLSession();
+    }
+
+    @Override
+    public Certificate[] getPeerCertificates() {
+        return delegate.getPeerCertificates();
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
+++ b/src/main/java/org/wildfly/security/http/util/PrivilegedServerMechanism.java
@@ -27,6 +27,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +147,11 @@ final class PrivilegedServerMechanism implements HttpServerAuthenticationMechani
         @Override
         public SSLSession getSSLSession() {
             return wrapped.getSSLSession();
+        }
+
+        @Override
+        public Certificate[] getPeerCertificates() {
+            return wrapped.getPeerCertificates();
         }
 
         @Override

--- a/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
+++ b/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
@@ -110,27 +110,27 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
     }
 
     public void setWantClientAuth(final SSLContext context, final SSLSocket sslSocket, final boolean value) {
-        // ignored
+        if (value) sslSocket.setWantClientAuth(value);
     }
 
     public void setWantClientAuth(final SSLContext context, final SSLEngine sslEngine, final boolean value) {
-        // ignored
+        if (value) sslEngine.setWantClientAuth(value);
     }
 
     public void setWantClientAuth(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final boolean value) {
-        // ignored
+        if (value) sslServerSocket.setWantClientAuth(value);
     }
 
     public void setNeedClientAuth(final SSLContext context, final SSLSocket sslSocket, final boolean value) {
-        // ignored
+        if (value) sslSocket.setNeedClientAuth(value);
     }
 
     public void setNeedClientAuth(final SSLContext context, final SSLEngine sslEngine, final boolean value) {
-        // ignored
+        if (value) sslEngine.setNeedClientAuth(value);
     }
 
     public void setNeedClientAuth(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final boolean value) {
-        // ignored
+        if (value) sslServerSocket.setNeedClientAuth(value);
     }
 
     public void setEnabledCipherSuites(final SSLContext sslContext, final SSLSocket sslSocket, final String[] cipherSuites) {


### PR DESCRIPTION
I have stuck with getPeerCertificates over requirePeerCertificates as it still remains optional for them to be returned.

I haven't remove access to the SSLSession yet as it is used but if we can port the caching portion over to the HttpScope for SSL_SESSION we may not need to provide access at all.