### PR TITLE
[ELY-1251] Remove allow-all-sasl-mechanisms, allow-sasl-mechanisms, and forbid-sasl-mechanisms from elytron-1_0.xsd since they have been removed from ElytronXmlParser

### DIFF
--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -107,9 +107,6 @@
             <xsd:element ref="abstract-user-spec"/>
             <xsd:element name="set-mechanism-realm" type="optional-name-type" minOccurs="0"/>
             <xsd:element name="rewrite-user-name-regex" type="regex-substitution-type" minOccurs="0"/>
-            <xsd:element name="allow-all-sasl-mechanisms" type="empty-type" minOccurs="0"/>
-            <xsd:element name="allow-sasl-mechanisms" type="names-list-type" minOccurs="0"/>
-            <xsd:element name="forbid-sasl-mechanisms" type="names-list-type" minOccurs="0"/>
             <xsd:element name="sasl-mechanism-selector" type="selector-type" minOccurs="0"/>
             <xsd:element name="set-mechanism-properties" type="properties-type" minOccurs="0"/>
             <xsd:element name="credentials" type="client-credentials-type" minOccurs="0"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1251
https://issues.jboss.org/browse/JBEAP-11639