### PR TITLE
[ELY-1095] RealmUnavailableException on iterating when ldap unavailable

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -476,7 +476,7 @@ public interface ElytronMessages extends BasicLogger {
     IllegalStateException failedToObtainSSLContext(@Cause Throwable cause);
 
     @Message(id = 1108, value = "Ldap-backed realm identity search failed")
-    RuntimeException ldapRealmIdentitySearchFailed(@Cause Throwable cause);
+    RealmUnavailableException ldapRealmIdentitySearchFailed(@Cause Throwable cause);
 
     @Message(id = 1109, value = "Ldap-backed realm is not configured to allow iterate over identities (iterator filter has to be set)")
     RealmUnavailableException ldapRealmNotConfiguredToSupportIteratingOverIdentities();

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -217,7 +217,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
             try {
                 return (String) entry.getAttributes().get(identityMapping.rdnIdentifier).get();
             } catch (NamingException e) {
-                throw log.ldapRealmIdentitySearchFailed(e);
+                throw new RuntimeException(log.ldapRealmIdentitySearchFailed(e));
             }
         }).distinct().iterator(); // distinct to prevent deadlock on identity locking when one identity found twice
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1095
Related to https://issues.jboss.org/browse/JBEAP-9547

Related to https://github.com/wildfly-security-incubator/wildfly-core/pull/140 but can be merged independently.

Fix to prevent RuntimeException on boot with ldap-realm.