### PR TITLE
ELY-1268: Create OTPasswords using an algorithm specification and a pass phrase

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
@@ -687,7 +688,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
                             streamWriter.writeStartElement("otp");
                             streamWriter.writeAttribute("algorithm", otp.getAlgorithm());
                             streamWriter.writeAttribute("hash", ByteIterator.ofBytes(otp.getHash()).base64Encode().drainToString());
-                            streamWriter.writeAttribute("seed", ByteIterator.ofBytes(otp.getSeed()).base64Encode().drainToString());
+                            streamWriter.writeAttribute("seed", ByteIterator.ofBytes(otp.getSeed().getBytes(StandardCharsets.US_ASCII)).base64Encode().drainToString());
                             streamWriter.writeAttribute("sequence", Integer.toString(otp.getSequenceNumber()));
                             streamWriter.writeEndElement();
                         } else {
@@ -948,7 +949,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             String name = null;
             String algorithm = null;
             byte[] hash = null;
-            byte[] seed = null;
+            String seed = null;
             int sequenceNumber = 0;
 
             final int attributeCount = streamReader.getAttributeCount();
@@ -963,9 +964,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
                 } else if ("algorithm".equals(localName)) {
                     algorithm = streamReader.getAttributeValue(i);
                 } else if ("hash".equals(localName)) {
-                    hash = CodePointIterator.ofString(streamReader.getAttributeValue(i)).base64Decode().drain();
+                    hash = CodePointIterator.ofString(streamReader.getAttributeValue(i)).base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain();
                 } else if ("seed".equals(localName)) {
-                    seed = CodePointIterator.ofString(streamReader.getAttributeValue(i)).base64Decode().drain();
+                    seed = new String(CodePointIterator.ofString(streamReader.getAttributeValue(i)).base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(), StandardCharsets.US_ASCII);
                 } else if ("sequence".equals(localName)) {
                     sequenceNumber = Integer.parseInt(streamReader.getAttributeValue(i));
                 } else {

--- a/src/main/java/org/wildfly/security/auth/realm/ldap/OtpCredentialLoader.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/OtpCredentialLoader.java
@@ -21,6 +21,7 @@ import javax.naming.directory.BasicAttributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.NoSuchAttributeException;
 
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.spec.AlgorithmParameterSpec;
@@ -128,8 +129,8 @@ class OtpCredentialLoader implements CredentialPersister {
                 Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(
                                 CodePointIterator.ofString((String) hashAttribute.get())
                                         .base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(),
-                                CodePointIterator.ofString((String) seedAttribute.get())
-                                        .base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(),
+                                new String (CodePointIterator.ofString((String) seedAttribute.get())
+                                        .base64Decode(Alphabet.Base64Alphabet.STANDARD, false).drain(), StandardCharsets.US_ASCII),
                                 Integer.parseInt((String) sequenceAttribute.get())));
                 if (credentialType.isAssignableFrom(PasswordCredential.class)) {
                     return credentialType.cast(new PasswordCredential(password));
@@ -154,7 +155,7 @@ class OtpCredentialLoader implements CredentialPersister {
                 Attributes attributes = new BasicAttributes();
                 attributes.put(algorithmAttributeName, password.getAlgorithm());
                 attributes.put(hashAttributeName, ByteIterator.ofBytes(password.getHash()).base64Encode().drainToString());
-                attributes.put(seedAttributeName, ByteIterator.ofBytes(password.getSeed()).base64Encode().drainToString());
+                attributes.put(seedAttributeName, ByteIterator.ofBytes(password.getSeed().getBytes(StandardCharsets.US_ASCII)).base64Encode().drainToString());
                 attributes.put(sequenceAttributeName, Integer.toString(password.getSequenceNumber()));
 
                 context.modifyAttributes(distinguishedName, DirContext.REPLACE_ATTRIBUTE, attributes);

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -319,7 +319,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                         final OneTimePasswordSpec passwordSpec = passwordFactory.getKeySpec(passwordFactory.translate(password), OneTimePasswordSpec.class);
                         encoder.startSequence();
                         encoder.encodeOctetString(passwordSpec.getHash());
-                        encoder.encodeOctetString(passwordSpec.getSeed());
+                        encoder.encodeIA5String(passwordSpec.getSeed());
                         encoder.encodeInteger(passwordSpec.getSequenceNumber());
                         encoder.endSequence();
                         break;
@@ -605,7 +605,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     case OneTimePassword.ALGORITHM_OTP_SHA1: {
                         decoder.startSequence();
                         final byte[] hash = decoder.decodeOctetString();
-                        final byte[] seed = decoder.decodeOctetString();
+                        final String seed = decoder.decodeIA5String();
                         final int sequenceNumber = decoder.decodeInteger().intValue();
                         decoder.endSequence();
                         passwordSpec = new OneTimePasswordSpec(hash, seed, sequenceNumber);

--- a/src/main/java/org/wildfly/security/password/impl/OneTimePasswordAlgorithmParametersSpiImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/OneTimePasswordAlgorithmParametersSpiImpl.java
@@ -46,7 +46,7 @@ public final class OneTimePasswordAlgorithmParametersSpiImpl extends AbstractAlg
     protected void engineEncode(final ASN1Encoder encoder, final OneTimePasswordAlgorithmSpec parameterSpec) {
         encoder.startSequence();
         encoder.encodeOctetString(parameterSpec.getAlgorithm());
-        encoder.encodeOctetString(parameterSpec.getSeed());
+        encoder.encodeIA5String(parameterSpec.getSeed());
         encoder.encodeInteger(parameterSpec.getSequenceNumber());
         encoder.endSequence();
     }
@@ -54,7 +54,7 @@ public final class OneTimePasswordAlgorithmParametersSpiImpl extends AbstractAlg
     protected OneTimePasswordAlgorithmSpec engineDecode(final ASN1Decoder decoder) {
         decoder.startSequence();
         final String algorithm = decoder.decodeOctetStringAsString();
-        final byte[] seed = decoder.decodeOctetString();
+        final String seed = decoder.decodeIA5String();
         final int sequenceNumber = decoder.decodeInteger().intValue();
         decoder.endSequence();
         return new OneTimePasswordAlgorithmSpec(algorithm, seed, sequenceNumber);

--- a/src/main/java/org/wildfly/security/password/impl/OneTimePasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/OneTimePasswordImpl.java
@@ -19,16 +19,26 @@
 package org.wildfly.security.password.impl;
 
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
+import static org.wildfly.security._private.ElytronMessages.log;
+import static org.wildfly.security.sasl.otp.OTP.MD5;
+import static org.wildfly.security.sasl.otp.OTP.SHA1;
 
 import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
+import java.util.Locale;
 
 import org.wildfly.security.password.interfaces.OneTimePassword;
+import org.wildfly.security.password.spec.OneTimePasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
+import org.wildfly.security.util.ByteStringBuilder;
+
+import javax.security.sasl.SaslException;
 
 /**
  * A {@code Password} implementation for {@link OneTimePassword}.
@@ -41,10 +51,10 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
 
     private final String algorithm;
     private final byte[] hash;
-    private final byte[] seed;
+    private final String seed;
     private final int sequenceNumber;
 
-    OneTimePasswordImpl(final String algorithm, final byte[] hash, final byte[] seed, final int sequenceNumber) {
+    OneTimePasswordImpl(final String algorithm, final byte[] hash, final String seed, final int sequenceNumber) {
         this.algorithm = algorithm;
         this.hash = hash;
         this.seed = seed;
@@ -52,11 +62,22 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
     }
 
     OneTimePasswordImpl(final OneTimePassword password) {
-        this(password.getAlgorithm(), password.getHash().clone(), password.getSeed().clone(), password.getSequenceNumber());
+        this(password.getAlgorithm(), password.getHash().clone(), password.getSeed(), password.getSequenceNumber());
     }
 
     OneTimePasswordImpl(final String algorithm, final OneTimePasswordSpec spec) {
-        this(algorithm, spec.getHash().clone(), spec.getSeed().clone(), spec.getSequenceNumber());
+        this(algorithm, spec.getHash().clone(), spec.getSeed(), spec.getSequenceNumber());
+    }
+
+    OneTimePasswordImpl(final String algorithm, final char[] password, final OneTimePasswordAlgorithmSpec spec) throws SaslException {
+        this(algorithm,
+                generateOTP(algorithm,
+                        getNormalizedPasswordBytes(password),
+                        spec.getSeed().toLowerCase(Locale.ENGLISH),
+                        spec.getSequenceNumber()
+                ),
+                spec.getSeed(),
+                spec.getSequenceNumber());
     }
 
     @Override
@@ -70,8 +91,8 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
     }
 
     @Override
-    public byte[] getSeed() {
-        return seed.clone();
+    public String getSeed() {
+        return seed;
     }
 
     @Override
@@ -82,7 +103,7 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
     @Override
     <S extends KeySpec> S getKeySpec(Class<S> keySpecType) throws InvalidKeySpecException {
         if (keySpecType.isAssignableFrom(OneTimePasswordSpec.class)) {
-            return keySpecType.cast(new OneTimePasswordSpec(hash.clone(), seed.clone(), sequenceNumber));
+            return keySpecType.cast(new OneTimePasswordSpec(hash.clone(), seed, sequenceNumber));
         }
         throw new InvalidKeySpecException();
     }
@@ -93,13 +114,92 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
         throw new InvalidKeyException();
     }
 
+    /**
+     * Generate a 64-bit OTP as specified in <a href="https://tools.ietf.org/html/rfc2289">RFC 2289</a>.
+     *
+     * @param algorithm the OTP algorithm, must be either "otp-md5" or "otp-sha1"
+     * @param passPhrase the pass phrase, as a byte array
+     * @param seed the seed
+     * @param sequenceNumber the number of times the hash function will be applied
+     * @return the 64-bit OTP hash
+     * @throws SaslException if the given OTP algorithm is invalid
+     */
+    private static byte[] generateOTP(String algorithm, byte[] passPhrase, String seed, int sequenceNumber) throws SaslException {
+        final MessageDigest messageDigest;
+        try {
+            messageDigest = getMessageDigest(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw log.mechInvalidOTPAlgorithm(algorithm).toSaslException();
+        }
+
+        // Initial step
+        final ByteStringBuilder seedAndPassPhrase = new ByteStringBuilder();
+        seedAndPassPhrase.append(seed);
+        seedAndPassPhrase.append(passPhrase);
+        byte[] hash = hashAndFold(algorithm, messageDigest, seedAndPassPhrase.toArray());
+
+        // Computation step
+        for (int i = 0; i < sequenceNumber; i++) {
+            messageDigest.reset();
+            hash = hashAndFold(algorithm, messageDigest, hash);
+        }
+        return hash;
+    }
+
+    private static MessageDigest getMessageDigest(String algorithm) throws NoSuchAlgorithmException {
+        switch (algorithm) {
+            case ALGORITHM_OTP_MD5:
+                return MessageDigest.getInstance(MD5);
+            case ALGORITHM_OTP_SHA1:
+                return MessageDigest.getInstance(SHA1);
+            default:
+                throw new NoSuchAlgorithmException();
+        }
+    }
+
+    /**
+     * Pass the given input through a hash function and fold the result to 64 bits.
+     *
+     * @param algorithm the OTP algorithm, must be either "otp-md5" or "otp-sha1"
+     * @param messageDigest the {@code MessageDigest} to use when generating the hash
+     * @param input the data to hash
+     * @return the folded hash
+     */
+    private static byte[] hashAndFold(String algorithm, MessageDigest messageDigest, byte[] input) {
+        messageDigest.update(input);
+        byte[] result = messageDigest.digest();
+        byte[] hash = new byte[OTP_HASH_SIZE];
+
+        // Fold the result (either 128 bits for MD5 or 160 bits for SHA-1) to 64 bits
+        for (int i = OTP_HASH_SIZE; i < result.length; i++) {
+            result[i % OTP_HASH_SIZE] ^= result[i];
+        }
+        System.arraycopy(result, 0, hash, 0, OTP_HASH_SIZE);
+
+        if (algorithm.equals(ALGORITHM_OTP_SHA1)) {
+            reverse(hash, 0, 4);
+            reverse(hash, 4, 4);
+        }
+        return hash;
+    }
+
+    private static void reverse(byte[] bytes, int offset, int length) {
+        byte tmp;
+        int mid = (length / 2) + offset;
+        for (int i = offset, j = offset + length - 1; i < mid; i++, j--) {
+            tmp = bytes[i];
+            bytes[i] = bytes[j];
+            bytes[j] = tmp;
+        }
+    }
+
     @Override
     <T extends KeySpec> boolean convertibleTo(Class<T> keySpecType) {
         return keySpecType.isAssignableFrom(OneTimePasswordSpec.class);
     }
 
     public int hashCode() {
-        return multiHashOrdered(multiHashOrdered(multiHashOrdered(Arrays.hashCode(hash), Arrays.hashCode(seed)), sequenceNumber), algorithm.hashCode());
+        return multiHashOrdered(multiHashOrdered(multiHashOrdered(Arrays.hashCode(hash),seed.hashCode()), sequenceNumber), algorithm.hashCode());
     }
 
     public boolean equals(final Object obj) {
@@ -107,7 +207,7 @@ class OneTimePasswordImpl extends AbstractPasswordImpl implements OneTimePasswor
             return false;
         }
         OneTimePasswordImpl other = (OneTimePasswordImpl) obj;
-        return sequenceNumber == other.sequenceNumber && algorithm.equals(other.algorithm) && Arrays.equals(hash, other.hash) && Arrays.equals(seed, other.seed);
+        return sequenceNumber == other.sequenceNumber && algorithm.equals(other.algorithm) && Arrays.equals(hash, other.hash) && seed.equals(other.seed);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/interfaces/OneTimePassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/OneTimePassword.java
@@ -60,7 +60,7 @@ public interface OneTimePassword extends OneWayPassword {
      *
      * @return the seed used to generate the hash
      */
-    byte[] getSeed();
+    String getSeed();
 
     /**
      * Get the sequence number used to generate the hash.
@@ -96,10 +96,10 @@ public interface OneTimePassword extends OneWayPassword {
      * @param sequenceNumber the sequence number
      * @return the raw password implementation
      */
-    static OneTimePassword createRaw(String algorithm, byte[] hash, byte[] seed, int sequenceNumber) {
+    static OneTimePassword createRaw(String algorithm, byte[] hash, String seed, int sequenceNumber) {
         Assert.checkNotNullParam("hash", hash);
         Assert.checkNotNullParam("seed", seed);
         Assert.checkNotNullParam("algorithm", algorithm);
-        return new RawOneTimePassword(algorithm, hash.clone(), seed.clone(), sequenceNumber);
+        return new RawOneTimePassword(algorithm, hash.clone(), seed, sequenceNumber);
     }
 }

--- a/src/main/java/org/wildfly/security/password/interfaces/RawOneTimePassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/RawOneTimePassword.java
@@ -27,10 +27,10 @@ class RawOneTimePassword extends RawPassword implements OneTimePassword {
     private static final long serialVersionUID = -5742928998692812041L;
 
     private final byte[] hash;
-    private final byte[] seed;
+    private final String seed;
     private final int sequenceNumber;
 
-    RawOneTimePassword(final String algorithm, final byte[] hash, final byte[] seed, final int sequenceNumber) {
+    RawOneTimePassword(final String algorithm, final byte[] hash, final String seed, final int sequenceNumber) {
         super(algorithm);
         this.hash = hash;
         this.seed = seed;
@@ -41,8 +41,8 @@ class RawOneTimePassword extends RawPassword implements OneTimePassword {
         return hash.clone();
     }
 
-    public byte[] getSeed() {
-        return seed.clone();
+    public String getSeed() {
+        return seed;
     }
 
     public int getSequenceNumber() {
@@ -54,7 +54,7 @@ class RawOneTimePassword extends RawPassword implements OneTimePassword {
     }
 
     public int hashCode() {
-        return multiHashOrdered(multiHashOrdered(multiHashOrdered(Arrays.hashCode(hash), Arrays.hashCode(seed)), sequenceNumber), getAlgorithm().hashCode());
+        return multiHashOrdered(multiHashOrdered(multiHashOrdered(Arrays.hashCode(hash), seed.hashCode()), sequenceNumber), getAlgorithm().hashCode());
     }
 
     public boolean equals(final Object obj) {
@@ -62,6 +62,6 @@ class RawOneTimePassword extends RawPassword implements OneTimePassword {
             return false;
         }
         RawOneTimePassword other = (RawOneTimePassword) obj;
-        return sequenceNumber == other.sequenceNumber && getAlgorithm().equals(other.getAlgorithm()) && Arrays.equals(hash, other.hash) && Arrays.equals(seed, other.seed);
+        return sequenceNumber == other.sequenceNumber && getAlgorithm().equals(other.getAlgorithm()) && Arrays.equals(hash, other.hash) && seed.equals(other.seed);
     }
 }

--- a/src/main/java/org/wildfly/security/password/spec/OneTimePasswordAlgorithmSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/OneTimePasswordAlgorithmSpec.java
@@ -20,7 +20,6 @@ package org.wildfly.security.password.spec;
 
 import java.io.Serializable;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 import java.util.Objects;
 
 import org.wildfly.common.Assert;
@@ -35,10 +34,10 @@ public final class OneTimePasswordAlgorithmSpec implements AlgorithmParameterSpe
     private static final long serialVersionUID = 2703192508293746122L;
 
     private final String algorithm;
-    private final byte[] seed;
+    private final String seed;
     private final int sequenceNumber;
 
-    public OneTimePasswordAlgorithmSpec(final String algorithm, final byte[] seed, final int sequenceNumber) {
+    public OneTimePasswordAlgorithmSpec(final String algorithm, final String seed, final int sequenceNumber) {
         Assert.checkNotNullParam("algorithm", algorithm);
         Assert.checkNotNullParam("seed", seed);
         this.algorithm = algorithm;
@@ -50,7 +49,7 @@ public final class OneTimePasswordAlgorithmSpec implements AlgorithmParameterSpe
         return algorithm;
     }
 
-    public byte[] getSeed() {
+    public String getSeed() {
         return seed;
     }
 
@@ -62,10 +61,10 @@ public final class OneTimePasswordAlgorithmSpec implements AlgorithmParameterSpe
         if (! (other instanceof OneTimePasswordAlgorithmSpec)) return false;
         if (this == other) return true;
         OneTimePasswordAlgorithmSpec otherSpec = (OneTimePasswordAlgorithmSpec) other;
-        return sequenceNumber == otherSpec.sequenceNumber && Objects.equals(algorithm, otherSpec.algorithm) && Arrays.equals(seed, otherSpec.seed);
+        return sequenceNumber == otherSpec.sequenceNumber && Objects.equals(algorithm, otherSpec.algorithm) && Objects.equals(seed, otherSpec.seed);
     }
 
     public int hashCode() {
-        return (sequenceNumber * 31 + Arrays.hashCode(seed)) * 31 + algorithm.hashCode();
+        return (sequenceNumber * 31 + seed.hashCode()) * 31 + algorithm.hashCode();
     }
 }

--- a/src/main/java/org/wildfly/security/password/spec/OneTimePasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/OneTimePasswordSpec.java
@@ -27,10 +27,10 @@ import org.wildfly.common.Assert;
 public final class OneTimePasswordSpec implements PasswordSpec {
 
     private final byte[] hash;
-    private final byte[] seed;
+    private final String seed;
     private final int sequenceNumber;
 
-    public OneTimePasswordSpec(final byte[] hash, final byte[] seed, final int sequenceNumber) {
+    public OneTimePasswordSpec(final byte[] hash, final String seed, final int sequenceNumber) {
         Assert.checkNotNullParam("hash", hash);
         Assert.checkNotNullParam("seed", seed);
         this.hash = hash;
@@ -42,7 +42,7 @@ public final class OneTimePasswordSpec implements PasswordSpec {
         return hash;
     }
 
-    public byte[] getSeed() {
+    public String getSeed() {
         return seed;
     }
 

--- a/src/main/java/org/wildfly/security/sasl/otp/OTP.java
+++ b/src/main/java/org/wildfly/security/sasl/otp/OTP.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.security.sasl.otp;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -117,7 +116,7 @@ public final class OTP {
      * @return the parameter specification for a one-time password generated using the given algorithm, seed, and sequence number
      */
     public static OneTimePasswordAlgorithmSpec getOTPParameterSpec(final String algorithm, final String seed, final int sequenceNumber) {
-        return new OneTimePasswordAlgorithmSpec(algorithm, seed.getBytes(StandardCharsets.US_ASCII), sequenceNumber);
+        return new OneTimePasswordAlgorithmSpec(algorithm, seed, sequenceNumber);
     }
 
     static boolean isMatched(final Map<String, ?> props, final boolean query) {

--- a/src/main/java/org/wildfly/security/sasl/otp/OTPSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/otp/OTPSaslServer.java
@@ -35,7 +35,6 @@ import static org.wildfly.security.sasl.otp.OTPUtil.validateSeed;
 import static org.wildfly.security.sasl.otp.OTPUtil.validateSequenceNumber;
 import static org.wildfly.security.sasl.otp.OTPUtil.validateUserName;
 
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.spec.InvalidKeySpecException;
@@ -126,7 +125,7 @@ final class OTPSaslServer extends AbstractSaslServer {
                 }
                 previousAlgorithm = previousPassword.getAlgorithm();
                 validateAlgorithm(previousAlgorithm);
-                previousSeed = new String(previousPassword.getSeed(), StandardCharsets.US_ASCII);
+                previousSeed = previousPassword.getSeed();
                 validateSeed(previousSeed);
                 previousSequenceNumber = previousPassword.getSequenceNumber();
                 validateSequenceNumber(previousSequenceNumber);
@@ -159,7 +158,7 @@ final class OTPSaslServer extends AbstractSaslServer {
                         } else {
                             currentHash = convertFromWords(di.drainToString(), previousAlgorithm);
                         }
-                        passwordSpec = new OneTimePasswordSpec(currentHash, previousSeed.getBytes(StandardCharsets.US_ASCII), previousSequenceNumber - 1);
+                        passwordSpec = new OneTimePasswordSpec(currentHash, previousSeed, previousSequenceNumber - 1);
                         algorithm = previousAlgorithm;
                         break;
                     }
@@ -189,12 +188,12 @@ final class OTPSaslServer extends AbstractSaslServer {
                             } else {
                                 newHash = convertFromWords(di.drainToString(), newAlgorithm);
                             }
-                            passwordSpec = new OneTimePasswordSpec(newHash, newSeed.getBytes(StandardCharsets.US_ASCII), newSequenceNumber);
+                            passwordSpec = new OneTimePasswordSpec(newHash, newSeed, newSequenceNumber);
                             algorithm = newAlgorithm;
                         } catch (SaslException e) {
                             // If the new params or new OTP could not be processed for any reason, the sequence
                             // number should be decremented if a valid current OTP is provided
-                            passwordSpec = new OneTimePasswordSpec(currentHash, previousSeed.getBytes(StandardCharsets.US_ASCII), previousSequenceNumber - 1);
+                            passwordSpec = new OneTimePasswordSpec(currentHash, previousSeed, previousSequenceNumber - 1);
                             algorithm = previousAlgorithm;
                             verifyAndUpdateCredential(currentHash, algorithm, passwordSpec);
                             throw log.mechOTPReinitializationFailed(e).toSaslException();

--- a/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
+++ b/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
@@ -33,7 +33,6 @@ import javax.security.sasl.SaslException;
 
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.util.ByteIterator;
-import org.wildfly.security.util.ByteStringBuilder;
 import org.wildfly.security.util.CodePointIterator;
 
 /**
@@ -58,52 +57,6 @@ class OTPUtil {
         }
         assert i == dict.length;
         randomCharDictionary = dict;
-    }
-
-    /**
-     * Generate a 64-bit OTP as specified in <a href="https://tools.ietf.org/html/rfc2289">RFC 2289</a>.
-     *
-     * @param algorithm the OTP algorithm, must be either "otp-md5" or "otp-sha1"
-     * @param passPhrase the pass phrase, as a byte array
-     * @param seed the seed, as a byte array
-     * @param sequenceNumber the number of times the hash function will be applied
-     * @return the 64-bit OTP hash
-     * @throws SaslException if the given OTP algorithm is invalid
-     */
-    public static byte[] generateOTP(String algorithm, byte[] passPhrase, byte[] seed, int sequenceNumber) throws SaslException {
-        final MessageDigest messageDigest;
-        try {
-            messageDigest = getMessageDigest(algorithm);
-        } catch (NoSuchAlgorithmException e) {
-            throw log.mechInvalidOTPAlgorithm(algorithm).toSaslException();
-        }
-
-        // Initial step
-        final ByteStringBuilder seedAndPassPhrase = new ByteStringBuilder();
-        seedAndPassPhrase.append(seed);
-        seedAndPassPhrase.append(passPhrase);
-        byte[] hash = hashAndFold(algorithm, messageDigest, seedAndPassPhrase.toArray());
-
-        // Computation step
-        for (int i = 0; i < sequenceNumber; i++) {
-            messageDigest.reset();
-            hash = hashAndFold(algorithm, messageDigest, hash);
-        }
-        return hash;
-    }
-
-    /**
-     * Generate a 64-bit OTP as specified in <a href="https://tools.ietf.org/html/rfc2289">RFC 2289</a>.
-     *
-     * @param algorithm the OTP algorithm, must be either "otp-md5" or "otp-sha1"
-     * @param passPhrase the pass phrase
-     * @param seed the seed
-     * @param sequenceNumber the number of times the hash function will be applied
-     * @return the 64-bit OTP hash
-     * @throws SaslException if the given OTP algorithm is invalid
-     */
-    public static byte[] generateOTP(String algorithm, String passPhrase, String seed, int sequenceNumber) throws SaslException {
-        return generateOTP(algorithm, passPhrase.getBytes(StandardCharsets.UTF_8), seed.toLowerCase(Locale.ENGLISH).getBytes(StandardCharsets.US_ASCII), sequenceNumber);
     }
 
     /**

--- a/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/FileSystemSecurityRealmTest.java
@@ -52,7 +52,6 @@ import org.wildfly.security.util.CodePointIterator;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -300,7 +299,7 @@ public class FileSystemSecurityRealmTest {
         credentials.add(new PasswordCredential(bCryptPassword));
 
         byte[] hash = CodePointIterator.ofString("505d889f90085847").hexDecode().drain();
-        byte[] seed = "ke1234".getBytes(StandardCharsets.US_ASCII);
+        String seed = "ke1234";
         PasswordFactory otpFactory = PasswordFactory.getInstance(OneTimePassword.ALGORITHM_OTP_SHA1);
         OneTimePassword otpPassword = (OneTimePassword) otpFactory.generatePassword(
                 new OneTimePasswordSpec(hash, seed, 500)
@@ -319,7 +318,7 @@ public class FileSystemSecurityRealmTest {
         assertNotNull(otp);
         assertEquals(OneTimePassword.ALGORITHM_OTP_SHA1, otp.getAlgorithm());
         assertArrayEquals(hash, otp.getHash());
-        assertArrayEquals(seed, otp.getSeed());
+        assertEquals(seed, otp.getSeed());
         assertEquals(500, otp.getSequenceNumber());
 
         AuthorizationIdentity authorizationIdentity = existingIdentity.getAuthorizationIdentity();
@@ -347,7 +346,7 @@ public class FileSystemSecurityRealmTest {
         credentials.add(new PasswordCredential(bCryptPassword));
 
         byte[] hash = CodePointIterator.ofString("505d889f90085847").hexDecode().drain();
-        byte[] seed = "ke1234".getBytes(StandardCharsets.US_ASCII);
+        String seed = "ke1234";
         PasswordFactory otpFactory = PasswordFactory.getInstance(OneTimePassword.ALGORITHM_OTP_SHA1);
         OneTimePassword otpPassword = (OneTimePassword) otpFactory.generatePassword(
                 new OneTimePasswordSpec(hash, seed, 500)

--- a/src/test/java/org/wildfly/security/ldap/PasswordSupportSuiteChild.java
+++ b/src/test/java/org/wildfly/security/ldap/PasswordSupportSuiteChild.java
@@ -138,12 +138,12 @@ public class PasswordSupportSuiteChild {
         assertNotNull(otp);
         assertEquals(1234, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'a', 'b', 'c', 'd' }, otp.getHash());
-        Assert.assertArrayEquals(new byte[] { 'e', 'f', 'g', 'h' }, otp.getSeed());
+        Assert.assertEquals("efgh", otp.getSeed());
     }
 
     @Test
     public void testOneTimePasswordUser1Update() throws Exception {
-        OneTimePasswordSpec spec = new OneTimePasswordSpec(new byte[] { 'i', 'j', 'k' }, new byte[] { 'l', 'm', 'n' }, 4321);
+        OneTimePasswordSpec spec = new OneTimePasswordSpec(new byte[] { 'i', 'j', 'k' }, "lmn", 4321);
         final PasswordFactory passwordFactory = PasswordFactory.getInstance("otp-sha1");
         final OneTimePassword password = (OneTimePassword) passwordFactory.generatePassword(spec);
         assertNotNull(password);
@@ -165,12 +165,12 @@ public class PasswordSupportSuiteChild {
         assertNotNull(otp);
         assertEquals(4321, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'i', 'j', 'k' }, otp.getHash());
-        Assert.assertArrayEquals(new byte[] { 'l', 'm', 'n' }, otp.getSeed());
+        Assert.assertEquals("lmn", otp.getSeed());
     }
 
     @Test
     public void testOneTimePasswordUser2SetCredentials() throws Exception {
-        OneTimePasswordSpec spec = new OneTimePasswordSpec(new byte[] { 'o', 'p', 'q' }, new byte[] { 'r', 's', 't' }, 65);
+        OneTimePasswordSpec spec = new OneTimePasswordSpec(new byte[] { 'o', 'p', 'q' }, "rst", 65);
         final PasswordFactory passwordFactory = PasswordFactory.getInstance("otp-sha1");
         final OneTimePassword password = (OneTimePassword) passwordFactory.generatePassword(spec);
         assertNotNull(password);
@@ -192,7 +192,7 @@ public class PasswordSupportSuiteChild {
         assertNotNull(otp);
         assertEquals(65, otp.getSequenceNumber());
         Assert.assertArrayEquals(new byte[] { 'o', 'p', 'q' }, otp.getHash());
-        Assert.assertArrayEquals(new byte[] { 'r', 's', 't' }, otp.getSeed());
+        Assert.assertEquals("rst", otp.getSeed());
     }
 
     @Test

--- a/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
+++ b/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
@@ -78,6 +78,8 @@ import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.OneTimePassword;
+import org.wildfly.security.password.spec.EncryptablePasswordSpec;
+import org.wildfly.security.password.spec.OneTimePasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
 import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
@@ -119,9 +121,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
 
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
@@ -170,9 +172,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("103029b112deb117").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 100));
+                "TeSt", 100));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("87fec7768b73ccf9").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 99));
+                "TeSt", 99));
 
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
@@ -221,9 +223,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -271,9 +273,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("103029b112deb117").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 100));
+                "TeSt", 100));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("87fec7768b73ccf9").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 99));
+                "TeSt", 99));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -322,9 +324,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("3712dcb4aa5316c1").hexDecode().drain(),
-                "ke1235".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1235", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -373,9 +375,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("3712dcb4aa5316c1").hexDecode().drain(),
-                "ke1235".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1235", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -425,9 +427,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("eb65a876fd5e5e8e").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 10)); // Low sequence number, the sequence should be reset
+                "ke1234", 10)); // Low sequence number, the sequence should be reset
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("870c2dcc4fd6b474").hexDecode().drain(),
-                "lr4321".getBytes(StandardCharsets.US_ASCII), 499));
+                "lr4321", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -472,9 +474,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -521,9 +523,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -569,9 +571,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
 
@@ -646,7 +648,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -692,7 +694,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -729,9 +731,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("5bf075d9959d036f").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 499));
+                "ke1234", 499));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -770,7 +772,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 500));
+                "ke1234", 500));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -805,7 +807,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "thisSeedIsTooLong".getBytes(StandardCharsets.US_ASCII), 500));
+                "thisSeedIsTooLong", 500));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -840,7 +842,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "A seed!".getBytes(StandardCharsets.US_ASCII), 500));
+                "A seed!", 500));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -875,7 +877,7 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("505d889f90085847").hexDecode().drain(),
-                "ke1234".getBytes(StandardCharsets.US_ASCII), 0));
+                "ke1234", 0));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -902,6 +904,21 @@ public class OTPTest extends BaseTestCase {
     }
 
     @Test
+    public void testGeneratePasswordFromPassPhrase() throws Exception {
+        final String algorithm = ALGORITHM_OTP_SHA1;
+
+        PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
+        final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("103029b112deb117").hexDecode().drain(),
+                "TeSt", 100));
+
+        OneTimePasswordAlgorithmSpec otpSpec = new OneTimePasswordAlgorithmSpec(algorithm, "TeSt", 100);
+        EncryptablePasswordSpec passwordSpec = new EncryptablePasswordSpec("This is a test.".toCharArray(), otpSpec);
+        OneTimePassword generatedOTPassword = (OneTimePassword) passwordFactory.generatePassword(passwordSpec);
+
+        assertTrue(password.equals(generatedOTPassword));
+    }
+
+    @Test
     public void testUnauthorizedAuthorizationId() throws Exception {
         final String algorithm = ALGORITHM_OTP_SHA1;
         final SaslClientFactory clientFactory = obtainSaslClientFactory(OTPSaslClientFactory.class);
@@ -909,9 +926,9 @@ public class OTPTest extends BaseTestCase {
 
         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
         final Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("103029b112deb117").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 100));
+                "TeSt", 100));
         OneTimePassword expectedUpdatedPassword = (OneTimePassword) passwordFactory.generatePassword(new OneTimePasswordSpec(CodePointIterator.ofString("87fec7768b73ccf9").hexDecode().drain(),
-                "TeSt".getBytes(StandardCharsets.US_ASCII), 99));
+                "TeSt", 99));
         final SaslServerBuilder.BuilderReference<SecurityDomain> securityDomainReference = new SaslServerBuilder.BuilderReference<>();
         final SaslServerBuilder.BuilderReference<Closeable> closeableReference = new SaslServerBuilder.BuilderReference<>();
         try {
@@ -967,7 +984,7 @@ public class OTPTest extends BaseTestCase {
 
         assertEquals(expectedUpdatedPassword.getAlgorithm(), updatedPassword.getAlgorithm());
         assertArrayEquals(expectedUpdatedPassword.getHash(), updatedPassword.getHash());
-        assertArrayEquals(expectedUpdatedPassword.getSeed(), updatedPassword.getSeed());
+        assertEquals(expectedUpdatedPassword.getSeed(), updatedPassword.getSeed());
         assertEquals(expectedUpdatedPassword.getSequenceNumber(), updatedPassword.getSequenceNumber());
         realmIdentity.dispose();
     }

--- a/src/test/java/org/wildfly/security/util/AbstractAlgorithmParametersSpiImplTest.java
+++ b/src/test/java/org/wildfly/security/util/AbstractAlgorithmParametersSpiImplTest.java
@@ -19,15 +19,15 @@
 package org.wildfly.security.util;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.junit.Test;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.password.spec.OneTimePasswordAlgorithmSpec;
-import org.wildfly.security.password.util.PasswordUtil;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class AbstractAlgorithmParametersSpiImplTest {
@@ -35,7 +35,7 @@ public class AbstractAlgorithmParametersSpiImplTest {
     @Test
     public void shouldRoundTripParameterSpecs() throws GeneralSecurityException, IOException {
         final OneTimePasswordAlgorithmSpec start = new OneTimePasswordAlgorithmSpec("otp-sha1",
-                PasswordUtil.generateRandomSalt(16), 14);
+                generateRandomOTPSeed(16), 14);
 
         final AlgorithmParameters oneWay = AlgorithmParameters.getInstance("otp-sha1", new WildFlyElytronProvider());
         oneWay.init(start);
@@ -49,7 +49,27 @@ public class AbstractAlgorithmParametersSpiImplTest {
         final OneTimePasswordAlgorithmSpec end = orAnother.getParameterSpec(OneTimePasswordAlgorithmSpec.class);
 
         assertEquals(start.getAlgorithm(), end.getAlgorithm());
-        assertArrayEquals(start.getSeed(), end.getSeed());
+        assertEquals(start.getSeed(), end.getSeed());
         assertEquals(start.getSequenceNumber(), end.getSequenceNumber());
+    }
+
+    /**
+     * This method generates a valid random seed using only valid characters
+     * from ISO-646 Invariant Code.
+     *
+     * @param saltSize number of bytes to be generated
+     *
+     * @return The seed
+     */
+    private String generateRandomOTPSeed(int saltSize){
+        byte[] salt = new byte[saltSize];
+        for (int i = 0, len = salt.length; i < len; )
+            for (int rnd = ThreadLocalRandom.current().nextInt(0, 128),
+                 n = Math.min(len - i, Integer.SIZE/Byte.SIZE);
+                 n-- > 0; rnd >>= Byte.SIZE) {
+                salt[i++] = (byte)rnd;
+            }
+
+        return new String(salt, StandardCharsets.US_ASCII);
     }
 }


### PR DESCRIPTION
We need to be able to calculate OTP hash value from WFCORE. There is an existing class doing it `org.wildfly.security.sasl.otp.OTPUtil` but it has default class visibility. Instead of change the visibility of that class, I have added the method to `org.wildfly.security.sasl.otp.OTP`, which is already public, reducing the cohesion between them. I think it is better with this change but .. any feedback would be great.

Jira issues:
https://issues.jboss.org/browse/ELY-1268
https://issues.jboss.org/browse/JBEAP-10532

It depends on https://github.com/wildfly/wildfly-core/pull/2590