### PR TITLE
[ELY-1348] LegacyPropertiesRealm should use spec passed into getCredential

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -157,7 +157,7 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1005, value = "Realm map does not contain mapping for default realm '%s'")
     IllegalArgumentException realmMapDoesNotContainDefault(String defaultRealm);
 
-    @Message(id = 1006, value = "No realm name found in users property file - file must contain \"#$REALM_NAME=RealmName$\" line")
+    @Message(id = 1006, value = "No realm name found in users property file - non-plain-text users file must contain \"#$REALM_NAME=RealmName$\" line")
     RealmUnavailableException noRealmFoundInProperties();
 
     @LogMessage(level = Logger.Level.DEBUG)

--- a/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealmTest.java
@@ -177,7 +177,7 @@ public class LegacyPropertiesSecurityRealmTest {
         assertEquals("DigestPassword", SupportLevel.SUPPORTED, elytronIdentity.getCredentialAcquireSupport(PasswordCredential.class, DigestPassword.ALGORITHM_DIGEST_MD5, null));
         assertEquals("Verify", SupportLevel.SUPPORTED, elytronIdentity.getEvidenceVerifySupport(PasswordGuessEvidence.class, null));
 
-        assertNotNull(elytronIdentity.getCredential(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR));
+        assertNull(elytronIdentity.getCredential(PasswordCredential.class, ClearPassword.ALGORITHM_CLEAR));
 
         DigestPassword elytronDigest = elytronIdentity.getCredential(PasswordCredential.class, DigestPassword.ALGORITHM_DIGEST_MD5).getPassword(DigestPassword.class);
         assertNotNull(elytronDigest);


### PR DESCRIPTION
LegacyPropertiesRealm should take advantage from "new" parameter of getCredential - AlgorithmParameterSpec. For plain-text property realms will not be digest realm specification in realm configuration or property file necessary, because password hashes will be generated from spec.

(btw... now looking, maybe we could remove creating digested passwords from clear passwords entirely and keep TwoWay to DigestPassword conversion on mechanism - which is already implemented...)

https://issues.jboss.org/browse/ELY-1348
https://issues.jboss.org/browse/JBEAP-8700