### PR TITLE
[Ely 584] used methods, AuthenticationConfiguration.EMPTY is flaged as deprecated

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -156,7 +156,16 @@ public final class AuthenticationConfiguration {
      * An empty configuration which can be used as the basis for any configuration.  This configuration supports no
      * remapping of any kind, and always uses an anonymous principal.
      */
+    @Deprecated
     public static final AuthenticationConfiguration EMPTY = new AuthenticationConfiguration();
+
+    /**
+     * An empty configuration which can be used as the basis for any configuration.  This configuration supports no
+     * remapping of any kind, and always uses an anonymous principal.
+     */
+    public static AuthenticationConfiguration empty() {
+        return EMPTY;
+    }
 
     private SaslClientFactory saslClientFactory = null;
     private int hashCode;

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
@@ -123,7 +123,7 @@ public final class AuthenticationContextConfigurationClient {
         Assert.checkNotNullParam("uri", uri);
         Assert.checkNotNullParam("authenticationContext", authenticationContext);
         final RuleNode<AuthenticationConfiguration> node = authenticationContext.authRuleMatching(uri, abstractType, abstractTypeAuthority, purpose);
-        AuthenticationConfiguration configuration = node != null ? node.getConfiguration() : AuthenticationConfiguration.EMPTY;
+        AuthenticationConfiguration configuration = node != null ? node.getConfiguration() : AuthenticationConfiguration.empty();
         final String uriHost = uri.getHost();
         if (uriHost != null && configuration.setHost == null) {
             configuration = configuration.useHost(uriHost);

--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -226,7 +226,7 @@ public final class ElytronXmlParser {
                 final AuthenticationContext context = config.getConfiguredAuthenticationContext();
                 if (context != null) return context;
             }
-            return AuthenticationContext.EMPTY;
+            return AuthenticationContext.empty();
         };
     }
 
@@ -636,9 +636,11 @@ public final class ElytronXmlParser {
         if (authenticationConfigurationsMap.containsKey(name)) {
             throw xmlLog.xmlDuplicateAuthenticationConfigurationName(name, reader);
         }
-        ExceptionUnaryOperator<AuthenticationConfiguration, ConfigXMLParseException> configuration = ignored -> AuthenticationConfiguration.EMPTY;
+
+        ExceptionUnaryOperator<AuthenticationConfiguration, ConfigXMLParseException> configuration = ignored -> AuthenticationConfiguration.empty();
         DeferredSupplier<Provider[]> providerSupplier = new DeferredSupplier<>(providers);
         configuration = andThenOp(configuration, parent -> parent.useProviders(providerSupplier));
+
         int foundBits = 0;
         if (! reader.hasNext()) {
             throw reader.unexpectedDocumentEnd();
@@ -779,7 +781,7 @@ public final class ElytronXmlParser {
                 }
             } else if (tag == END_ELEMENT) {
                 final ExceptionUnaryOperator<AuthenticationConfiguration, ConfigXMLParseException> finalConfiguration = configuration;
-                authenticationConfigurationsMap.put(name, () -> finalConfiguration.apply(AuthenticationConfiguration.EMPTY));
+                authenticationConfigurationsMap.put(name, () -> finalConfiguration.apply(AuthenticationConfiguration.empty()));
                 return;
             } else {
                 throw reader.unexpectedContent();

--- a/src/test/java/org/wildfly/security/auth/client/AuthenticationConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/AuthenticationConfigurationTest.java
@@ -33,8 +33,8 @@ public final class AuthenticationConfigurationTest {
         AuthenticationConfiguration c1;
         AuthenticationConfiguration c2;
 
-        c1 = AuthenticationConfiguration.EMPTY.useName("name1").usePort(1234).useProtocol("abcd");
-        c2 = AuthenticationConfiguration.EMPTY.useName("name1").usePort(1234).useProtocol("abcd");
+        c1 = AuthenticationConfiguration.empty().useName("name1").usePort(1234).useProtocol("abcd");
+        c2 = AuthenticationConfiguration.empty().useName("name1").usePort(1234).useProtocol("abcd");
 
         assertEquals(c1, c2);
     }
@@ -44,8 +44,8 @@ public final class AuthenticationConfigurationTest {
         AuthenticationConfiguration c1;
         AuthenticationConfiguration c2;
 
-        c1 = AuthenticationConfiguration.EMPTY.useName("name1").usePort(1234).useProtocol("abcd").usePassword("abcd");
-        c2 = AuthenticationConfiguration.EMPTY.useName("name1").usePort(1234).useProtocol("abcd").usePassword("abcd");
+        c1 = AuthenticationConfiguration.empty().useName("name1").usePort(1234).useProtocol("abcd").usePassword("abcd");
+        c2 = AuthenticationConfiguration.empty().useName("name1").usePort(1234).useProtocol("abcd").usePassword("abcd");
 
         assertEquals(c1, c2);
     }
@@ -56,10 +56,10 @@ public final class AuthenticationConfigurationTest {
         AuthenticationConfiguration c1;
         AuthenticationConfiguration c2;
 
-        c1 = AuthenticationConfiguration.EMPTY.useName("name1").usePassword("password1").usePort(1234);
-        c2 = AuthenticationConfiguration.EMPTY.useName("name2").useProtocol("abcd").usePort(1234);
+        c1 = AuthenticationConfiguration.empty().useName("name1").usePassword("password1").usePort(1234);
+        c2 = AuthenticationConfiguration.empty().useName("name2").useProtocol("abcd").usePort(1234);
         assertEquals(
-            AuthenticationConfiguration.EMPTY.useName("name1").useCredentials(c1.getCredentialSource()).usePort(1234).useProtocol("abcd"),
+            AuthenticationConfiguration.empty().useName("name1").useCredentials(c1.getCredentialSource()).usePort(1234).useProtocol("abcd"),
             c2.with(c1)
         );
 

--- a/src/test/java/org/wildfly/security/auth/client/AuthenticationContextTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/AuthenticationContextTest.java
@@ -29,13 +29,13 @@ import org.wildfly.security.ssl.SSLContextBuilder;
 public final class AuthenticationContextTest {
 
     private final AuthenticationConfiguration config1
-            = AuthenticationConfiguration.EMPTY.useName("name1").usePort(1111).useProtocol("protocol1").usePassword("password1");
+            = AuthenticationConfiguration.empty().useName("name1").usePort(1111).useProtocol("protocol1").usePassword("password1");
     private final AuthenticationConfiguration config2
-            = AuthenticationConfiguration.EMPTY.useName("name2").usePort(2222).useProtocol("protocol2").usePassword("password2");
+            = AuthenticationConfiguration.empty().useName("name2").usePort(2222).useProtocol("protocol2").usePassword("password2");
     private final AuthenticationConfiguration config3
-            = AuthenticationConfiguration.EMPTY.useName("name3").usePort(3333).useProtocol("protocol3").usePassword("password3");
+            = AuthenticationConfiguration.empty().useName("name3").usePort(3333).useProtocol("protocol3").usePassword("password3");
     private final AuthenticationConfiguration config4
-            = AuthenticationConfiguration.EMPTY.useName("name4").usePort(4444).useProtocol("protocol4").usePassword("password4");
+            = AuthenticationConfiguration.empty().useName("name4").usePort(4444).useProtocol("protocol4").usePassword("password4");
 
     private final SecurityFactory<SSLContext> ssl1 = new SSLContextBuilder().setSessionTimeout(1).build();
     private final SecurityFactory<SSLContext> ssl2 = new SSLContextBuilder().setSessionTimeout(2).build();

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -941,7 +941,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
                                 .useRealm(realm)
@@ -967,7 +967,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .useCredentialStoreEntry(cs, alias)
                                 .useRealm(realm)

--- a/src/test/java/org/wildfly/security/sasl/digest/DigestCallbackHandlerUtils.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/DigestCallbackHandlerUtils.java
@@ -56,7 +56,7 @@ public class DigestCallbackHandlerUtils {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
                                 .useRealm(sentRealm)

--- a/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
@@ -563,7 +563,7 @@ public class EntityTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useKeyStoreCredential(loadKeyStore(keyStore), keyStoreAlias, new KeyStore.PasswordProtection(keyStorePassword))
                                 .useTrustManager(trustManager)
                                 .allowSaslMechanisms(mechanisms));
@@ -577,7 +577,7 @@ public class EntityTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useKeyManagerCredential(keyManager)
                                 .useTrustManager(trustManager)
                                 .allowSaslMechanisms(mechanisms));
@@ -591,7 +591,7 @@ public class EntityTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useCertificateCredential(privateKey, certificateChain)
                                 .useTrustManager(trustManager)
                                 .allowSaslMechanisms(mechanisms));

--- a/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
+++ b/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
@@ -624,7 +624,7 @@ public class Gs2SuiteChild extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useAuthorizationName(authorizationId)
                                 .useGSSCredential(credential)
                                 .allowSaslMechanisms(mechanisms));

--- a/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
@@ -279,7 +279,7 @@ public class OAuth2SaslClientTest extends BaseTestCase {
     @Test
     public void testResourceOwnerCredentialsUsingAPI() throws Exception {
         AuthenticationContext context = AuthenticationContext.empty()
-                .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.EMPTY
+                .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.empty()
                         .useCredentials(OAuth2CredentialSource.builder(new URL("http://localhost:50831/token"))
                                 .clientCredentials("elytron-client", "dont_tell_me")
                                 .useResourceOwnerPassword("alice", "dont_tell_me")
@@ -310,13 +310,13 @@ public class OAuth2SaslClientTest extends BaseTestCase {
     @Test
     public void failedResourceOwnerCredentialsUsingAPI() throws Exception {
         AuthenticationContext context = AuthenticationContext.empty()
-                .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.EMPTY
+                .with(MatchRule.ALL.matchHost("resourceserver.com"), AuthenticationConfiguration.empty()
                         .useCredentials(OAuth2CredentialSource.builder(new URL("http://localhost:50831/token"))
                                 .useResourceOwnerPassword("unknown", "dont_tell_me")
                                 .clientCredentials("bad", "bad")
                                 .build())
                         .allowSaslMechanisms("OAUTHBEARER"))
-                .with(MatchRule.ALL.matchHost("localhost").matchPort(50831).matchPath("/token"), AuthenticationConfiguration.EMPTY
+                .with(MatchRule.ALL.matchHost("localhost").matchPort(50831).matchPath("/token"), AuthenticationConfiguration.empty()
                         .useName("elytron_client")
                         .usePassword("dont_tell_me"));
         AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
@@ -362,7 +362,7 @@ public class OAuth2SaslClientTest extends BaseTestCase {
                 .build();
 
 
-        AuthenticationContext externalContext = AuthenticationContext.empty().with(MatchRule.ALL.matchHost("localhost"), AuthenticationConfiguration.EMPTY.useCallbackHandler(new CallbackHandler() {
+        AuthenticationContext externalContext = AuthenticationContext.empty().with(MatchRule.ALL.matchHost("localhost"), AuthenticationConfiguration.empty().useCallbackHandler(new CallbackHandler() {
             @Override
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (Callback callback : callbacks) {
@@ -413,7 +413,7 @@ public class OAuth2SaslClientTest extends BaseTestCase {
                 .build();
 
 
-        AuthenticationContext externalContext = AuthenticationContext.empty().with(MatchRule.ALL.matchHost("localhost"), AuthenticationConfiguration.EMPTY.useCallbackHandler(new CallbackHandler() {
+        AuthenticationContext externalContext = AuthenticationContext.empty().with(MatchRule.ALL.matchHost("localhost"), AuthenticationConfiguration.empty().useCallbackHandler(new CallbackHandler() {
             @Override
             public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
                 for (Callback callback : callbacks) {

--- a/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
+++ b/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
@@ -984,7 +984,7 @@ public class OTPTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .useChoice(MATCH_RESPONSE_CHOICE, responseChoice)
                                 .useChoice(MATCH_PASSWORD_FORMAT_CHOICE, passwordFormatChoice)
@@ -999,7 +999,7 @@ public class OTPTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .useChoice(MATCH_RESPONSE_CHOICE, responseChoice)
                                 .useChoice(MATCH_PASSWORD_FORMAT_CHOICE, passwordFormatChoice)
@@ -1025,7 +1025,7 @@ public class OTPTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .useChoice(MATCH_RESPONSE_CHOICE, responseChoice)
                                 .useChoice(MATCH_PASSWORD_FORMAT_CHOICE, passwordFormatChoice)

--- a/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
+++ b/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
@@ -260,7 +260,7 @@ public class PlainTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
                                 .allowSaslMechanisms(PLAIN));

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
@@ -36,7 +36,7 @@ class ScramCallbackHandlerUtils {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
                                 .allowSaslMechanisms("SCRAM-SHA-256"));
@@ -49,7 +49,7 @@ class ScramCallbackHandlerUtils {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
                                 .allowSaslMechanisms("SCRAM-SHA-256"));

--- a/src/test/java/org/wildfly/security/sasl/test/AnonymousTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/AnonymousTest.java
@@ -158,7 +158,7 @@ public class AnonymousTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useAnonymous());
 
 

--- a/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
@@ -414,7 +414,7 @@ public class LocalUserTest extends BaseTestCase {
         final AuthenticationContext context = AuthenticationContext.empty()
                 .with(
                         MatchRule.ALL,
-                        AuthenticationConfiguration.EMPTY
+                        AuthenticationConfiguration.empty()
                                 .useName(expectedUsername)
                                 .useRealm("mainRealm")
                                 .allowSaslMechanisms(LOCAL_USER));


### PR DESCRIPTION
Added method empty() for AuthenticationConfiguration to make things consistent.