### PR TITLE
[ELY-1051] Coverity, derefere null return value in KeyStoreCredentialStore.store

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -1200,7 +1200,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 if (entry instanceof KeyStore.SecretKeyEntry) {
                     saveSecretKey(alias, oos, (KeyStore.SecretKeyEntry)entry);
                 } else {
-                    throw log.unrecognizedEntryType(entry.getClass().getCanonicalName());
+                    throw log.unrecognizedEntryType(entry != null ? entry.getClass().getCanonicalName() : "null");
                 }
             }
             oos.flush();


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1051
JBEAP: https://issues.jboss.org/browse/JBEAP-10078