### PR TITLE
[ELY-1096][JBEAP-10473]: Avoid possible race conditions incrementing the size of Rotating File Audit

### DIFF
--- a/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -92,10 +92,26 @@ public class FileAuditEndpoint implements AuditEndpoint {
         }
     }
 
+    /**
+     * Writes <code>bytes.length</code> bytes from the specified byte array
+     * to the underlying output stream managed by this class.
+     * The general contract for <code>write(bytes)</code> is that it must be
+     * invoked from a synchronization block surrounding one log message processing.
+     *
+     * @param bytes the data.
+     * @throws IOException if an I/O error occurs.
+     */
     protected void write(byte[] bytes) throws IOException {
         outputStream.write(bytes);
     }
 
+    /**
+     * The general contract for <code>preWrite(date)</code> is that any method override
+     * must ensure thread safety invoking this method from a synchronization block
+     * surrounding one log message processing.
+     *
+     * @param date
+     */
     protected void preWrite(Date date) {
         // NO-OP by default
     }

--- a/src/main/java/org/wildfly/security/audit/RotatingFileAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/RotatingFileAuditEndpoint.java
@@ -50,7 +50,7 @@ public class RotatingFileAuditEndpoint extends FileAuditEndpoint {
 
     private String nextSuffix;
     private long nextRollover = Long.MAX_VALUE;
-    private volatile long currentSize = 0;
+    private long currentSize = 0;
 
     RotatingFileAuditEndpoint(Builder builder) throws IOException {
         super(builder);


### PR DESCRIPTION
Although currentSize was declared as volatile, this field modifier is not enough to prevent race conditions. This patch uses an AtomicLong instead.

Jira issues:
https://issues.jboss.org/browse/ELY-1096
https://issues.jboss.org/browse/JBEAP-10473