### PR TITLE
[JBEAP-10709] [ELY-1130] keystore entry alias is not necessary if the…

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -740,6 +740,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 2033, value = "key must implement SecretKeySpec and keySpec must be SecretKeySpec, given key, keySpec: [%s]")
     InvalidKeySpecException keyMustImplementSecretKeySpecAndKeySpecMustBeSecretKeySpec(String keyAndKeySpec);
 
+    @Message(id = 2034, value = "Alias must be specified if more than one entry exist in keystore")
+    ConfigXMLParseException missingAlias(@Param Location location);
+
     /* util package */
 
     @Message(id = 3001, value = "Unexpected padding")

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -316,7 +316,7 @@
             <xsd:element name="credential-store" type="credential-store-reference-type" minOccurs="1" maxOccurs="1"/>
         </xsd:choice>
         <xsd:attribute name="key-store-name" type="xsd:string" use="required"/>
-        <xsd:attribute name="alias" type="xsd:string" use="required"/>
+        <xsd:attribute name="alias" type="xsd:string" use="optional"/>
     </xsd:complexType>
 
     <xsd:complexType name="credential-store-reference-type">


### PR DESCRIPTION
…re is only one entry in keystore.
JBEAP issue: https://issues.jboss.org/browse/JBEAP-10709
ELY issue: https://issues.jboss.org/browse/ELY-1130