### PR TITLE
[ELY-1050] Coverity, derefere null return value in KeyStoreCredentialStore.saveSecretKey

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1815,6 +1815,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 9534, value = "\"%s\" is not a block based algorithm")
     CredentialStoreException algorithmNotBlockBased(String algorithm);
 
+    @Message(id = 9535, value = "Algorithm \"%s\" does not use an initialization vector (IV)")
+    CredentialStoreException algorithmNotIV(String algorithm);
+
     /* X.500 exceptions */
 
     @Message(id = 10000, value = "X.509 certificate extension with OID %s already exists")

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -1222,6 +1222,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
 
             byte[] encrypted = encrypt.doFinal(padded);
             byte[] iv = encrypt.getIV();
+            if (iv == null) throw log.algorithmNotIV(encrypt.getAlgorithm());
 
             oos.writeInt(SECRET_KEY_ENTRY_TYPE);
             writeBytes(encrypted, oos);


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1050
JBEAP: https://issues.jboss.org/browse/JBEAP-10077