### PR TITLE
[ELY-1239] incorrect protection parameter credentials

### DIFF
--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -183,7 +183,7 @@
             <xsd:element name="global" type="empty-type" />
             <xsd:element name="use-service-loader" type="module-ref-type" />
         </xsd:all>
-    </xsd:complexType>   
+    </xsd:complexType>
 
     <xsd:element name="abstract-sasl-factories" abstract="true"/>
     <xsd:element name="use-provider-sasl-factory" substitutionGroup="abstract-sasl-factories" type="empty-type" />
@@ -287,7 +287,7 @@
 
         <xsd:all minOccurs="0" maxOccurs="1">
             <xsd:element name="attributes" type="attributes-type"/>
-            <xsd:element name="protection-parameter-credentials" type="client-credentials-type"/>
+            <xsd:element name="protection-parameter-credentials" type="protection-parameter-credentials-type"/>
             <xsd:element name="providers" type="providers-type" />
         </xsd:all>
 
@@ -310,6 +310,13 @@
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="protection-parameter-credentials-type">
+        <xsd:choice minOccurs="0" maxOccurs="1">
+            <xsd:element name="credential-store-reference" type="credential-store-reference-type"/>
+            <xsd:element name="clear-password" type="clear-password-type"/>
+        </xsd:choice>
     </xsd:complexType>
 
     <!-- File-backed realm elements -->

--- a/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -203,7 +203,7 @@ public class XmlConfigurationTest {
             "    <credential-stores>\n" +
             "        <credential-store name=\"store1\" type=\"" + KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE + "\">\n" +
             "            <protection-parameter-credentials>\n" +
-            "                <clear-password password=\"1234\"/>\n" +
+            "                <credential-store-reference clear-text=\"1234\"/>\n" +
             "            </protection-parameter-credentials>\n" +
             "            <attributes>\n" +
             "                <attribute name=\"keyStoreType\" value=\"JCEKS\"/>\n" +


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-11451
https://issues.jboss.org/browse/ELY-1239

I have retained clear-password element despite it has alternative in credential-store-reference, but there might be already some client configurations using it.