### PR TITLE
ELY-1199:Allow creation of empty credential stores

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -134,7 +134,10 @@ import org.wildfly.security.x500.X500;
  * <ul>
  *     <li>{@code location}: specifies the location of the key store (none means, use an in-memory store and do not store changes)</li>
  *     <li>{@code modifiable}: specifies whether the credential store should be modifiable</li>
- *     <li>{@code create}: specifies to automatically create storage file for this credential store (defaults to {@code false})</li>
+ *     <li>{@code create}: specifies to automatically create storage file for this credential store (defaults to {@code false}).
+ *          <p>
+ *          If {@code external} is true, the storage file will be created calling the {@link #flush} method. If {@code external} is false and the storage file does not exist yet,
+ *          then an empty credential store is created when {@link #initialize} method is invoked.</li>
  *     <li>{@code keyStoreType}: specifies the key store type to use (defaults to {@link KeyStore#getDefaultType()})</li>
  *     <li>{@code keyAlias}: specifies the secret key alias within the key store to use for encrypt/decrypt of data in external storage (defaults to {@code cs_key})</li>
  *     <li>{@code external}: specifies whether to store data to external storage and encrypted by {@code keyAlias} key (defaults to {@code false})</li>
@@ -208,6 +211,10 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             encryptionKeyAlias = attributes.getOrDefault(KEYALIAS, "cs_key");
             cryptographicAlgorithm = attributes.get(CRYPTOALG);
             load(keyStoreType);
+            if ( create  && !useExternalStorage && location != null && !Files.exists(location) ){
+                //Only in this case, flush the data to the file allowing the credential store creation independently of modifiable flag
+                flush();
+            }
             initialized = true;
         }
     }


### PR DESCRIPTION
Patch to allow creating empty credential stores independently of its modifiable attribute.

https://issues.jboss.org/browse/ELY-1199
https://issues.jboss.org/browse/JBEAP-9211

depends on: https://github.com/wildfly/wildfly-core/pull/2469