### PR TITLE
[ELY-1191] CLIENT_CERT Authentication may not have access to SSLSession

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -58,6 +58,9 @@ public interface HttpServerRequest extends HttpServerScopes {
     /**
      * Get the {@link SSLSession} (if any) that has been established for the connection in use.
      *
+     * Note that even if this is null {@link #getPeerCertificates()} can still return some certificates, as the certificates
+     * may have been provided to the underlying server via some external mechanism (such as headers).
+     *
      * @return the {@link SSLSession} (if any) that has been established for the connection in use, or {@code null} if none
      *         exists.
      */

--- a/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
@@ -24,11 +24,14 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
 import javax.net.ssl.SSLSession;
+import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
 
 import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.auth.callback.CachedIdentityAuthorizeCallback;
@@ -77,18 +80,20 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
      */
     @Override
     public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
-        if (attemptReAuthentication(request)) {
+        Function<SecurityDomain, IdentityCache> cacheFunction = createIdentityCacheFunction(request);
+
+        if (cacheFunction!= null && attemptReAuthentication(request, cacheFunction)) {
             log.trace("ClientCertAuthenticationMechanism: re-authentication succeed");
             return;
         }
-        if (attemptAuthentication(request)) {
+        if (attemptAuthentication(request, cacheFunction)) {
             return;
         }
         log.trace("ClientCertAuthenticationMechanism: both, re-authentication and authentication, failed");
         fail(request);
     }
 
-    private boolean attemptAuthentication(HttpServerRequest request) throws HttpAuthenticationException {
+    private boolean attemptAuthentication(HttpServerRequest request, Function<SecurityDomain, IdentityCache> cacheFunction) throws HttpAuthenticationException {
         Certificate[] peerCertificates = request.getPeerCertificates();
         if (peerCertificates == null) {
             log.trace("CLIENT-CERT Peer Unverified");
@@ -112,16 +117,28 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
         boolean verified = callback.isVerified();
         log.tracef("X509PeerCertificateChainEvidence was verified by EvidenceVerifyCallback handler: %b", verified);
         if (verified) {
-            CachedIdentityAuthorizeCallback authorizeCallback = new CachedIdentityAuthorizeCallback(evidence.getPrincipal(), createIdentityCache(request), true);
+            final BooleanSupplier authorizedFunction;
+            final Callback authorizeCallBack;
+            if (cacheFunction != null) {
+                CachedIdentityAuthorizeCallback cacheCallback = new CachedIdentityAuthorizeCallback(evidence.getPrincipal(), cacheFunction, true);
+                authorizedFunction = cacheCallback::isAuthorized;
+                authorizeCallBack = cacheCallback;
+            } else {
+                String name = evidence.getPrincipal().getName();
+                AuthorizeCallback plainCallback = new AuthorizeCallback(name, name);
+                authorizedFunction = plainCallback::isAuthorized;
+                authorizeCallBack = plainCallback;
+            }
+
             try {
-                MechanismUtil.handleCallbacks(CLIENT_CERT_NAME, callbackHandler, authorizeCallback);
+                MechanismUtil.handleCallbacks(CLIENT_CERT_NAME, callbackHandler, authorizeCallBack);
             } catch (AuthenticationMechanismException e) {
                 throw e.toHttpAuthenticationException();
             } catch (UnsupportedCallbackException e) {
                 throw log.mechCallbackHandlerFailedForUnknownReason(CLIENT_CERT_NAME, e).toHttpAuthenticationException();
             }
 
-            boolean authorized = authorizeCallback.isAuthorized();
+            boolean authorized = authorizedFunction.getAsBoolean();
             log.tracef("X509PeerCertificateChainEvidence was authorized by CachedIdentityAuthorizeCallback(%s) handler: %b", evidence.getPrincipal(), authorized);
             if (authorized && succeed(request)) {
                 log.trace("ClientCertAuthenticationMechanism: authentication succeed");
@@ -155,8 +172,8 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
         }
     }
 
-    private boolean attemptReAuthentication(HttpServerRequest request) throws HttpAuthenticationException {
-        CachedIdentityAuthorizeCallback authorizeCallback = new CachedIdentityAuthorizeCallback(createIdentityCache(request), true);
+    private boolean attemptReAuthentication(HttpServerRequest request, Function<SecurityDomain, IdentityCache> cacheFunction) throws HttpAuthenticationException {
+        CachedIdentityAuthorizeCallback authorizeCallback = new CachedIdentityAuthorizeCallback(cacheFunction, true);
         try {
             MechanismUtil.handleCallbacks(CLIENT_CERT_NAME, callbackHandler, authorizeCallback);
         } catch (AuthenticationMechanismException e) {
@@ -172,32 +189,9 @@ public class ClientCertAuthenticationMechanism implements HttpServerAuthenticati
         return false;
     }
 
-    private Function<SecurityDomain, IdentityCache> createIdentityCache(HttpServerRequest request) {
+    private Function<SecurityDomain, IdentityCache> createIdentityCacheFunction(HttpServerRequest request) {
         SSLSession sslSession = request.getSSLSession();
-        if (sslSession == null) {
-            return securityDomain -> new IdentityCache() {
-
-                private volatile CachedIdentity cachedIdentity;
-
-                @Override
-                public void put(SecurityIdentity identity) {
-                    cachedIdentity = new CachedIdentity(getMechanismName(), identity);
-                }
-
-                @Override
-                public CachedIdentity get() {
-                    return cachedIdentity;
-                }
-
-                @Override
-                public CachedIdentity remove() {
-                    CachedIdentity old = cachedIdentity;
-                    cachedIdentity = null;
-                    return old;
-                }
-            };
-        }
-        return securityDomain -> new IdentityCache() {
+        return sslSession == null ? null : securityDomain -> new IdentityCache() {
 
             final Map<SecurityDomain, CachedIdentity> identities = SSLUtils.computeIfAbsent(sslSession, "org.wildfly.elytron.identity-cache", key -> new ConcurrentHashMap<>());
 


### PR DESCRIPTION
This pull request is a follow up to Stuart's PR: -

https://github.com/wildfly-security/wildfly-elytron/pull/832

If we don't have an SSLSession available to us skip caching entirely.