### PR TITLE
[JBEAP-11067][ELY-1184] return correct offset when current char is not name char.

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
+++ b/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
@@ -408,7 +408,7 @@ public abstract class SaslMechanismSelector {
                                         }
                                         cp = i.next();
                                         if (! isNameChar(cp)) {
-                                            nextStringVal = string.substring(start, i.offset());
+                                            nextStringVal = string.substring(start, i.offset() - 1);
                                             i.prev();
                                             this.offs = offs;
                                             next = TOK_NAME;


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1184
https://issues.jboss.org/browse/JBEAP-11067

offset of end bracket ')' is wrongly returned after it's been identified as non name char.