### PR TITLE
[ELY-1209] allow-all-mechanisms, allow/forbid-sasl-mechanisms removing

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -1078,51 +1078,6 @@ public final class AuthenticationConfiguration {
         return new AuthenticationConfiguration(this, SET_SASL_SELECTOR, saslMechanismSelector);
     }
 
-    /**
-     * Create a new configuration which is the same as this configuration, but which does not forbid any SASL mechanisms.
-     *
-     * @return the new configuration.
-     */
-    public AuthenticationConfiguration allowAllSaslMechanisms() {
-        return setSaslMechanismSelector(SaslMechanismSelector.ALL);
-    }
-
-    /**
-     * Create a new configuration which is the same as this configuration, but which explicitly allows only the given named mechanisms.
-     * Any unlisted mechanisms will not be supported unless the configuration supports it.
-     *
-     * @param names the mechanism names
-     * @return the new configuration
-     */
-    public AuthenticationConfiguration allowSaslMechanisms(String... names) {
-        if (names == null || names.length == 0) {
-            // clear out all explicitly-allowed names
-            return setSaslMechanismSelector(null);
-        }
-        SaslMechanismSelector selector = SaslMechanismSelector.NONE;
-        for (String name : names) {
-            selector = selector.addMechanism(name);
-        }
-        return setSaslMechanismSelector(selector);
-    }
-
-    /**
-     * Create a new configuration which is the same as this configuration, but which forbids the given named mechanisms.
-     *
-     * @param names the mechanism names
-     * @return the new configuration
-     */
-    public AuthenticationConfiguration forbidSaslMechanisms(String... names) {
-        SaslMechanismSelector selector = saslMechanismSelector;
-        if (selector == null) {
-            selector = SaslMechanismSelector.DEFAULT;
-        }
-        for (String name : names) {
-            selector = selector.forbidMechanism(name);
-        }
-        return setSaslMechanismSelector(selector);
-    }
-
     // other
 
     /**

--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -701,30 +701,9 @@ public final class ElytronXmlParser {
                         configuration = andThenOp(configuration, parentConfig -> parentConfig.useMechanismProperties(mechanismProperties, true));
                         break;
                     }
-                    case "allow-all-sasl-mechanisms": {
+                    case "sasl-mechanism-selector": {
                         if (isSet(foundBits, 6)) throw reader.unexpectedElement();
                         foundBits = setBit(foundBits, 6);
-                        parseEmptyType(reader);
-                        configuration = andThenOp(configuration, AuthenticationConfiguration::allowAllSaslMechanisms);
-                        break;
-                    }
-                    case "allow-sasl-mechanisms": {
-                        if (isSet(foundBits, 7)) throw reader.unexpectedElement();
-                        foundBits = setBit(foundBits, 7);
-                        final String[] names = parseNamesType(reader);
-                        configuration = andThenOp(configuration, parentConfig -> parentConfig.allowSaslMechanisms(names));
-                        break;
-                    }
-                    case "forbid-sasl-mechanisms": {
-                        if (isSet(foundBits, 8)) throw reader.unexpectedElement();
-                        foundBits = setBit(foundBits, 8);
-                        final String[] names = parseNamesType(reader);
-                        configuration = andThenOp(configuration, parentConfig -> parentConfig.forbidSaslMechanisms(names));
-                        break;
-                    }
-                    case "sasl-mechanism-selector": {
-                        if (isSet(foundBits, 14)) throw reader.unexpectedElement();
-                        foundBits = setBit(foundBits, 14);
                         final SaslMechanismSelector selector = parseSaslMechanismSelectorType(reader);
                         configuration = andThenOp(configuration, parentConfig -> parentConfig.setSaslMechanismSelector(selector));
                         break;

--- a/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
+++ b/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
@@ -150,9 +150,27 @@ public abstract class SaslMechanismSelector {
         return new AddSelector(this, mechName);
     }
 
+    public SaslMechanismSelector addMechanisms(String... mechNames) {
+        Assert.checkNotNullParam("mechNames", mechNames);
+        SaslMechanismSelector selector = this;
+        for (String mechName : mechNames) {
+            selector = new AddSelector(selector, mechName);
+        }
+        return selector;
+    }
+
     public SaslMechanismSelector forbidMechanism(String mechName) {
         Assert.checkNotNullParam("mechName", mechName);
         return new ForbidSelector(this, mechName);
+    }
+
+    public SaslMechanismSelector forbidMechanisms(String... mechNames) {
+        Assert.checkNotNullParam("mechNames", mechNames);
+        SaslMechanismSelector selector = this;
+        for (String mechName : mechNames) {
+            selector = new ForbidSelector(selector, mechName);
+        }
+        return selector;
     }
 
     public SaslMechanismSelector addMatching(SaslMechanismPredicate predicate) {

--- a/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -85,7 +85,7 @@ public class XmlConfigurationTest {
             "<authentication-client xmlns=\"urn:elytron:1.0\">\n" +
             "    <authentication-configurations>\n" +
             "        <configuration name=\"test-1\">\n" +
-            "            <allow-sasl-mechanisms names=\"someName\"/>\n" +
+            "            <sasl-mechanism-selector selector=\"#ALL\" />\n" +
             "        </configuration>\n" +
             "        <configuration name=\"test-2\">\n" +
             "            <sasl-mechanism-selector selector=\"someName\"/>\n" +
@@ -188,7 +188,7 @@ public class XmlConfigurationTest {
             "            <set-host name=\"localhost\"/>\n" +
             "            <set-protocol name=\"HTTP\"/>\n" +
             "            <set-user-name name=\"jane\"/>\n" +
-            "            <allow-all-sasl-mechanisms />\n" +
+            "            <sasl-mechanism-selector selector=\"#ALL\" />\n" +
             "            <set-mechanism-realm name=\"mainRealm\"/>\n" +
             "            <set-mechanism-properties>\n" +
             "                <property key=\"key-one\" value=\"value-one\"/>\n" +
@@ -308,7 +308,7 @@ public class XmlConfigurationTest {
                 "            <set-host name=\"localhost\"/>\n" +
                 "            <set-protocol name=\"HTTP\"/>\n" +
                 "            <set-user-name name=\"jane\"/>\n" +
-                "            <allow-all-sasl-mechanisms />\n" +
+                "            <sasl-mechanism-selector selector=\"#ALL\" />\n" +
                 "            <set-mechanism-realm name=\"mainRealm\"/>\n" +
                 "            <set-mechanism-properties>\n" +
                 "                <property key=\"key-one\" value=\"value-one\"/>\n" +

--- a/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -48,6 +48,7 @@ import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.credential.store.CredentialStoreBuilder;
 import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.util.ByteIterator;
@@ -129,7 +130,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         CallbackHandler clientCallback;
         Map<String, Object> clientProps = new HashMap<>();
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testRfc2831example1", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -181,7 +182,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         CallbackHandler clientCallback;
         Map<String, Object> clientProps = new HashMap<>();
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testRfc2831example2", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -232,7 +233,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         CallbackHandler clientCallback;
         Map<String, Object> clientProps = new HashMap<>();
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testAuthorizedAuthorizationId", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -284,7 +285,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         Map<String, Object> clientProps = new HashMap<>();
         clientProps.put(QOP_PROPERTY, "auth-int");
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testAuthorizedAuthorizationId", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -420,7 +421,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         Map<String, Object> clientProps = new HashMap<>();
         clientProps.put(QOP_PROPERTY, "auth-conf");
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testQopAuthConfRc4", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -611,7 +612,7 @@ public class CompatibilityClientTest extends BaseTestCase {
         Map<String, Object> clientProps = new HashMap<>();
         clientProps.put(QOP_PROPERTY, "auth-conf");
         if (useCredentialStore) {
-            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "testQopAuthConfRc4", "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
+            clientCallback = createCredentialStoreBasedClientCallbackHandler("chris", null, "chris_pwd_alias", CS_FILE_NAME, "secret_store_1", "secret_key_1");
         } else {
             clientCallback = createClientCallbackHandler("chris", "secret".toCharArray(), null);
         }
@@ -945,12 +946,12 @@ public class CompatibilityClientTest extends BaseTestCase {
                                 .useName(username)
                                 .usePassword(password)
                                 .useRealm(realm)
-                                .allowSaslMechanisms(SaslMechanismInformation.Names.DIGEST_MD5));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(SaslMechanismInformation.Names.DIGEST_MD5)));
 
         return ClientUtils.getCallbackHandler(new URI("doesnot://matter?"), context);
     }
 
-    private CallbackHandler createCredentialStoreBasedClientCallbackHandler(String username, String realm, String storeName, String alias, String storeFileName, String storePassword, String keyPassword)
+    private CallbackHandler createCredentialStoreBasedClientCallbackHandler(String username, String realm, String alias, String storeFileName, String storePassword, String keyPassword)
             throws Exception {
         final HashMap<String, String> csAttributes = new HashMap<>();
         csAttributes.put("location", storeFileName);
@@ -971,8 +972,8 @@ public class CompatibilityClientTest extends BaseTestCase {
                                 .useName(username)
                                 .useCredentialStoreEntry(cs, alias)
                                 .useRealm(realm)
-                                .allowSaslMechanisms(SaslMechanismInformation.Names.DIGEST_MD5)
-                );
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(SaslMechanismInformation.Names.DIGEST_MD5)));
+
         return ClientUtils.getCallbackHandler(new URI("doesnot://matter"), context);
     }
 

--- a/src/test/java/org/wildfly/security/sasl/digest/DigestCallbackHandlerUtils.java
+++ b/src/test/java/org/wildfly/security/sasl/digest/DigestCallbackHandlerUtils.java
@@ -32,6 +32,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.interfaces.DigestPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.DigestPasswordSpec;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 
@@ -60,7 +61,7 @@ public class DigestCallbackHandlerUtils {
                                 .useName(username)
                                 .usePassword(password)
                                 .useRealm(sentRealm)
-                                .allowSaslMechanisms(SaslMechanismInformation.Names.DIGEST_MD5));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(SaslMechanismInformation.Names.DIGEST_MD5)));
 
 
         return ClientUtils.getCallbackHandler(new URI("seems://irrelevant"), context);

--- a/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
+++ b/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
@@ -65,6 +65,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.KeyStoreBackedSecurityRealm;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
@@ -566,7 +567,7 @@ public class EntityTest extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useKeyStoreCredential(loadKeyStore(keyStore), keyStoreAlias, new KeyStore.PasswordProtection(keyStorePassword))
                                 .useTrustManager(trustManager)
-                                .allowSaslMechanisms(mechanisms));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanisms(mechanisms)));
 
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
@@ -580,7 +581,7 @@ public class EntityTest extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useKeyManagerCredential(keyManager)
                                 .useTrustManager(trustManager)
-                                .allowSaslMechanisms(mechanisms));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanisms(mechanisms)));
 
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
@@ -594,7 +595,7 @@ public class EntityTest extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useCertificateCredential(privateKey, certificateChain)
                                 .useTrustManager(trustManager)
-                                .allowSaslMechanisms(mechanisms));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanisms(mechanisms)));
 
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);

--- a/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
+++ b/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
@@ -75,6 +75,7 @@ import org.wildfly.security.auth.realm.ldap.SimpleDirContextFactoryBuilder;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.auth.util.RegexNameRewriter;
 import org.wildfly.security.credential.GSSKerberosCredential;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.gssapi.GssapiTestSuite;
 import org.wildfly.security.sasl.test.BaseTestCase;
@@ -627,7 +628,7 @@ public class Gs2SuiteChild extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useAuthorizationName(authorizationId)
                                 .useGSSCredential(credential)
-                                .allowSaslMechanisms(mechanisms));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanisms(mechanisms)));
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
     }

--- a/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
+++ b/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientTest.java
@@ -52,6 +52,7 @@ import org.wildfly.security.auth.realm.token.validator.JwtValidator;
 import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.credential.source.OAuth2CredentialSource;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
@@ -284,7 +285,7 @@ public class OAuth2SaslClientTest extends BaseTestCase {
                                 .clientCredentials("elytron-client", "dont_tell_me")
                                 .useResourceOwnerPassword("alice", "dont_tell_me")
                                 .build())
-                        .allowSaslMechanisms("OAUTHBEARER"));
+                        .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("OAUTHBEARER")));
         AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
         AuthenticationConfiguration configuration = contextConfigurationClient.getAuthenticationConfiguration(URI.create("http://resourceserver.com"), context);
         SaslClient saslClient = contextConfigurationClient.createSaslClient(URI.create("http://resourceserver.com"), configuration, Arrays.asList("OAUTHBEARER"));
@@ -315,7 +316,7 @@ public class OAuth2SaslClientTest extends BaseTestCase {
                                 .useResourceOwnerPassword("unknown", "dont_tell_me")
                                 .clientCredentials("bad", "bad")
                                 .build())
-                        .allowSaslMechanisms("OAUTHBEARER"))
+                        .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("OAUTHBEARER")))
                 .with(MatchRule.ALL.matchHost("localhost").matchPort(50831).matchPath("/token"), AuthenticationConfiguration.empty()
                         .useName("elytron_client")
                         .usePassword("dont_tell_me"));

--- a/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
+++ b/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
@@ -79,6 +79,7 @@ import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.OneTimePassword;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
@@ -989,7 +990,7 @@ public class OTPTest extends BaseTestCase {
                                 .useChoice(MATCH_RESPONSE_CHOICE, responseChoice)
                                 .useChoice(MATCH_PASSWORD_FORMAT_CHOICE, passwordFormatChoice)
                                 .usePassword(password)
-                                .allowSaslMechanisms(algorithm));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(algorithm)));
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
     }
@@ -1016,7 +1017,7 @@ public class OTPTest extends BaseTestCase {
                                         }
                                     }
                                 }, EnumSet.of(CallbackKind.CREDENTIAL_RESET))
-                                .allowSaslMechanisms(algorithm));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(algorithm)));
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
     }
@@ -1041,7 +1042,7 @@ public class OTPTest extends BaseTestCase {
                                         }
                                     }
                                 }, EnumSet.of(CallbackKind.CREDENTIAL_RESET))
-                                .allowSaslMechanisms(algorithm));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(algorithm)));
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
     }

--- a/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
+++ b/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
@@ -43,6 +43,7 @@ import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
 import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 
@@ -263,7 +264,7 @@ public class PlainTest extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
-                                .allowSaslMechanisms(PLAIN));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(PLAIN)));
 
 
         return ClientUtils.getCallbackHandler(new URI("doesnot://matter?"), context);

--- a/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
+++ b/src/test/java/org/wildfly/security/sasl/scram/ScramCallbackHandlerUtils.java
@@ -26,6 +26,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.password.Password;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 
 /**
  * @author Kabir Khan
@@ -39,7 +40,7 @@ class ScramCallbackHandlerUtils {
                         AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
-                                .allowSaslMechanisms("SCRAM-SHA-256"));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("SCRAM-SHA-256")));
 
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);
@@ -52,7 +53,7 @@ class ScramCallbackHandlerUtils {
                         AuthenticationConfiguration.empty()
                                 .useName(username)
                                 .usePassword(password)
-                                .allowSaslMechanisms("SCRAM-SHA-256"));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("SCRAM-SHA-256")));
 
 
         return ClientUtils.getCallbackHandler(new URI("remote://localhost"), context);

--- a/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
@@ -42,6 +42,7 @@ import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
 import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.localuser.LocalUserServerFactory;
 import org.wildfly.security.util.CodePointIterator;
 
@@ -417,7 +418,7 @@ public class LocalUserTest extends BaseTestCase {
                         AuthenticationConfiguration.empty()
                                 .useName(expectedUsername)
                                 .useRealm("mainRealm")
-                                .allowSaslMechanisms(LOCAL_USER));
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism(LOCAL_USER)));
 
 
         return ClientUtils.getCallbackHandler(new URI("doesnot://matter?"), context);


### PR DESCRIPTION
Removed allowAllSaslMechanisms, allowSaslMechanisms, forbidSaslMechanisms methods of AuthenticationConfiguration as requested in JBEAP-11209.
To simplify their replacing added addMechanisms and forbidMechanisms for adding/forbidding more mechanisms in one call.

https://issues.jboss.org/browse/ELY-1209
https://issues.jboss.org/browse/JBEAP-11209

Need to be merged in coordination with https://github.com/wildfly/wildfly-core/pull/2510