### PR TITLE
[ELY-1330] Ensure the server fails authentication if the client sends the "y" channel binding flag even though the server supports channel binding

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2SaslServer.java
@@ -160,7 +160,13 @@ final class Gs2SaslServer extends AbstractSaslServer {
                         throw log.mechChannelBindingTypeMismatch(getMechanismName()).toSaslException();
                     }
                     skipDelimiter(bi);
-                } else if (b == 'y' || b == 'n') {
+                } else if (b == 'y') {
+                    if (plus || (bindingType != null && bindingData != null)) {
+                        // server supports channel binding
+                        throw log.mechChannelBindingNotProvided(getMechanismName()).toSaslException();
+                    }
+                    skipDelimiter(bi);
+                } else if (b == 'n') {
                     if (plus) {
                         throw log.mechChannelBindingNotProvided(getMechanismName()).toSaslException();
                     }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1330
https://issues.jboss.org/browse/JBEAP-12689