### PR TITLE
[ELY-1218] The mutual SASL mechanism predicate should not require TLS to be used

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/SaslMechanismPredicate.java
+++ b/src/main/java/org/wildfly/security/sasl/SaslMechanismPredicate.java
@@ -182,7 +182,7 @@ public abstract class SaslMechanismPredicate {
 
     static final SaslMechanismPredicate MUTUAL = new SaslMechanismPredicate() {
         boolean test(final String mechName, final SSLSession sslSession) {
-            return sslSession != null && SaslMechanismInformation.MUTUAL.test(mechName);
+            return SaslMechanismInformation.MUTUAL.test(mechName);
         }
 
         void toString(final StringBuilder b) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1218
https://issues.jboss.org/browse/JBEAP-11288