### PR TITLE
[ELY-1271] unusable SecurityDomain for SSLContext handling

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -932,6 +932,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 4026, value = "Could not create trust manager [%s]")
     IllegalStateException sslErrorCreatingTrustManager(String name, @Cause Throwable cause);
 
+    @Message(id = 4027, value = "SecurityDomain of SSLContext does not support X509PeerCertificateChainEvidence verification")
+    IllegalArgumentException securityDomainOfSSLContextDoesNotSupportX509();
+
     /* mechanism package */
 
     @Message(id = 5001, value = "[%s] Authentication mechanism exchange received a message after authentication was already complete")

--- a/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
+++ b/src/main/java/org/wildfly/security/ssl/SSLContextBuilder.java
@@ -82,6 +82,11 @@ public final class SSLContextBuilder {
      *    certificate authentication
      */
     public SSLContextBuilder setSecurityDomain(final SecurityDomain securityDomain) {
+
+        if (securityDomain != null && securityDomain.getEvidenceVerifySupport(X509PeerCertificateChainEvidence.class).isNotSupported()) {
+            throw ElytronMessages.tls.securityDomainOfSSLContextDoesNotSupportX509();
+        }
+
         this.securityDomain = securityDomain;
 
         return this;


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1271
https://issues.jboss.org/browse/JBEAP-11867