### PR TITLE
[ELY-1157] When merging an AuthenticationConfiguration instance with another one, only replace this AuthenticationConfiguration's credential source if it is explicitly configured in the other one

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -320,7 +320,7 @@ public final class AuthenticationConfiguration {
         this.forwardSecurityDomain = getOrDefault(other.forwardSecurityDomain, original.forwardSecurityDomain);
         this.userCallbackHandler = getOrDefault(other.userCallbackHandler, original.userCallbackHandler);
         this.userCallbackKinds = getOrDefault(other.userCallbackKinds, original.userCallbackKinds);
-        this.credentialSource = getOrDefault(other.credentialSource, original.credentialSource);
+        this.credentialSource = other.credentialSource == IdentityCredentials.NONE ? original.credentialSource : other.credentialSource;
         this.setPort = getOrDefault(other.setPort, original.setPort);
         this.providerSupplier = getOrDefault(other.providerSupplier, original.providerSupplier);
         this.keyManagerFactory = getOrDefault(other.keyManagerFactory, original.keyManagerFactory);

--- a/src/test/java/org/wildfly/security/auth/client/AuthenticationConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/AuthenticationConfigurationTest.java
@@ -63,5 +63,12 @@ public final class AuthenticationConfigurationTest {
             c2.with(c1)
         );
 
+        c1 = AuthenticationConfiguration.EMPTY.useName("name1").usePassword("password1");
+        c2 = AuthenticationConfiguration.EMPTY.usePort(1234);
+        assertEquals(
+                AuthenticationConfiguration.EMPTY.useName("name1").useCredentials(c1.getCredentialSource()).usePort(1234),
+                c1.with(c2)
+        );
+
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1157