### PR TITLE
[ELY-1216] Ensure that any mechanisms that are forbidden using the minus SASL selector operator actually get removed from the list even if a subsequent SASL selector predicate would allow it

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
+++ b/src/main/java/org/wildfly/security/sasl/SaslMechanismSelector.java
@@ -143,7 +143,11 @@ public abstract class SaslMechanismSelector {
 
     abstract Supplier<String> doCreateSupplier(LinkedHashSet<String> set, SSLSession sslSession);
 
-    void preprocess(Set<String> mechNames, SSLSession sslSession) {}
+    void preprocess(Set<String> mechNames, SSLSession sslSession) {
+        if (prev != null) {
+            prev.preprocess(mechNames, sslSession);
+        }
+    }
 
     public SaslMechanismSelector addMechanism(String mechName) {
         Assert.checkNotNullParam("mechName", mechName);
@@ -825,6 +829,7 @@ public abstract class SaslMechanismSelector {
         }
 
         void preprocess(final Set<String> mechNames, final SSLSession sslSession) {
+            prev.preprocess(mechNames, sslSession);
             mechNames.remove(mechName);
         }
 
@@ -907,6 +912,7 @@ public abstract class SaslMechanismSelector {
         }
 
         void preprocess(final Set<String> mechNames, final SSLSession sslSession) {
+            prev.preprocess(mechNames, sslSession);
             mechNames.removeIf(mechName -> predicate.test(mechName, sslSession));
         }
 

--- a/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -114,6 +114,15 @@ public class XmlConfigurationTest {
             "        <configuration name=\"test-10\">\n" +
             "            <sasl-mechanism-selector selector=\"PLAIN DIGEST-MD5 ANONYMOUS JBOSS-LOCAL-USER\"/>\n" +
             "        </configuration>\n" +
+            "        <configuration name=\"test-11\">\n" +
+            "            <sasl-mechanism-selector selector=\"someName -PLAIN #ALL\"/>\n" +
+            "        </configuration>\n" +
+            "        <configuration name=\"test-12\">\n" +
+            "            <sasl-mechanism-selector selector=\"-PLAIN JBOSS-LOCAL-USER PLAIN\"/>\n" +
+            "        </configuration>\n" +
+            "        <configuration name=\"test-13\">\n" +
+            "            <sasl-mechanism-selector selector=\"-PLAIN someName -DIGEST-MD5 #ALL\"/>\n" +
+            "        </configuration>\n" +
             "    </authentication-configurations>\n" +
             "    <authentication-rules>\n" +
             "        <rule use-configuration=\"test-1\">\n" +
@@ -133,6 +142,15 @@ public class XmlConfigurationTest {
             "        </rule>\n" +
             "        <rule use-configuration=\"test-10\">\n" +
             "            <match-host name=\"host-10\"/>\n" +
+            "        </rule>\n" +
+            "        <rule use-configuration=\"test-11\">\n" +
+            "            <match-host name=\"host-11\"/>\n" +
+            "        </rule>\n" +
+            "        <rule use-configuration=\"test-12\">\n" +
+            "            <match-host name=\"host-12\"/>\n" +
+            "        </rule>\n" +
+            "        <rule use-configuration=\"test-13\">\n" +
+            "            <match-host name=\"host-13\"/>\n" +
             "        </rule>\n" +
             "    </authentication-rules>\n" +
             "</authentication-client>\n" +
@@ -161,6 +179,19 @@ public class XmlConfigurationTest {
         AuthenticationConfiguration ac10 = ac.authRuleMatching(new URI("http://host-10/"), null, null).getConfiguration();
         filtered = ac10.saslMechanismSelector.apply(Arrays.asList("PLAIN", "DIGEST-MD5", "JBOSS-LOCAL-USER", "ABC"), null).toArray(new String[]{});
         Assert.assertArrayEquals(new String[]{"PLAIN", "DIGEST-MD5", "JBOSS-LOCAL-USER"}, filtered);
+
+        // ELY-1216
+        AuthenticationConfiguration ac11 = ac.authRuleMatching(new URI("http://host-11/"), null, null).getConfiguration();
+        filtered = ac11.saslMechanismSelector.apply(Arrays.asList("A", "B", "PLAIN"), null).toArray(new String[]{});
+        Assert.assertArrayEquals(new String[]{"A", "B"}, filtered);
+
+        AuthenticationConfiguration ac12 = ac.authRuleMatching(new URI("http://host-12/"), null, null).getConfiguration();
+        filtered = ac12.saslMechanismSelector.apply(Arrays.asList("A", "B", "PLAIN", "JBOSS-LOCAL-USER"), null).toArray(new String[]{});
+        Assert.assertArrayEquals(new String[]{"JBOSS-LOCAL-USER"}, filtered);
+
+        AuthenticationConfiguration ac13 = ac.authRuleMatching(new URI("http://host-13/"), null, null).getConfiguration();
+        filtered = ac13.saslMechanismSelector.apply(Arrays.asList("A", "B", "PLAIN", "DIGEST-MD5", "JBOSS-LOCAL-USER"), null).toArray(new String[]{});
+        Assert.assertArrayEquals(new String[]{"A", "B", "JBOSS-LOCAL-USER"}, filtered);
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1216
https://issues.jboss.org/browse/JBEAP-11265