### PR TITLE
[ELY-1194][JBEAP-11110] OAuth2SaslServer fail after client dummy response

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/oauth2/OAuth2SaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/oauth2/OAuth2SaslServer.java
@@ -76,9 +76,8 @@ final class OAuth2SaslServer extends AbstractSaslServer {
                     return serverResponse;
                 }
                 case S_IN_ERROR: {
-                    // client is trying to abort the authentication, we just force FAILED state
-                    ok = false;
-                    return null;
+                    // client sent dummy client response, server fails the authentication
+                    throw log.mechAuthenticationFailed(getMechanismName()).toSaslException();
                 }
                 case COMPLETE_STATE: {
                     if (response != null && response.length != 0) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1194
https://issues.jboss.org/browse/JBEAP-11110

By RFC server should fail after receiving client dummy response:
https://tools.ietf.org/html/rfc7628#section-3
(in previous version server didnt sent anything and didnt close connection - connection got trapped in waiting)