### PR TITLE
[ELY-1121] Clarify contract of RealmIdentity.exists() and avoid using it in general for authentication.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/token/TokenSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/token/TokenSecurityRealm.java
@@ -157,7 +157,7 @@ public final class TokenSecurityRealm implements SecurityRealm {
 
         @Override
         public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
-            if (isBearerTokenEvidence(evidenceType)) {
+            if (exists() && isBearerTokenEvidence(evidenceType)) {
                 return SupportLevel.SUPPORTED;
             }
 

--- a/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/RealmIdentity.java
@@ -163,8 +163,14 @@ public interface RealmIdentity {
     boolean verifyEvidence(Evidence evidence) throws RealmUnavailableException;
 
     /**
-     * Determine if the identity exists in lieu of verifying or acquiring a credential.  This method is intended to be
-     * used to verify an identity for non-authentication purposes only.
+     * Determine if the identity exists in lieu of verifying or acquiring a credential. This method is intended to be used to
+     * verify an identity for non-authentication purposes only.
+     *
+     * Implementations of this method should return {@code false} up until the point it is known that a call to
+     * {@link #getAuthorizationIdentity()} can successfully return an identity.
+     *
+     * If a realm can load an identity independently of credential acquisition and evidence verification if not already loaded
+     * it should be loaded at the time of this call to return an accurate result.
      *
      * @return {@code true} if the identity exists in this realm, {@code false} otherwise
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
@@ -182,6 +188,7 @@ public interface RealmIdentity {
      *
      * @return the authorization identity (may not be {@code null})
      *
+     * @throws IllegalStateException if called for an identity that does not exist
      * @throws RealmUnavailableException if the realm is not able to handle requests for any reason
      */
     default AuthorizationIdentity getAuthorizationIdentity() throws RealmUnavailableException {

--- a/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
@@ -48,9 +48,13 @@ public interface SecurityRealm {
     }
 
     /**
-     * Get a handle for to the identity for the given locator in the context of this security realm. Any
-     * validation / name mapping is an implementation detail for the realm.  The identity may or may not exist.  The
-     * returned handle <em>must</em> be cleaned up by a call to {@link RealmIdentity#dispose()}.
+     * Get a handle for to the identity for the given evidence in the context of this security realm. Any validation / name
+     * mapping is an implementation detail for the realm. The identity may or may not exist. The returned handle <em>must</em>
+     * be cleaned up by a call to {@link RealmIdentity#dispose()}.
+     *
+     * Where this method is used to obtain a {@link RealmIdentity} prior to evidence verification the return value of
+     * {@link RealmIdentity#exists()} is required to be accurate, if the method is not able to return {@code true} then the
+     * identity will be discarded and not used for evidence verification.
      *
      * @param evidence an evidence instance which identifies the identity within the realm (must not be {@code null})
      * @return the {@link RealmIdentity} for the provided evidence (not {@code null})

--- a/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityRealm.java
@@ -52,9 +52,8 @@ public interface SecurityRealm {
      * mapping is an implementation detail for the realm. The identity may or may not exist. The returned handle <em>must</em>
      * be cleaned up by a call to {@link RealmIdentity#dispose()}.
      *
-     * Where this method is used to obtain a {@link RealmIdentity} prior to evidence verification the return value of
-     * {@link RealmIdentity#exists()} is required to be accurate, if the method is not able to return {@code true} then the
-     * identity will be discarded and not used for evidence verification.
+     * Where this method is used to obtain a {@link RealmIdentity} prior to evidence verification the method
+     * {@link RealmIdentity#getEvidenceVerifySupport(Class, String)} will be used to verify if the identity is usable.
      *
      * @param evidence an evidence instance which identifies the identity within the realm (must not be {@code null})
      * @return the {@link RealmIdentity} for the provided evidence (not {@code null})

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1050,9 +1050,7 @@ public final class ServerAuthenticationContext {
         } else {
             realmIdentity = securityRealm.getRealmIdentity(finalPrincipal);
         }
-        if (! realmIdentity.exists()) {
-            return new InvalidNameState(capturedIdentity, mechanismConfiguration, mechanismRealmConfiguration, privateCredentials, publicCredentials);
-        }
+
         return new NameAssignedState(capturedIdentity, realmInfo, realmIdentity, preRealmPrincipal, mechanismConfiguration, mechanismRealmConfiguration, privateCredentials, publicCredentials);
     }
 

--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -76,6 +76,7 @@ import org.wildfly.security.authz.AuthorizationIdentity;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.evidence.AlgorithmEvidence;
 import org.wildfly.security.evidence.Evidence;
 import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
 import org.wildfly.security.password.Password;
@@ -1535,6 +1536,9 @@ public final class ServerAuthenticationContext {
                 }
                 return true;
             }
+            Class<? extends Evidence> evidenceType = evidence.getClass();
+            String algorithm = evidence instanceof AlgorithmEvidence ? ((AlgorithmEvidence) evidence).getAlgorithm() : null;
+
             // verify evidence with no name set: use the realms to find a match (SSO scenario, etc.)
             final SecurityDomain domain = getSecurityDomain();
             final Collection<RealmInfo> realmInfos = domain.getRealmInfos();
@@ -1542,7 +1546,7 @@ public final class ServerAuthenticationContext {
             RealmInfo realmInfo = null;
             for (RealmInfo info : realmInfos) {
                 realmIdentity = info.getSecurityRealm().getRealmIdentity(evidence);
-                if (realmIdentity.exists()) {
+                if (realmIdentity.getEvidenceVerifySupport(evidenceType, algorithm).mayBeSupported()) {
                     realmInfo = info;
                     break;
                 } else {
@@ -1553,7 +1557,6 @@ public final class ServerAuthenticationContext {
                 // no verification possible, no identity found
                 return false;
             }
-            assert realmIdentity != null && realmIdentity.exists();
             final Principal resolvedPrincipal = realmIdentity.getRealmIdentityPrincipal();
             if (resolvedPrincipal == null) {
                 // we have to have a principal


### PR DESCRIPTION
This PR now avoids using the exists() method entirely during authentication.

Where we do need to find out if a RealmIdentity is usable for authentication we have the getCredentialAcquireSupport and getEvidenceVerifySupport exactly for this purpose.