### PR TITLE
[ELY-1060] [JBEAP-8793] Coverity static analysis, dereference after null check, KeyStoreCredentialStore (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -808,7 +808,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 throw log.cannotInitializeCredentialStore(e);
             }
         } else {
-            throw log.automaticStorageCreationDisabled(location.toString());
+            throw log.automaticStorageCreationDisabled(location != null ? location.toString() : "null");
         }
         Matcher matcher;
         while (enumeration.hasMoreElements()) {


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1060
JBEAP: https://issues.jboss.org/browse/JBEAP-8793