### PR TITLE
[ELY-923] CachingSecurityRealm - listening optional

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/CachingModifiableSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/CachingModifiableSecurityRealm.java
@@ -29,7 +29,6 @@ import org.wildfly.security.auth.server.ModifiableRealmIdentity;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.RealmIdentity;
 import org.wildfly.security.auth.server.RealmUnavailableException;
-import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.cache.RealmIdentityCache;
@@ -46,11 +45,12 @@ public class CachingModifiableSecurityRealm extends CachingSecurityRealm impleme
     /**
      * Creates a new instance.
      *
-     * @param realm the {@link SecurityRealm} whose {@link RealmIdentity} should be cached..
+     * @param realm the {@link ModifiableSecurityRealm} whose {@link RealmIdentity} should be cached
      * @param cache the {@link RealmIdentityCache} instance
+     * @param listening whether change listener should be registered
      */
-    public CachingModifiableSecurityRealm(CacheableSecurityRealm realm, RealmIdentityCache cache) {
-        super(realm, cache);
+    public CachingModifiableSecurityRealm(ModifiableSecurityRealm realm, RealmIdentityCache cache, boolean listening) {
+        super(realm, cache, listening);
     }
 
     @Override
@@ -164,8 +164,6 @@ public class CachingModifiableSecurityRealm extends CachingSecurityRealm impleme
             private void executeAndInvalidate(ExceptionConsumer<ModifiableRealmIdentity, RealmUnavailableException> operation) throws RealmUnavailableException {
                 try {
                     operation.accept(modifiable);
-                } catch (RealmUnavailableException rue) {
-                    throw rue;
                 } finally {
                     removeFromCache(modifiable.getRealmIdentityPrincipal());
                 }

--- a/src/main/java/org/wildfly/security/auth/realm/CachingSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/CachingSecurityRealm.java
@@ -46,24 +46,27 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  */
 public class CachingSecurityRealm implements SecurityRealm {
 
-    private final CacheableSecurityRealm realm;
+    private final SecurityRealm realm;
     private final RealmIdentityCache cache;
 
     /**
      * Creates a new instance.
      *
-     * @param realm the {@link SecurityRealm} whose {@link RealmIdentity} should be cached..
+     * @param realm the {@link SecurityRealm} whose {@link RealmIdentity} should be cached
      * @param cache the {@link RealmIdentityCache} instance
+     * @param listening whether change listener should be registered
      */
-    public CachingSecurityRealm(CacheableSecurityRealm realm, RealmIdentityCache cache) {
+    public CachingSecurityRealm(SecurityRealm realm, RealmIdentityCache cache, boolean listening) {
         this.realm = checkNotNullParam("realm", realm);
         this.cache = checkNotNullParam("cache", cache);
 
-        if (realm instanceof CacheableSecurityRealm) {
-            CacheableSecurityRealm cacheable = CacheableSecurityRealm.class.cast(realm);
-            cacheable.registerIdentityChangeListener(this::removeFromCache);
-        } else {
-            throw ElytronMessages.log.realmCacheUnexpectedType(realm, CacheableSecurityRealm.class);
+        if (listening) {
+            if (realm instanceof CacheableSecurityRealm) {
+                CacheableSecurityRealm cacheable = CacheableSecurityRealm.class.cast(realm);
+                cacheable.registerIdentityChangeListener(this::removeFromCache);
+            } else {
+                throw ElytronMessages.log.realmCacheUnexpectedType(realm, CacheableSecurityRealm.class);
+            }
         }
     }
 
@@ -242,7 +245,7 @@ public class CachingSecurityRealm implements SecurityRealm {
         cache.clear();
     }
 
-    protected CacheableSecurityRealm getCacheableRealm() {
+    protected SecurityRealm getCacheableRealm() {
         return realm;
     }
 }

--- a/src/test/java/org/wildfly/security/auth/realm/cache/ModifiableSecurityRealmIdentityCacheTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/cache/ModifiableSecurityRealmIdentityCacheTest.java
@@ -176,7 +176,7 @@ public class ModifiableSecurityRealmIdentityCacheTest {
 
         addUser(realm, "joe", "User");
 
-        return new CachingModifiableSecurityRealm(new MockCacheableModifiableSecurityRealm(realm), createRealmIdentitySimpleJavaMapCache());
+        return new CachingModifiableSecurityRealm(new MockCacheableModifiableSecurityRealm(realm), createRealmIdentitySimpleJavaMapCache(), true);
     }
 
     private void addUser(ModifiableSecurityRealm realm, String userName, String roles) throws RealmUnavailableException {

--- a/src/test/java/org/wildfly/security/auth/realm/cache/SecurityRealmIdentityCacheTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/cache/SecurityRealmIdentityCacheTest.java
@@ -172,10 +172,9 @@ public class SecurityRealmIdentityCacheTest {
 
             @Override
             public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
-                return getEvidenceVerifySupport(evidenceType, algorithmName);
+                return realm.getEvidenceVerifySupport(evidenceType, algorithmName);
             }
-        }, cache) {
-        };
+        }, cache, true);
     }
 
     private void addUser(Map<String, SimpleRealmEntry> securityRealm, String userName, String roles) {

--- a/src/test/java/org/wildfly/security/ldap/LdapSecurityRealmIdentityCacheSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/LdapSecurityRealmIdentityCacheSuiteChild.java
@@ -177,7 +177,7 @@ public class LdapSecurityRealmIdentityCacheSuiteChild {
         if (credentialLoader) builder.userPasswordCredentialLoader().build();
         if (directVerification) builder.addDirectEvidenceVerification();
         return new CachingModifiableSecurityRealm(new MockCacheableModifiableSecurityRealm(builder.build()),
-                createRealmIdentitySimpleJavaMapCache());
+                createRealmIdentitySimpleJavaMapCache(), true);
     }
 
     private class MockCacheableModifiableSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRealm {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-923
https://issues.jboss.org/browse/JBEAP-8679
connected with subsystem PR https://github.com/wildfly-security-incubator/wildfly-core/pull/126

* listening for changes in cached realm made optional
* CacheableSecurityRealm type replaced by SecurityRealm where not necessary
* and by ModifiableSecurityRealm conversely to strengthen type check