### PR TITLE
[ELY-1298] GssapiCompatibilitySuiteChild fails on IBM JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
                         <childDelegation>true</childDelegation>
                         <reuseForks>false</reuseForks>
                         <argLine>${modular.jdk.args} ${modular.jdk.props}</argLine>
+                        <!-- See also excludedGroups property in profiles -->
                     </configuration>
                 </plugin>
 
@@ -485,6 +486,20 @@
                 <!-- use version of jboss-logging that works much better with JDK9 -->
                 <modular.jdk.props>-Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <version.org.jboss.logging.tools>2.1.0.Beta1</version.org.jboss.logging.tools>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>ibmJdk</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>IBM Corporation</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- Surefire plugin's excluded test categories -->
+                <excludedGroups>org.wildfly.security.ExcludedOnIbmJdk</excludedGroups>
             </properties>
         </profile>
     </profiles>

--- a/src/test/java/org/wildfly/security/ExcludedOnIbmJdk.java
+++ b/src/test/java/org/wildfly/security/ExcludedOnIbmJdk.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security;
+
+/**
+ * A JUnit Category to exclude tests known to fail on IBM JDK.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public interface ExcludedOnIbmJdk {
+}

--- a/src/test/java/org/wildfly/security/sasl/gssapi/GssapiCompatibilitySuiteChild.java
+++ b/src/test/java/org/wildfly/security/sasl/gssapi/GssapiCompatibilitySuiteChild.java
@@ -55,8 +55,10 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+import org.wildfly.security.ExcludedOnIbmJdk;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.util.ByteIterator;
 import org.wildfly.security.util.CodePointIterator;
@@ -72,6 +74,7 @@ import static org.junit.Assert.fail;
  */
 @RunWith(JMockit.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@Category(ExcludedOnIbmJdk.class)
 public class GssapiCompatibilitySuiteChild {
 
     protected boolean wildfly = true; // whether use WildFly or JDK SASL provider, set to false to obtain/verify reference output


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1298

This excludes `GssapiCompatibilitySuiteChild` on IBM JDK, because I see no better way how to solve this. See https://issues.jboss.org/browse/ELY-1298?focusedCommentId=13454485&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13454485 for details.