### PR TITLE
[ELY-632] No log messages comming from Elytron - authentication process start

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/BasicAuthenticationMechanism.java
@@ -166,7 +166,7 @@ class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationMechani
                             }
 
                         } else {
-                            log.debugf("User %s authorization failed.", username);
+                            log.debugf("User %s authentication failed.", username);
                             fail();
 
                             request.authenticationFailed(log.authenticationFailed(username, BASIC_NAME), response -> prepareResponse(displayRealmName, response));


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ELY-632

This is an amendment to https://github.com/wildfly-security/wildfly-elytron/pull/504