### PR TITLE
[ELY-1014] Digest credential realm from mechanism, no HOST realm default

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1461,6 +1461,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6014, value = "Authentication mechanism '%s' cannot be found")
     HttpAuthenticationException httpServerAuthenticationMechanismNotFound(String mechanismName);
 
+    @Message(id = 6015, value = "Unable to authenticate using DIGEST mechanism - realm name needs to be specified")
+    IllegalStateException digestMechanismRequireRealm();
+
     /* asn1 package */
 
     @Message(id = 7001, value = "Unrecognized encoding algorithm [%s]")

--- a/src/test/java/org/wildfly/security/sasl/digest/DigestTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/DigestTest.java
@@ -526,6 +526,7 @@ public class DigestTest extends BaseTestCase {
                 .setPassword(DigestPassword.ALGORITHM_DIGEST_MD5, getDigestKeySpec("George", "gpwd", "TestServer"))
                 .setProtocol("TestProtocol")
                 .setServerName("TestServer")
+                .addMechanismRealm("TestServer")
                 .addMechanismRealm("TestRealm")
                 .build();
 


### PR DESCRIPTION
* ServerAuthenticationContext should repect RealmCallback and provide adequacy credential (FastUnsupportedCallbackException when no credential for required realm)
* Digest mechanism should not use HOST as default realm, as it can be misused by attacker to reuse URP from different realm

Replaces https://github.com/wildfly-security/wildfly-elytron/pull/732

Tested successfuly in rev **f6a0358** with wildfly-core and wildfly.