### PR TITLE
[ELY-1013] PicketBox compatibility mode for PBE utility

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -824,6 +824,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 3031, value = "Too many KerberosTicket instances in private credentials")
     GeneralSecurityException tooManyKerberosTicketsFound();
 
+    @Message(id = 3032, value = "Base64 string created with unsupported PicketBox version \"%s\"")
+    IllegalArgumentException wrongBase64InPBCompatibleMode(String base64);
+
     /* ssl package */
 
     @Message(id = 4001, value = "No algorithm found matching TLS/SSL protocol selection criteria")


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1013
https://issues.jboss.org/browse/JBEAP-9254

PicketBox is encoding bytes to base64 non standard way which cannot be fix simply by PB alphabet.
Therefore I created new compatibility mode to produce the same result. 