### PR TITLE
[ELY-986] Method equals for MatchRule throws java.lang.IllegalStateException

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/MatchPortRule.java
+++ b/src/main/java/org/wildfly/security/auth/client/MatchPortRule.java
@@ -46,6 +46,10 @@ class MatchPortRule extends MatchRule {
         return other.getMatchPort() == port && parentHalfEqual(other);
     }
 
+    public int getMatchPort() {
+        return port;
+    }
+
     public int hashCode() {
         return multiHashUnordered(parentHashCode(), 7919, port);
     }

--- a/src/main/java/org/wildfly/security/auth/client/MatchRule.java
+++ b/src/main/java/org/wildfly/security/auth/client/MatchRule.java
@@ -578,7 +578,9 @@ public abstract class MatchRule {
     public final String toString() {
         final StringBuilder b = new StringBuilder();
         asString(b);
-        b.setLength(b.length() - 1);
+        if (b.length() > 1) {
+            b.setLength(b.length() - 1);
+        }
         return b.toString();
     }
 

--- a/src/test/java/org/wildfly/security/auth/client/AuthenticationContextTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/AuthenticationContextTest.java
@@ -339,7 +339,7 @@ public final class AuthenticationContextTest {
         assertNotNull(rn);
         assertEquals(expectedConfiguration, rn.getConfiguration());
         // https://issues.jboss.org/browse/ELY-986
-        // assertEquals(expectedRule, rn.getRule());
+         assertEquals(expectedRule, rn.getRule());
     }
 
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ELY-986