### PR TITLE
Update & fix build and its dependancies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <version.checkstyle>6.8</version.checkstyle>
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
         <modular.jdk.args/>
+        <modular.jdk.props/>
     </properties>
 
     <build>
@@ -142,7 +143,7 @@
                         </includes>
                         <childDelegation>true</childDelegation>
                         <reuseForks>false</reuseForks>
-                        <argLine>-javaagent:${org.jmockit:jmockit:jar} ${modular.jdk.args}</argLine>
+                        <argLine>${modular.jdk.args} ${modular.jdk.props}</argLine>
                     </configuration>
                 </plugin>
 
@@ -263,7 +264,7 @@
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
             <version>${version.org.wildfly.common}</version>
-            <scope>provided</scope>
+            <!-- scope is compile ELY-1153 -->
         </dependency>
 
         <dependency>
@@ -463,11 +464,11 @@
             </activation>
             <properties>
                 <!-- [WFCORE-1431] remove SASL workaround -->
-                <modular.jdk.args>--add-modules java.corba,java.sql 
-                </modular.jdk.args>
+                <modular.jdk.args>--add-modules java.corba,java.sql --illegal-access=permit</modular.jdk.args>
                 <!-- There are lots of issues with checkstyle runtime on JDK9, it somewhat works but really slows down build, disabling it for now-->
                 <checkstyle.skip>true</checkstyle.skip>
                 <!-- use version of jboss-logging that works much better with JDK9 -->
+                <modular.jdk.props>-Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <version.org.jboss.logging.tools>2.1.0.Beta1</version.org.jboss.logging.tools>
             </properties>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <version>24</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -61,22 +61,22 @@
 
         <version.org.jboss.logging>3.3.1.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.0.6.Final</version.org.jboss.logmanager>
-        <version.org.jboss.logmanager.log4j-jboss>1.1.3.Final</version.org.jboss.logmanager.log4j-jboss>
+        <version.org.jboss.logmanager.log4j-jboss>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.0.1.Final</version.org.jboss.logging.tools>
-        <version.org.jboss.modules>1.6.0.CR1</version.org.jboss.modules>
+        <version.org.jboss.modules>1.6.0.CR2</version.org.jboss.modules>
         <version.org.jboss.slf4j>1.0.3.GA</version.org.jboss.slf4j>
         <version.org.jboss.spec.org.jboss.spec.javax.security.jacc>1.0.1.Final</version.org.jboss.spec.org.jboss.spec.javax.security.jacc>
         <version.org.jboss.spec.jboss-json-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.jboss-json-api_1.0_spec>
         <version.org.jboss.threads>2.2.1.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services.metainf-services>1.7</version.org.kohsuke.metainf-services.metainf-services>
-        <version.junit.junit>4.11</version.junit.junit>
-        <version.jmockit>1.22</version.jmockit>
-        <version.hsqldb>2.3.1</version.hsqldb>
+        <version.junit.junit>4.12</version.junit.junit>
+        <version.jmockit>1.33</version.jmockit>
+        <version.hsqldb>2.4.0</version.hsqldb>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.com.nimbusds.nimbus-jose-jwt>4.13.1</version.com.nimbusds.nimbus-jose-jwt>
-        <version.com.squareup.okhttp3.mockwebserver>3.4.1</version.com.squareup.okhttp3.mockwebserver>
+        <version.com.nimbusds.nimbus-jose-jwt>4.39.2</version.com.nimbusds.nimbus-jose-jwt>
+        <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.6.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.client.config>1.0.0.CR2</version.org.wildfly.client.config>
+        <version.org.wildfly.client.config>1.0.0.CR3</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.2.0.CR1</version.org.wildfly.common>
 
         <test.level>INFO</test.level>
@@ -142,7 +142,7 @@
                         </includes>
                         <childDelegation>true</childDelegation>
                         <reuseForks>false</reuseForks>
-                        <argLine>${modular.jdk.args}</argLine>
+                        <argLine>-javaagent:${org.jmockit:jmockit:jar} ${modular.jdk.args}</argLine>
                     </configuration>
                 </plugin>
 
@@ -463,31 +463,13 @@
             </activation>
             <properties>
                 <!-- [WFCORE-1431] remove SASL workaround -->
-                <modular.jdk.args>--add-modules java.corba,java.sql --add-exports java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
-                --add-exports java.security.sasl/com.sun.security.sasl=ALL-UNNAMED --add-exports jdk.unsupported/sun.reflect=ALL-UNNAMED
-                --add-exports java.base/sun.security.x509=ALL-UNNAMED
+                <modular.jdk.args>--add-modules java.corba,java.sql 
                 </modular.jdk.args>
                 <!-- There are lots of issues with checkstyle runtime on JDK9, it somewhat works but really slows down build, disabling it for now-->
                 <checkstyle.skip>true</checkstyle.skip>
+                <!-- use version of jboss-logging that works much better with JDK9 -->
+                <version.org.jboss.logging.tools>2.1.0.Beta1</version.org.jboss.logging.tools>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.compiler.plugin}</version>
-                        <configuration>
-                            <!-- fork is needed so compiler args can be used -->
-                            <fork>true</fork>
-                            <compilerArgs>
-                                <arg>-J--add-modules</arg>
-                                <arg>-Jjava.annotations.common</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-
-                </plugins>
-            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Makes build work on JDK9
fixes issues with running standalone-clients that rely on transitive deps to be present.