### PR TITLE
[ELY-1278] Coverity static analysis: Dereference null return value in ServerAuthenticationContext (Elytron)

### DIFF
--- a/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -24,6 +24,7 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
@@ -1001,7 +1002,8 @@ public final class ServerAuthenticationContext implements AutoCloseable {
                         log.trace("Peer unverified", e);
                         peerCerts = null;
                     }
-                    serverCerts = X500.asX509CertificateArray(sslCallback.getSslSession().getLocalCertificates());
+                    final Certificate[] localCertificates = sslCallback.getSslSession().getLocalCertificates();
+                    serverCerts = localCertificates != null ? X500.asX509CertificateArray(localCertificates) : null;
                     handleOne(callbacks, idx + 1);
                 } else if (callback instanceof ChannelBindingCallback) {
                     TLSServerEndPointChannelBinding.handleChannelBindingCallback((ChannelBindingCallback) callback, serverCerts);


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1278
JBEAP: https://issues.jboss.org/browse/JBEAP-11925