### PR TITLE
[ELY-1115] SAC: InvalidNameState for non-existing identities

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1050,6 +1050,9 @@ public final class ServerAuthenticationContext {
         } else {
             realmIdentity = securityRealm.getRealmIdentity(finalPrincipal);
         }
+        if (! realmIdentity.exists()) {
+            return new InvalidNameState(capturedIdentity, mechanismConfiguration, mechanismRealmConfiguration, privateCredentials, publicCredentials);
+        }
         return new NameAssignedState(capturedIdentity, realmInfo, realmIdentity, preRealmPrincipal, mechanismConfiguration, mechanismRealmConfiguration, privateCredentials, publicCredentials);
     }
 
@@ -1703,6 +1706,11 @@ public final class ServerAuthenticationContext {
         @Override
         MechanismRealmConfiguration getMechanismRealmConfiguration() {
             return mechanismRealmConfiguration;
+        }
+
+        @Override
+        RealmIdentity getRealmIdentity() {
+            return RealmIdentity.NON_EXISTENT;
         }
 
         @Override


### PR DESCRIPTION
Clearing after hotfix: https://github.com/wildfly-security/wildfly-elytron/pull/821

Using InvalidNameState also when identity does not exist in realm. (Not only when not found in realm.)

Not critical.