### PR TITLE
ELY-1191 Undertow CLIENT_CERT via Elytron and HTTP/2 does not work

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -58,6 +58,9 @@ public interface HttpServerRequest extends HttpServerScopes {
     /**
      * Get the {@link SSLSession} (if any) that has been established for the connection in use.
      *
+     * Note that even if this is null {@link #getPeerCertificates()} can still return some certificates, as the certificates
+     * may have been provided to the underlying server via some external mechanism (such as headers).
+     *
      * @return the {@link SSLSession} (if any) that has been established for the connection in use, or {@code null} if none
      *         exists.
      */


### PR DESCRIPTION
This will also fix CLIENT_CERT in the case where SSL is being terminated at the reverse proxy and the certificate information is being provided by headers.