### PR TITLE
[ELY-1014] Warn on missing MechanismConfiguration

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -623,6 +623,10 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1156, value = "Cannot obtain a credential from a security factory")
     IOException cannotObtainCredentialFromFactory(@Cause GeneralSecurityException e);
 
+    @LogMessage(level = WARN)
+    @Message(id = 1157, value = "Unable to resolve MechanismConfiguration for MechanismInformation")
+    void unableToResolveMechanismConfiguration(@Cause Throwable e);
+
     /* keystore package */
 
     @Message(id = 2001, value = "Invalid key store entry password for alias \"%s\"")

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -921,7 +921,6 @@ public final class ServerAuthenticationContext {
                         }
                         setMechanismInformation(mi);
                     } catch (Exception e) {
-                        log.trace(e);
                         throw new IOException(e);
                     }
                 } else if (callback instanceof CredentialUpdateCallback) {

--- a/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
@@ -79,6 +79,7 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
     public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
         SSLSession sslSession = request.getSSLSession();
         if (sslSession == null) {
+            log.trace("CLIENT-CERT no SSL session");
             request.noAuthenticationInProgress();
             return;
         }

--- a/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
@@ -124,6 +124,7 @@ class DigestAuthenticationMechanism implements HttpServerAuthenticationMechanism
                         validateResponse(responseTokens, request);
                         return;
                     } catch (AuthenticationMechanismException e) {
+                        log.trace(e);
                         request.badRequest(e.toHttpAuthenticationException(), response -> prepareResponse(realmName, response, false));
                         return;
                     }
@@ -212,9 +213,12 @@ class DigestAuthenticationMechanism implements HttpServerAuthenticationMechanism
      * Check if realm used by client is allowed to by used to auth
      */
     private void checkRealm(String realm, String defaultRealm) throws AuthenticationMechanismException {
-        for (String current : getAvailableRealms()) {
-            if (realm.equals(current)) {
-                return;
+        String[] realms = getAvailableRealms();
+        if (realms != null) {
+            for (String current : realms) {
+                if (realm.equals(current)) {
+                    return;
+                }
             }
         }
         if (realm.equals(defaultRealm)) {
@@ -284,7 +288,7 @@ class DigestAuthenticationMechanism implements HttpServerAuthenticationMechanism
         } catch (AuthenticationMechanismException e) {
             throw e.toHttpAuthenticationException();
         }
-        if (realms.length > 0) {
+        if (realms != null && realms.length > 0) {
             return realms[0];
         }
 

--- a/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.http.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
 import static org.wildfly.security.http.HttpConstants.HOST;
 
 import java.util.Map;
@@ -108,6 +109,7 @@ public class SetMechanismInformationMechanismFactory implements HttpServerAuthen
 
                 } catch (Throwable e) {
                     // Give up now since the mechanism information could not be successfully resolved to a mechanism configuration
+                    log.unableToResolveMechanismConfiguration(e);
                     request.noAuthenticationInProgress();
                     return;
                 }

--- a/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SetMechanismInformationSaslServerFactory.java
@@ -25,9 +25,10 @@ import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
-import org.wildfly.security._private.ElytronMessages;
 import org.wildfly.security.auth.callback.MechanismInformationCallback;
 import org.wildfly.security.auth.server.MechanismInformation;
+
+import static org.wildfly.security._private.ElytronMessages.log;
 
 /**
  * A {@link SaslServerFactory} implementation that will always ensure mechanism information is passed to the {@link CallbackHandler} before the first authentication callbacks.
@@ -73,7 +74,7 @@ public final class SetMechanismInformationSaslServerFactory extends AbstractDele
             cbh.handle(new Callback[] { mechanismInformationCallback });
         } catch (Throwable e) {
             // The mechanism information could not be successfully resolved to a mechanism configuration
-            ElytronMessages.log.trace(e);
+            log.unableToResolveMechanismConfiguration(e);
             return null;
         }
         return super.createSaslServer(mechanism, protocol, serverName, props, cbh);


### PR DESCRIPTION
* Added warning on missing MechanismConfiguration for given MechanismInformation
* (trace in ServerAuthenticationContext not necessary already - visible in warn cause)

no subsystem part
wildfly-core, wildfly ladybird tests green