### PR TITLE
[ELY-1315] KeyStoreCredentialStore not using writeLock when it should be used

### DIFF
--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -811,8 +811,8 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
     }
 
     private Hold lockForWrite() {
-        readWriteLock.readLock().lock();
-        return () -> readWriteLock.readLock().unlock();
+        readWriteLock.writeLock().lock();
+        return () -> readWriteLock.writeLock().unlock();
     }
 
     private static final Pattern INDEX_PATTERN = Pattern.compile("(.+)/([a-z0-9_]+)/([-a-z0-9_]+)?/([2-7a-z]+)?$");


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1315
https://issues.jboss.org/browse/JBEAP-12569