### PR TITLE
[ELY-1195] Coverity, Dereference after null check in KeyStoreCredentialStore (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -847,7 +847,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             }
         } catch (GeneralSecurityException e) {
             throw log.cannotInitializeCredentialStore(
-                    log.internalEncryptionProblem(e, dataLocation.toString()));
+                    log.internalEncryptionProblem(e, dataLocation != null ? dataLocation.toString() : "null"));
         } catch (IOException e) {
             throw log.cannotInitializeCredentialStore(e);
         }


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1195
JBEAP: https://issues.jboss.org/browse/JBEAP-11113