### PR TITLE
[ELY-1313] KeyStoreCredentialStore encrypt initialization fix for BouncyCastle

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -1281,7 +1281,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             writeBytes(entry.getSecretKey().getEncoded(), entryOos);
             entryOos.flush();
 
-            encrypt.init(Cipher.ENCRYPT_MODE, storageSecretKey);
+            encrypt.init(Cipher.ENCRYPT_MODE, storageSecretKey, (AlgorithmParameterSpec) null); // ELY-1308: third param need to workaround BouncyCastle bug
             int blockSize = encrypt.getBlockSize();
             if (blockSize == 0) throw log.algorithmNotBlockBased(encrypt.getAlgorithm());
             Assert.checkMaximumParameter("cipher block size", 256, blockSize);


### PR DESCRIPTION
Backport of https://github.com/wildfly-security/wildfly-elytron/pull/925

https://issues.jboss.org/browse/ELY-1313
https://issues.jboss.org/browse/JBEAP-11821