### PR TITLE
[ELY-1147] Coverity: Elytron defect: Unguarded read in VaultCredentialStore class

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/VaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/VaultCredentialStore.java
@@ -206,7 +206,9 @@ public final class VaultCredentialStore extends CredentialStoreSpi {
 
     @Override
     public Set<String> getAliases() throws UnsupportedOperationException, CredentialStoreException {
-        return data.keySet();
+        synchronized (data) {
+            return data.keySet();
+        }
     }
 
 }


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1147
JBEAP: https://issues.jboss.org/browse/JBEAP-10813