### PR TITLE
[ELY-1083][JBEAP-10381] trust-store configuration for Elytron client

### DIFF
--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -147,6 +147,7 @@
     <xsd:complexType name="ssl-context-type">
         <xsd:all>
             <xsd:element name="key-store-ssl-certificate" type="key-store-ref-type" minOccurs="0"/>
+            <xsd:element name="trust-store" type="trust-store-ref-type" minOccurs="0"/>
             <xsd:element name="cipher-suite" type="ssl-cipher-selector-type" minOccurs="0"/>
             <xsd:element name="protocol" type="names-list-type" minOccurs="0"/>
             <xsd:element name="provider-name" type="name-type" minOccurs="0"/>
@@ -324,6 +325,10 @@
         <xsd:attribute name="store" type="xsd:string"/>
         <xsd:attribute name="alias" type="xsd:string"/>
         <xsd:attribute name="clear-text" type="xsd:string"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="trust-store-ref-type">
+        <xsd:attribute name="key-store-name" type="xsd:string" use="required"/>
     </xsd:complexType>
 
     <xsd:complexType name="bearer-token-type">

--- a/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config.xml
+++ b/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <key-stores>
+            <key-store name="scarab" type="JKS">
+                <file name="target/test-classes/ca/jks/scarab.keystore"/>
+            </key-store>
+            <key-store name="ladybird" type="JKS">
+                <file name="target/test-classes/ca/jks/ladybird.keystore"/>
+            </key-store>
+        </key-stores>
+        <ssl-contexts>
+            <ssl-context name="my-ssl">
+                <key-store-ssl-certificate key-store-name="ladybird" alias="ladybird">
+                    <key-store-clear-password password="Elytron"/>
+                </key-store-ssl-certificate>
+                <trust-store key-store-name="scarab"/>
+            </ssl-context>
+        </ssl-contexts>
+        <ssl-context-rules>
+            <rule use-ssl-context="my-ssl">
+                <match-host name="test.org"/>
+            </rule>
+        </ssl-context-rules>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1083
https://issues.jboss.org/browse/JBEAP-10381

* added possibility to configure used truststore in Elytron client XML
* modified tests of SSL to use Elytron client XML