### PR TITLE
[JBEAP-10476] [ELY-1097] Different message if keyAlias does not exist.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1882,4 +1882,7 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 11005, value = "Invalid unicode endoding, offending sequence: %s.")
     IOException invalidUnicodeSequence(String s, @Cause NoSuchElementException nsee);
+
+    @Message(id = 11006, value = "External storage key under alias \"%s\" does not exist")
+    CredentialStoreException externalStorageKeyDoesNotExist(String keyAlias);
 }

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -1125,6 +1125,9 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
         private void fetchStorageSecretKey(String keyAlias, char[] keyPassword) throws CertificateException, NoSuchAlgorithmException, IOException, CredentialStoreException, UnrecoverableEntryException, KeyStoreException {
             storageSecretKeyStore.load(null, keyPassword);
             KeyStore.Entry entry = storageSecretKeyStore.getEntry(keyAlias, new KeyStore.PasswordProtection(keyPassword));
+            if (entry == null) {
+                throw log.externalStorageKeyDoesNotExist(keyAlias);
+            }
             if (! (entry instanceof KeyStore.SecretKeyEntry)) {
                 throw log.wrongTypeOfExternalStorageKey(keyAlias);
             }


### PR DESCRIPTION
issue: https://issues.jboss.org/browse/JBEAP-10476

Different message for case that keyAlias does not exists and case that if exists but is of different type than SecretKey.
