### PR TITLE
[ELY-1181] For IBM use a credsType of 'both' instead of 'initiator' to be compatible with using a KeyTab.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
@@ -326,7 +326,7 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
 
             if (IS_IBM) {
                 options.put("noAddress", "true");
-                options.put("credsType", (isServer && !obtainKerberosTicket) ? "acceptor" : "initiator");
+                options.put("credsType", (isServer && !obtainKerberosTicket) ? "acceptor" : "both");
                 options.put("useKeytab", keyTab.toURI().toURL().toString());
             } else {
                 options.put("storeKey", "true");


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1181
https://issues.jboss.org/browse/JBEAP-9309