### PR TITLE
[ELY-1163] Allow mechanism properties to be overriden.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -993,13 +993,32 @@ public final class AuthenticationConfiguration {
      * Create a new configuration which is the same as this configuration, but which sets the properties that will be passed to
      * the {@code SaslClientFactory} when the mechanism is created.
      *
+     * Existing properties defined on this authentication context will be retained unless overridden by new properties, any
+     * properties resulting with a value of {@code null} will be removed.
+     *
      * @param mechanismProperties the properties to be passed to the {@code SaslClientFactory} to create the mechanism.
      * @return the new configuration.
      */
     public AuthenticationConfiguration useMechanismProperties(Map<String, String> mechanismProperties) {
-        if (mechanismProperties == null || mechanismProperties.isEmpty()) return this;
-        final HashMap<String, Object> newMap = new HashMap<>(mechanismProperties);
-        newMap.putAll(this.mechanismProperties);
+        return useMechanismProperties(mechanismProperties, false);
+    }
+
+    /**
+     * Create a new configuration which is the same as this configuration, but which sets the properties that will be passed to
+     * the {@code SaslClientFactory} when the mechanism is created.
+     *
+     * If exclusive the existing properties will be discarded and replaced with the new properties otherwise existing properties
+     * defined on this authentication context will be retained unless overridden by new properties, any properties resulting
+     * with a value of {@code null} will be removed.
+     *
+     * @param mechanismProperties the properties to be passed to the {@code SaslClientFactory} to create the mechanism.
+     * @param exclusive should the provided properties be used exclusively or merged with the existing properties?
+     * @return the new configuration.
+     */
+    public AuthenticationConfiguration useMechanismProperties(Map<String, String> mechanismProperties, boolean exclusive) {
+        if (!exclusive && (mechanismProperties == null || mechanismProperties.isEmpty())) return this;
+        final HashMap<String, Object> newMap = exclusive ? new HashMap<>() : new HashMap<>(this.mechanismProperties);
+        newMap.putAll(mechanismProperties);
         newMap.values().removeIf(Objects::isNull);
         return new AuthenticationConfiguration(this, SET_MECH_PROPS, optimizeMap(newMap));
     }

--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -609,7 +609,7 @@ public final class ElytronXmlParser {
                         if (isSet(foundBits, 5)) throw reader.unexpectedElement();
                         foundBits = setBit(foundBits, 5);
                         final Map<String, String> mechanismProperties = parsePropertiesType(reader);
-                        configuration = andThenOp(configuration, parentConfig -> parentConfig.useMechanismProperties(mechanismProperties));
+                        configuration = andThenOp(configuration, parentConfig -> parentConfig.useMechanismProperties(mechanismProperties, true));
                         break;
                     }
                     case "allow-all-sasl-mechanisms": {


### PR DESCRIPTION
Configuration from the XML overrides all default properties.