### PR TITLE
[ELY-1136] / [ELY-1137] Support for External authentication based on SSL Peer identity.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/callback/SSLCallback.java
+++ b/src/main/java/org/wildfly/security/auth/callback/SSLCallback.java
@@ -18,17 +18,14 @@
 
 package org.wildfly.security.auth.callback;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import java.io.Serializable;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocket;
 
 /**
- * A callback which provides information to the callback handler about the established SSL/TLS security layer involved
- * in an authentication.
+ * A callback which provides information to the callback handler about the established SSLSession.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
@@ -37,49 +34,17 @@ public final class SSLCallback implements ExtendedCallback, Serializable {
     private static final long serialVersionUID = 7854221380587494535L;
 
     /**
-     * @serial The SSL context.
+     * @serial The SSL session.
      */
-    private final SSLContext sslContext;
-    /**
-     * @serial The SSL engine, if any.
-     */
-    private final SSLEngine sslEngine;
-    /**
-     * @serial The SSL socket, if any.
-     */
-    private final SSLSocket sslSocket;
+    private final SSLSession sslSession;
 
     /**
      * Construct a new instance.
      *
-     * @param sslContext the SSL context used
-     * @param sslSocket the SSL socket
+     * @param sslSession the {@link SSLSession}
      */
-    public SSLCallback(final SSLContext sslContext, final SSLSocket sslSocket) {
-        this.sslContext = sslContext;
-        this.sslSocket = sslSocket;
-        sslEngine = null;
-    }
-
-    /**
-     * Construct a new instance.
-     *
-     * @param sslContext the SSL context used
-     * @param sslEngine the SSL engine of the connection
-     */
-    public SSLCallback(final SSLContext sslContext, final SSLEngine sslEngine) {
-        this.sslContext = sslContext;
-        this.sslEngine = sslEngine;
-        sslSocket = null;
-    }
-
-    /**
-     * Get the SSL context used.
-     *
-     * @return the SSL context used
-     */
-    public SSLContext getSslContext() {
-        return sslContext;
+    public SSLCallback(final SSLSession sslSession) {
+        this.sslSession = checkNotNullParam("sslSession", sslSession);
     }
 
     /**
@@ -88,51 +53,7 @@ public final class SSLCallback implements ExtendedCallback, Serializable {
      * @return the SSL session in force
      */
     public SSLSession getSslSession() {
-        return sslEngine != null ? sslEngine.getSession() : sslSocket.getSession();
+        return sslSession;
     }
 
-    /**
-     * Get the SSL parameters in use.
-     *
-     * @return the SSL parameters in use
-     */
-    public SSLParameters getSslParameters() {
-        return sslEngine != null ? sslEngine.getSSLParameters() : sslSocket.getSSLParameters();
-    }
-
-    /**
-     * Determine whether the SSL connection is in "client mode".
-     *
-     * @return {@code true} for client mode, {@code false} for server mode
-     */
-    public boolean isClientMode() {
-        return sslEngine != null ? sslEngine.getUseClientMode() : sslSocket.getUseClientMode();
-    }
-
-    /**
-     * Determine whether client authentication was requested.
-     *
-     * @return {@code true} if client authentication was requested, {@code false} otherwise
-     */
-    public boolean isClientAuthWanted() {
-        return sslEngine != null ? sslEngine.getWantClientAuth() : sslSocket.getWantClientAuth();
-    }
-
-    /**
-     * Determine whether client authentication was required.
-     *
-     * @return {@code true} if client authentication was required, {@code false} otherwise
-     */
-    public boolean isClientAuthNeeded() {
-        return sslEngine != null ? sslEngine.getNeedClientAuth() : sslSocket.getNeedClientAuth();
-    }
-
-    /**
-     * Determine whether session creation is enabled for this connection.
-     *
-     * @return {@code true} if session creation is enabled, {@code false} otherwise
-     */
-    public boolean isSessionCreationEnabled() {
-        return sslEngine != null ? sslEngine.getEnableSessionCreation() : sslSocket.getEnableSessionCreation();
-    }
 }

--- a/src/main/java/org/wildfly/security/sasl/util/SSLQueryCallbackHandler.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SSLQueryCallbackHandler.java
@@ -16,17 +16,20 @@
  * limitations under the License.
  */
 
-package org.wildfly.security.auth.callback;
+package org.wildfly.security.sasl.util;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSession;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.wildfly.security.auth.callback.SSLCallback;
 
 /**
  * A callback handler which delegates to another callback handler, passing the authentication's SSL/TLS information to that
@@ -36,48 +39,30 @@ import javax.security.auth.callback.UnsupportedCallbackException;
  */
 public final class SSLQueryCallbackHandler implements CallbackHandler {
     private final CallbackHandler delegate;
-    private final SSLContext sslContext;
-    private final SSLEngine sslEngine;
-    private final SSLSocket sslSocket;
+    private final Supplier<SSLSession> sslSession;
 
-    private final AtomicBoolean once = new AtomicBoolean();
+    private final AtomicBoolean once = new AtomicBoolean(true);
 
     /**
      * Construct a new instance.
      *
      * @param delegate the delegate callback handler
-     * @param sslContext the SSL context used
-     * @param sslEngine the SSL engine of the connection
+     * @param sslSession supplier for the current SSL session
      */
-    public SSLQueryCallbackHandler(final CallbackHandler delegate, final SSLContext sslContext, final SSLEngine sslEngine) {
+    public SSLQueryCallbackHandler(final CallbackHandler delegate, final Supplier<SSLSession> sslSession) {
         this.delegate = delegate;
-        this.sslContext = sslContext;
-        this.sslEngine = sslEngine;
-        sslSocket = null;
-    }
-
-    /**
-     * Construct a new instance.
-     *
-     * @param delegate the delegate callback handler
-     * @param sslContext the SSL context used
-     * @param sslSocket the SSL socket
-     */
-    public SSLQueryCallbackHandler(final CallbackHandler delegate, final SSLContext sslContext, final SSLSocket sslSocket) {
-        this.delegate = delegate;
-        this.sslContext = sslContext;
-        this.sslSocket = sslSocket;
-        sslEngine = null;
+        this.sslSession = checkNotNullParam("sslSession", sslSession);
     }
 
     public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        if (! once.compareAndSet(false, true)) {
+        SSLSession sslSession;
+        if (! once.compareAndSet(false, true) || (sslSession = this.sslSession.get()) == null) {
             delegate.handle(callbacks);
             return;
         }
         final int length = callbacks.length;
         final Callback[] newCallbacks = new Callback[length + 1];
-        newCallbacks[0] = sslEngine != null ? new SSLCallback(sslContext, sslEngine) : new SSLCallback(sslContext, sslSocket);
+        newCallbacks[0] = new SSLCallback(sslSession);
         System.arraycopy(callbacks, 0, newCallbacks, 1, length);
         try {
             delegate.handle(newCallbacks);
@@ -89,4 +74,9 @@ public final class SSLQueryCallbackHandler implements CallbackHandler {
             throw e;
         }
     }
+
+    void activate () {
+        once.set(false);
+    }
+
 }


### PR DESCRIPTION
We will probably still need a follow up step to make use of any identity cached on the SSLSession but for now this covers the main approach to get the SSL session into the ServerAuthenticationContext and used  to obtain the certificates to verify as evidence.