### PR TITLE
ELY-1250: Add SASL protocol configuration in AuthenticationConfiguration and use it for SaslClient configuration

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
@@ -274,6 +274,17 @@ public final class AuthenticationContextConfigurationClient {
     }
 
     /**
+     * Get the actual sasl protocol to use for the given configuration.
+     *
+     * @param configuration the configuration (must not be {@code null})
+     * @return the real port to use
+     */
+    public String getSaslProtocol(AuthenticationConfiguration configuration) {
+        Assert.checkNotNullParam("configuration", configuration);
+        return configuration.getSaslProtocol();
+    }
+
+    /**
      * Get the authentication principal to use for the given configuration.
      *
      * @param configuration the configuration (must not be {@code null})

--- a/src/main/java/org/wildfly/security/sasl/util/SecurityProviderSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SecurityProviderSaslClientFactory.java
@@ -110,7 +110,7 @@ public final class SecurityProviderSaslClientFactory implements SaslClientFactor
                     saslClient = pair.saslClientFactory.createSaslClient(mechArray, authorizationId, protocol, serverName, props, cbh);
                     if (saslClient != null) {
                         if (log.isTraceEnabled()) {
-                            log.tracef("Created SaslClient for mechanism %s, using Provider %s", saslClient.getMechanismName(), pair.provider.getName());
+                            log.tracef("Created SaslClient for mechanism %s, using Provider %s and protocol %s", saslClient.getMechanismName(), pair.provider.getName(), protocol);
                         }
                         return saslClient;
                     }

--- a/src/main/java/org/wildfly/security/sasl/util/SecurityProviderSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SecurityProviderSaslServerFactory.java
@@ -83,6 +83,9 @@ public final class SecurityProviderSaslServerFactory implements SaslServerFactor
                                 saslServer = ((SaslServerFactory) service.newInstance(null)).createSaslServer(mechanism,
                                         protocol, serverName, props, cbh);
                                 if (saslServer != null) {
+                                    if (log.isTraceEnabled()) {
+                                        log.tracef("Created SaslServer for mechanism %s and protocol %s", mechanism, protocol);
+                                    }
                                     return saslServer;
                                 }
                             } catch (NoSuchAlgorithmException | ClassCastException | InvalidParameterException e) {


### PR DESCRIPTION
It was necessary to enable a new property on AuthenticationConfiguration to manage the `remote.connection.node1.connect.options.org.xnio.Options.SASL_PROTOCOL` property. This value now is used to configure the ProtocolSaslClientFactory. 

Jira issues:
https://issues.jboss.org/browse/JBEAP-10996
https://issues.jboss.org/browse/ELY-1250

It depends on https://github.com/jboss-remoting/jboss-remoting/pull/124