### PR TITLE
[JBEAP-10835] [ELY-1149] validate given attributes in credential store implementation.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -36,6 +36,7 @@ import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.InvalidParameterSpecException;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import static org.jboss.logging.Logger.Level.DEBUG;
@@ -1800,6 +1801,10 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 9525, value = "location and externalPath initial attributes are the same. [location=%s, externalPath=%s]")
     CredentialStoreException locationAndExternalPathAreIdentical(String location, String externalPath);
+
+    @Message(id = 9526, value = "Unable to initialize credential store as attribute %s is unsupported in %s" )
+    CredentialStoreException unsupportedAttribute(String attribute, List<String> validAttribute);
+
 
     /* X.500 exceptions */
 

--- a/src/main/java/org/wildfly/security/credential/store/CredentialStoreSpi.java
+++ b/src/main/java/org/wildfly/security/credential/store/CredentialStoreSpi.java
@@ -17,8 +17,11 @@
  */
 package org.wildfly.security.credential.store;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -143,5 +146,19 @@ public abstract class CredentialStoreSpi {
      */
     public Set<String> getAliases() throws UnsupportedOperationException, CredentialStoreException {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Validate given attributes in credential store implementation.
+     *
+     * @param attributes attributes to used to pass information to credential store service.
+     * @param validAttributes valid attributes based on credential store implementation.
+     * @throws CredentialStoreException if validation fails
+     */
+    public void validateAttribute(Map<String, String> attributes, List<String> validAttributes) throws CredentialStoreException {
+        for (String attr : attributes.keySet()) {
+            if (!validAttributes.contains(attr))
+                throw log.unsupportedAttribute(attr, validAttributes);
+        }
     }
 }

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -151,6 +152,17 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
     public static final String KEY_STORE_CREDENTIAL_STORE = KeyStoreCredentialStore.class.getSimpleName();
 
     private static final String X_509 = "X.509";
+    private static final String CREATE = "create";
+    private static final String CRYPTOALG = "cryptoAlg";
+    private static final String EXTERNAL = "external";
+    private static final String EXTERNALPATH = "externalPath";
+    private static final String KEYALIAS = "keyAlias";
+    private static final String KEYSTORETYPE = "keyStoreType";
+    private static final String LOCATION = "location";
+    private static final String MODIFIABLE = "modifiable";
+
+    private static final List<String> validAttribtues = Arrays.asList(CREATE, CRYPTOALG, EXTERNAL, EXTERNALPATH, KEYALIAS,
+            KEYSTORETYPE, LOCATION, MODIFIABLE);
 
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
     private final HashMap<String, TopEntry> cache = new HashMap<>();
@@ -171,17 +183,18 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             if (protectionParameter == null) {
                 throw log.protectionParameterRequired();
             }
+            validateAttribute(attributes, validAttribtues);
             cache.clear();
             this.protectionParameter = protectionParameter;
-            modifiable = Boolean.parseBoolean(attributes.getOrDefault("modifiable", "true"));
-            create = Boolean.parseBoolean(attributes.getOrDefault("create", "false"));
-            final String locationName = attributes.get("location");
+            modifiable = Boolean.parseBoolean(attributes.getOrDefault(MODIFIABLE, "true"));
+            create = Boolean.parseBoolean(attributes.getOrDefault(CREATE, "false"));
+            final String locationName = attributes.get(LOCATION);
             location = locationName == null ? null : Paths.get(locationName);
             this.providers = providers;
-            String keyStoreType = attributes.getOrDefault("keyStoreType", KeyStore.getDefaultType());
-            useExternalStorage = Boolean.parseBoolean(attributes.getOrDefault("external", "false"));
+            String keyStoreType = attributes.getOrDefault(KEYSTORETYPE, KeyStore.getDefaultType());
+            useExternalStorage = Boolean.parseBoolean(attributes.getOrDefault(EXTERNAL, "false"));
             if (useExternalStorage) {
-                final String externalPathName = attributes.get("externalPath");
+                final String externalPathName = attributes.get(EXTERNALPATH);
                 if (externalPathName == null) {
                     externalPath = location;
                     location = null;
@@ -192,8 +205,8 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     }
                 }
             }
-            encryptionKeyAlias = attributes.getOrDefault("keyAlias", "cs_key");
-            cryptographicAlgorithm = attributes.get("cryptoAlg");
+            encryptionKeyAlias = attributes.getOrDefault(KEYALIAS, "cs_key");
+            cryptographicAlgorithm = attributes.get(CRYPTOALG);
             load(keyStoreType);
             initialized = true;
         }

--- a/src/main/java/org/wildfly/security/credential/store/impl/VaultCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/VaultCredentialStore.java
@@ -28,7 +28,9 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,6 +61,7 @@ public final class VaultCredentialStore extends CredentialStoreSpi {
     public static final String VAULT_CREDENTIAL_STORE = "VaultCredentialStore";
 
     private static final String LOCATION = "location";
+    private static final List<String> validAttribtues = Arrays.asList(LOCATION);
 
     // synchronize all accesses, particularly during load/store
     private final Map<String, byte[]> data = new HashMap<>();
@@ -87,6 +90,7 @@ public final class VaultCredentialStore extends CredentialStoreSpi {
         if (secretKey == null) {
             throw log.cannotAcquireCredentialFromStore(null);
         }
+        validateAttribute(attributes, validAttribtues);
         final String location = attributes.get(LOCATION);
         if (location != null) {
             final File locationFile = new File(location, "VAULT.dat");


### PR DESCRIPTION
JBEAP: https://issues.jboss.org/browse/JBEAP-10835
ELY: https://issues.jboss.org/browse/ELY-1149

validate given attribute in credential store implementation if it needs to be. 
Default provided implementations KeyStoreCredentialStore and VaultCredentialStore