### PR TITLE
[ELY-1014] DigestAuthenticationMechanism fixes for incomplete config

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1458,6 +1458,12 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6014, value = "Authentication mechanism '%s' cannot be found")
     HttpAuthenticationException httpServerAuthenticationMechanismNotFound(String mechanismName);
 
+    @Message(id = 6015, value = "Unable to authenticate using DIGEST mechanism - realm name needs to be specified")
+    IllegalStateException digestMechanismRequireRealm();
+
+    @Message(id = 6016, value = "Unable to initialize DIGEST mechanism - available realms not specified")
+    HttpAuthenticationException availableRealmsNotSpecified();
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm [%s]")

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -818,6 +818,7 @@ public final class ServerAuthenticationContext {
                 } else if (callback instanceof CredentialCallback) {
                     final CredentialCallback credentialCallback = (CredentialCallback) callback;
 
+                    // TODO: should consider realm from RealmCallback
                     final Credential credential = getCredential(credentialCallback.getCredentialType(), credentialCallback.getAlgorithm());
                     if (credential != null) {
                         log.tracef("Handling CredentialCallback: obtained successfully");

--- a/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.http.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.http.HttpConstants.HOST;
 
 import java.util.Map;
@@ -108,6 +109,7 @@ public class SetMechanismInformationMechanismFactory implements HttpServerAuthen
 
                 } catch (Throwable e) {
                     // Give up now since the mechanism information could not be successfully resolved to a mechanism configuration
+                    log.trace("Providing MechanismInformation failed", e);
                     request.noAuthenticationInProgress();
                     return;
                 }


### PR DESCRIPTION
* fix for situation when default realm is configured, but available realms are not
* fix for wrong realm name in users clear property file / realms with two-way passwords without realm name consistent with auth mechanism (digest from two-way first)

Now for working digest auth it is sufficient to have corresponding realm names in one of following:
* a) web.xml AND user property file
* b) web.xml AND mechanism in http-authentication-factory

ADDED security fix:
* Removed defaulting realm to HTTP Host - was allowing to spoof unallowed realm from client