### PR TITLE
[ELY-1034] Additional error handling for HTTP authentication.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1464,6 +1464,15 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6015, value = "Unable to authenticate using DIGEST mechanism - realm name needs to be specified")
     IllegalStateException digestMechanismRequireRealm();
 
+    @Message(id = 6016, value = "HTTP authentication failed validating request, no mechanisms remain to continue authentication.")
+    HttpAuthenticationException httpAuthenticationFailedEvaluatingRequest();
+
+    @Message(id = 6017, value = "HTTP authentication is required but no authentication mechansims are available.")
+    HttpAuthenticationException httpAuthenticationNoMechanisms();
+
+    @Message(id = 6018, value = "HTTP authentication none of the responders successfuly sent a response.")
+    HttpAuthenticationException httpAuthenticationNoSuccessfulResponder();
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm [%s]")

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticationException.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticationException.java
@@ -27,6 +27,11 @@ import java.io.IOException;
 public class HttpAuthenticationException extends IOException {
 
     /**
+     *
+     */
+    private static final long serialVersionUID = 2920504964210220416L;
+
+    /**
      * Constructs a new {@code HttpAuthenticationException}. The message is left blank ({@code null}),
      * and no cause is specified.
      */


### PR DESCRIPTION
Generally failed mechanisms lead to an internal server error unless we still have mechanisms available that could succeed, additionally having no mechanisms available when authentication if required is an internal server error.