### PR TITLE
[ELY-1151] empty authorization name handling

### DIFF
--- a/src/main/java/org/wildfly/security/mechanism/scram/ScramClient.java
+++ b/src/main/java/org/wildfly/security/mechanism/scram/ScramClient.java
@@ -105,7 +105,8 @@ public final class ScramClient {
      * @throws AuthenticationMechanismException if the client authentication failed for some reason
      */
     public ScramInitialClientMessage getInitialResponse() throws AuthenticationMechanismException {
-        final NameCallback nameCallback = authorizationId == null ? new NameCallback("User name") : new NameCallback("User name", authorizationId);
+        final NameCallback nameCallback = authorizationId == null || authorizationId.length() == 0 ?
+                new NameCallback("User name") : new NameCallback("User name", authorizationId);
         try {
             MechanismUtil.handleCallbacks(mechanism.toString(), callbackHandler, nameCallback);
         } catch (UnsupportedCallbackException e) {

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
@@ -220,7 +220,7 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
             }
         }
 
-        NameCallback nameCallback = authorizationId != null ?
+        NameCallback nameCallback = authorizationId != null && authorizationId.length() != 0 ?
                 new NameCallback("User name", authorizationId) : new NameCallback("User name");
 
         // get password

--- a/src/main/java/org/wildfly/security/sasl/localuser/LocalUserClient.java
+++ b/src/main/java/org/wildfly/security/sasl/localuser/LocalUserClient.java
@@ -109,8 +109,8 @@ public final class LocalUserClient extends AbstractSaslClient {
                 String authenticationId = getAuthorizationId();
                 String authenticationRealm = null;
                 if (quietAuth == false) {
-                    final NameCallback nameCallback = authenticationId != null ? new OptionalNameCallback("User name",
-                            authenticationId) : new OptionalNameCallback("User name");
+                    final NameCallback nameCallback = authenticationId != null && authenticationId.length() != 0 ?
+                            new OptionalNameCallback("User name", authenticationId) : new OptionalNameCallback("User name");
                     final RealmCallback realmCallback = new RealmCallback("User realm");
                     handleCallbacks(nameCallback, realmCallback);
                     authenticationId = nameCallback.getName();

--- a/src/main/java/org/wildfly/security/sasl/localuser/LocalUserServer.java
+++ b/src/main/java/org/wildfly/security/sasl/localuser/LocalUserServer.java
@@ -240,7 +240,7 @@ public final class LocalUserServer extends AbstractSaslServer implements SaslSer
                 if (authenticationId == null || authenticationId.length() == 0) {
                     authenticationId = defaultUser;
                 }
-                if (authenticationId == null) {
+                if (authenticationId == null || authenticationId.length() == 0) {
                     throw log.mechAuthenticationNameIsEmpty(getMechanismName()).toSaslException();
                 }
                 if (authorizationId == null) {

--- a/src/main/java/org/wildfly/security/sasl/otp/OTPSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/otp/OTPSaslClient.java
@@ -84,7 +84,8 @@ final class OTPSaslClient extends AbstractSaslClient {
                 final ByteStringBuilder response = new ByteStringBuilder();
                 final String authorizationId = getAuthorizationId();
                 validateAuthorizationId(authorizationId);
-                nameCallback = authorizationId == null ? new NameCallback("User name") : new NameCallback("User name", authorizationId);
+                nameCallback = authorizationId == null || authorizationId.length() == 0 ?
+                        new NameCallback("User name") : new NameCallback("User name", authorizationId);
                 handleCallbacks(nameCallback);
                 userName = nameCallback.getName();
                 validateUserName(userName);


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1151

Null authorizationId handling in SaslClients.