### PR TITLE
[ELY-1115][JBEAP-9628] Fix of null principal handling

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/NameRewriter.java
+++ b/src/main/java/org/wildfly/security/auth/server/NameRewriter.java
@@ -64,7 +64,7 @@ public interface NameRewriter {
             if (principal == null) return null;
             if (principal instanceof NamePrincipal) {
                 String rewritten = NameRewriter.this.rewriteName(principal.getName());
-                return rewritten == null ? null : new NamePrincipal(rewritten);
+                return new NamePrincipal(rewritten);
             }
             return principal;
         };

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -397,6 +397,7 @@ public final class SecurityDomain {
         }
         Principal preRealmPrincipal = preRealmPrincipalRewriter.apply(principal);
         if (preRealmPrincipal == null) {
+            log.tracef("Pre-realm rewritter: null output for principal %s", principal);
             throw log.invalidName();
         }
 
@@ -407,11 +408,13 @@ public final class SecurityDomain {
 
         Principal postRealmPrincipal = postRealmPrincipalRewriter.apply(preRealmPrincipal);
         if (postRealmPrincipal == null) {
+            log.tracef("Post-realm rewritter: null output for principal %s", preRealmPrincipal);
             throw log.invalidName();
         }
 
         Principal realmRewrittenPrincipal = realmInfo.getPrincipalRewriter().apply(postRealmPrincipal);
         if (realmRewrittenPrincipal == null) {
+            log.tracef("Realm rewritter: null output for principal %s", postRealmPrincipal);
             throw log.invalidName();
         }
 


### PR DESCRIPTION
Returned original behavior - return NamePrincipal(null) instead of null principal from principal rewritter.
(reverting change which has broken wildfly tests)

need to be merged together with https://github.com/wildfly-security-incubator/wildfly-core/pull/156