### PR TITLE
[ELY-1362] Thread.getContextClassLoader() can return null.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -2365,8 +2365,11 @@ public final class ElytronXmlParser {
         }
 
         InputStream createStream() throws IOException {
-            final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            final InputStream stream = contextClassLoader.getResourceAsStream(resourceName);
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader == null) {
+                classLoader = ElytronXmlParser.class.getClassLoader();
+            }
+            final InputStream stream = classLoader.getResourceAsStream(resourceName);
             if (stream == null) throw new FileNotFoundException(resourceName);
             return stream;
         }

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -168,7 +168,7 @@ public final class SecurityDomain {
             classLoader = currentThread.getContextClassLoader();
         }
 
-        return CLASS_LOADER_DOMAIN_MAP.get(classLoader);
+        return classLoader != null ? CLASS_LOADER_DOMAIN_MAP.get(classLoader) : null;
     }
 
     /**


### PR DESCRIPTION
Currently waiting for appropriate ACKs on the Jira issue but this is ready for review so we can merge as soon as the paperwork is in place.

https://issues.jboss.org/browse/JBEAP-13113