### PR TITLE
[ELY-1186] Do not establish a realm on the server if only the default realm was offered to the client

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
@@ -477,7 +477,7 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         }
     }
 
-    protected byte[] getPredigestedSaltedPassword(RealmCallback realmCallback, NameCallback nameCallback) throws SaslException {
+    protected byte[] getPredigestedSaltedPassword(RealmCallback realmCallback, NameCallback nameCallback, final boolean defaultRealm) throws SaslException {
         final String realmName = realmCallback.getDefaultText();
         final String userName = nameCallback.getDefaultName();
         final DigestPasswordAlgorithmSpec parameterSpec;
@@ -488,7 +488,11 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         }
         CredentialCallback credentialCallback = new CredentialCallback(PasswordCredential.class, passwordAlgorithm(getMechanismName()), parameterSpec);
         try {
-            tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
+            if (defaultRealm) {
+                tryHandleCallbacks(nameCallback, credentialCallback);
+            } else {
+                tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
+            }
             return credentialCallback.applyToCredential(PasswordCredential.class, c -> c.getPassword().castAndApply(DigestPassword.class, DigestPassword::getDigest));
         } catch (UnsupportedCallbackException e) {
             if (e.getCallback() == credentialCallback) {
@@ -501,10 +505,14 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         }
     }
 
-    protected byte[] getSaltedPasswordFromTwoWay(RealmCallback realmCallback, NameCallback nameCallback, boolean readOnlyRealmUsername) throws SaslException {
+    protected byte[] getSaltedPasswordFromTwoWay(RealmCallback realmCallback, NameCallback nameCallback, boolean readOnlyRealmUsername, final boolean defaultRealm) throws SaslException {
         CredentialCallback credentialCallback = new CredentialCallback(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR);
         try {
-            tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
+            if (defaultRealm) {
+                tryHandleCallbacks(nameCallback, credentialCallback);
+            } else {
+                tryHandleCallbacks(realmCallback, nameCallback, credentialCallback);
+            }
         } catch (UnsupportedCallbackException e) {
             if (e.getCallback() == credentialCallback) {
                 return null;
@@ -533,10 +541,14 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
         return digest_urp;
     }
 
-    protected byte[] getSaltedPasswordFromPasswordCallback(RealmCallback realmCallback, NameCallback nameCallback, boolean readOnlyRealmUsername) throws SaslException {
+    protected byte[] getSaltedPasswordFromPasswordCallback(RealmCallback realmCallback, NameCallback nameCallback, boolean readOnlyRealmUsername, final boolean defaultRealm) throws SaslException {
         PasswordCallback passwordCallback = new PasswordCallback("User password", false);
         try {
-            tryHandleCallbacks(realmCallback, nameCallback, passwordCallback);
+            if (defaultRealm) {
+                tryHandleCallbacks(nameCallback, passwordCallback);
+            } else {
+                tryHandleCallbacks(realmCallback, nameCallback, passwordCallback);
+            }
         } catch (UnsupportedCallbackException e) {
             if (e.getCallback() == passwordCallback) {
                 return null;

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
@@ -226,12 +226,12 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         // get password
         RealmCallback realmCallback = realm != null ?
                 new RealmCallback("User realm", realm) : new RealmCallback("User realm");
-        byte[] digest_urp = getPredigestedSaltedPassword(realmCallback, nameCallback);
+        byte[] digest_urp = getPredigestedSaltedPassword(realmCallback, nameCallback, false);
         if (digest_urp == null) {
-            digest_urp = getSaltedPasswordFromTwoWay(realmCallback, nameCallback, false);
+            digest_urp = getSaltedPasswordFromTwoWay(realmCallback, nameCallback, false, false);
         }
         if (digest_urp == null) {
-            digest_urp = getSaltedPasswordFromPasswordCallback(realmCallback, nameCallback, false);
+            digest_urp = getSaltedPasswordFromPasswordCallback(realmCallback, nameCallback, false, false);
         }
         if (digest_urp == null) {
             throw log.mechCallbackHandlerDoesNotSupportCredentialAcquisition(getMechanismName(), null).toSaslException();

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -55,10 +55,12 @@ import org.wildfly.security.util.ByteStringBuilder;
 class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
 
     private final Predicate<String> digestUriAccepted;
+    private final boolean defaultRealm;
 
-    DigestSaslServer(String[] realms, String mechanismName, String protocol, String serverName, CallbackHandler callbackHandler, Charset charset, String[] qops, String[] ciphers, Predicate<String> digestUriAccepted, Supplier<Provider[]> providers) throws SaslException {
+    DigestSaslServer(String[] realms, final boolean defaultRealm, String mechanismName, String protocol, String serverName, CallbackHandler callbackHandler, Charset charset, String[] qops, String[] ciphers, Predicate<String> digestUriAccepted, Supplier<Provider[]> providers) throws SaslException {
         super(mechanismName, protocol, serverName, callbackHandler, FORMAT.SERVER, charset, ciphers, providers);
         this.realms = realms;
+        this.defaultRealm = defaultRealm;
         this.supportedCiphers = getSupportedCiphers(ciphers);
         this.qops = qops;
         this.digestUriAccepted = digestUriAccepted;
@@ -256,12 +258,12 @@ class DigestSaslServer extends AbstractDigestMechanism implements SaslServer {
         // get password
         final NameCallback nameCallback = new NameCallback("User name", userName);
         final RealmCallback realmCallback = new RealmCallback("User realm", clientRealm);
-        byte[] digest_urp = getPredigestedSaltedPassword(realmCallback, nameCallback);
+        byte[] digest_urp = getPredigestedSaltedPassword(realmCallback, nameCallback, defaultRealm);
         if (digest_urp == null) {
-            digest_urp = getSaltedPasswordFromTwoWay(realmCallback, nameCallback, true);
+            digest_urp = getSaltedPasswordFromTwoWay(realmCallback, nameCallback, true, defaultRealm);
         }
         if (digest_urp == null) {
-            digest_urp = getSaltedPasswordFromPasswordCallback(realmCallback, nameCallback, true);
+            digest_urp = getSaltedPasswordFromPasswordCallback(realmCallback, nameCallback, true, defaultRealm);
         }
         if (digest_urp == null) {
             throw log.mechCallbackHandlerDoesNotSupportCredentialAcquisition(getMechanismName(), null).toSaslException();

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestServerFactory.java
@@ -86,8 +86,12 @@ public class DigestServerFactory extends AbstractDigestFactory implements SaslSe
         } catch (IOException e) {
             throw ElytronMessages.log.mechCallbackHandlerFailedForUnknownReason(mechanism, e).toSaslException();
         }
+        final boolean defaultRealm;
         if (realms == null) {
+            defaultRealm = true;
             realms = new String[] { serverName };
+        } else {
+            defaultRealm = false;
         }
 
         Boolean utf8 = (Boolean)props.get(WildFlySasl.USE_UTF8);
@@ -114,7 +118,7 @@ public class DigestServerFactory extends AbstractDigestFactory implements SaslSe
             digestUriTest = digestUriTest.or(acceptableUris::contains);
         }
 
-        final DigestSaslServer server = new DigestSaslServer(realms, mechanism, protocol, serverName, cbh, charset, qops, cipherOpts, digestUriTest, providers);
+        final DigestSaslServer server = new DigestSaslServer(realms, defaultRealm, mechanism, protocol, serverName, cbh, charset, qops, cipherOpts, digestUriTest, providers);
         server.init();
         return server;
     }


### PR DESCRIPTION
The RealmCallback is created but not used on the server if ```defaultRealm``` is ```true``` (it is always ```false``` on the client).  While this is not strictly the most efficient solution, it was the best combination of a minimal and safe change that I could come up with.