### PR TITLE
[ELY-1333] Upgrade remaining component dependencies to their Final versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <version.org.jboss.logmanager>2.0.6.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.0.1.Final</version.org.jboss.logging.tools>
-        <version.org.jboss.modules>1.6.0.CR2</version.org.jboss.modules>
+        <version.org.jboss.modules>1.6.0.Final</version.org.jboss.modules>
         <version.org.jboss.slf4j>1.0.3.GA</version.org.jboss.slf4j>
         <version.org.jboss.spec.org.jboss.spec.javax.security.jacc>1.0.1.Final</version.org.jboss.spec.org.jboss.spec.javax.security.jacc>
         <version.org.jboss.spec.jboss-json-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.jboss-json-api_1.0_spec>
@@ -76,8 +76,8 @@
         <version.com.nimbusds.nimbus-jose-jwt>4.39.2</version.com.nimbusds.nimbus-jose-jwt>
         <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.6.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.client.config>1.0.0.CR3</version.org.wildfly.client.config>
-        <version.org.wildfly.common>1.2.0.CR1</version.org.wildfly.common>
+        <version.org.wildfly.client.config>1.0.0.Final</version.org.wildfly.client.config>
+        <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>
 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->


### PR DESCRIPTION
Not directly related to a JBEAP issue as this is just a step we need to take before we can create out own Final tag.