### PR TITLE
[ELY-1338] Reduce visibility of methods to avoid custom extensions outside of the package from being created.

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1873,8 +1873,7 @@ public interface ElytronMessages extends BasicLogger {
 
     /* Audit Exceptions */
 
-    @Message(id = 11000, value = "Partial SecurityEvent written.")
-    IOException partialSecurityEventWritten(@Cause IOException cause);
+    // 11000 - Unused in any Final release
 
     @LogMessage(level = Logger.Level.FATAL)
     @Message(id = 11001, value = "Endpoint unable to handle SecurityEvent priority=%s, message=%s")

--- a/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -62,7 +62,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
         setFile(builder.location.toFile());
     }
 
-    protected void setFile(final File file) throws IOException {
+    void setFile(final File file) throws IOException {
         boolean ok = false;
         final FileOutputStream fos = new FileOutputStream(file, true);
         try {
@@ -84,7 +84,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
         }
     }
 
-    protected File getFile() {
+    File getFile() {
         return file;
     }
 
@@ -105,7 +105,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * @param bytes the data.
      * @throws IOException if an I/O error occurs.
      */
-    protected void write(byte[] bytes) throws IOException {
+    void write(byte[] bytes) throws IOException {
         outputStream.write(bytes);
     }
 
@@ -116,7 +116,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      *
      * @param instant
      */
-    protected void preWrite(Instant instant) {
+    void preWrite(Instant instant) {
         // NO-OP by default
     }
 
@@ -166,7 +166,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * Close opened file streams.
      * Must be called synchronized block together with reopening using {@code setFile()}.
      */
-    protected void closeStreams() throws IOException {
+    void closeStreams() throws IOException {
         outputStream.flush();
         fileDescriptor.sync();
         outputStream.close();


### PR DESCRIPTION
This is a minor continuation of https://issues.jboss.org/browse/JBEAP-12631

It would be good at a later point to switch fully to ByteBuffers and NIO Channels, for now however as we are in the final stages of release I have not gone quite this far as it would impact the file size calculation.

For now however I have reduced the visibility of the methods overridden by child implementations to discourage extension so we can freely change these methods in a future release.
