### PR TITLE
[ELY-134] Javadoc adding

### DIFF
--- a/src/main/java/org/wildfly/security/FailedSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/FailedSecurityFactory.java
@@ -21,15 +21,24 @@ package org.wildfly.security;
 import java.security.GeneralSecurityException;
 
 /**
+ * A {@link SecurityFactory} implementation which only throws specified exception on create.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class FailedSecurityFactory<T> implements SecurityFactory<T> {
+
     private final GeneralSecurityException exception;
 
+    /**
+     * Creates a new factory instance.
+     *
+     * @param exception the exception to be thrown on create
+     */
     public FailedSecurityFactory(final GeneralSecurityException exception) {
         this.exception = exception;
     }
 
+    @Override
     public T create() throws GeneralSecurityException {
         throw exception;
     }

--- a/src/main/java/org/wildfly/security/FixedSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/FixedSecurityFactory.java
@@ -21,15 +21,24 @@ package org.wildfly.security;
 import java.security.GeneralSecurityException;
 
 /**
+ * A {@link SecurityFactory} implementation which returns specified object every time.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class FixedSecurityFactory<T> implements SecurityFactory<T> {
+
     private final T value;
 
+    /**
+     * Creates a new factory instance.
+     *
+     * @param value the value to be returned on create
+     */
     public FixedSecurityFactory(final T value) {
         this.value = value;
     }
 
+    @Override
     public T create() throws GeneralSecurityException {
         return value;
     }

--- a/src/main/java/org/wildfly/security/NullSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/NullSecurityFactory.java
@@ -21,6 +21,8 @@ package org.wildfly.security;
 import java.security.GeneralSecurityException;
 
 /**
+ * A {@link SecurityFactory} implementation which returns null every time.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class NullSecurityFactory<T> implements SecurityFactory<T> {
@@ -30,11 +32,18 @@ public final class NullSecurityFactory<T> implements SecurityFactory<T> {
     NullSecurityFactory() {
     }
 
+    /**
+     * Gets an instance of this singleton class.
+     *
+     * @param <T> the type of the security factory
+     * @return the only instance of this factory
+     */
     @SuppressWarnings("unchecked")
     public static <T> NullSecurityFactory<T> getInstance() {
         return (NullSecurityFactory<T>) INSTANCE;
     }
 
+    @Override
     public T create() throws GeneralSecurityException {
         return null;
     }

--- a/src/main/java/org/wildfly/security/OneTimeSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/OneTimeSecurityFactory.java
@@ -23,12 +23,20 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import java.security.GeneralSecurityException;
 
 /**
+ * A {@link SecurityFactory} implementation which calls delegated factory at first and
+ * returns created object for any other create call. Thread safe.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class OneTimeSecurityFactory<T> implements SecurityFactory<T> {
     private volatile SecurityFactory<T> factory;
     private volatile T obj;
 
+    /**
+     * Creates a new factory instance.
+     *
+     * @param factory a security factory to use to obtain object which should be returned by this factory every time
+     */
     public OneTimeSecurityFactory(final SecurityFactory<T> factory) {
         this.factory = factory;
     }

--- a/src/main/java/org/wildfly/security/audit/AuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/AuditEndpoint.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.wildfly.common.function.ExceptionBiConsumer;
 
 /**
- * An endpoint that recieves audit messages.
+ * An endpoint that receives audit messages.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */

--- a/src/main/java/org/wildfly/security/audit/AuditLogger.java
+++ b/src/main/java/org/wildfly/security/audit/AuditLogger.java
@@ -38,23 +38,25 @@ public final class AuditLogger implements Consumer<SecurityEvent> {
     private final Function<SecurityEvent, EventPriority> priorityMapper;
     private final Function<SecurityEvent, String> messageFormatter;
 
-    /**
-     *
-     */
     AuditLogger(Builder builder) {
         auditEndpoint = checkNotNullParam("auditEndpoint", builder.auditEndpoint);
         priorityMapper = checkNotNullParam("priorityMapper", builder.priorityMapper);
         messageFormatter = checkNotNullParam("messageFormatter", builder.messageFormatter);
     }
 
+    /**
+     * Accept security event to be processed by audit endpoints.
+     *
+     * @param event security event to be processed
+     */
     @Override
-    public void accept(SecurityEvent t) {
+    public void accept(SecurityEvent event) {
         try {
-            EventPriority priority = priorityMapper.apply(t);
+            EventPriority priority = priorityMapper.apply(event);
             if (priority == EventPriority.OFF)
                 return;
 
-            String formatted = messageFormatter.apply(t);
+            String formatted = messageFormatter.apply(event);
             try {
                 auditEndpoint.accept(priority, formatted);
             } catch (Throwable throwable) {
@@ -65,10 +67,18 @@ public final class AuditLogger implements Consumer<SecurityEvent> {
         }
     }
 
+    /**
+     * Obtain a new {@link Builder} capable of building a {@link AuditLogger}.
+     *
+     * @return a new {@link Builder} capable of building a {@link AuditLogger}
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for audit logger instances.
+     */
     public static class Builder {
 
         private ExceptionBiConsumer<EventPriority, String, IOException> auditEndpoint;
@@ -114,6 +124,11 @@ public final class AuditLogger implements Consumer<SecurityEvent> {
             return this;
         }
 
+        /**
+         * Construct a new audit logger instance.
+         *
+         * @return the built audit logger.
+         */
         public Consumer<SecurityEvent> build() {
             return new AuditLogger(this);
         }

--- a/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
+++ b/src/main/java/org/wildfly/security/audit/JsonSecurityEventFormatter.java
@@ -36,7 +36,7 @@ import org.wildfly.security.auth.server.event.SecurityEventVisitor;
 import org.wildfly.security.auth.server.event.SecurityPermissionCheckEvent;
 
 /**
- * A formatter for security events that converts the event to a JSON String.
+ * A formatter for security events that converts events into JSON strings.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -44,9 +44,6 @@ public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, Strin
 
     private final Supplier<DateTimeFormatter> dateTimeFormatterSupplier;
 
-    /**
-     *
-     */
     JsonSecurityEventFormatter(Builder builder) {
         this.dateTimeFormatterSupplier = builder.dateTimeFormatterSupplier;
     }
@@ -124,14 +121,17 @@ public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, Strin
     }
 
     /**
-     * Create a new builder.
+     * Obtain a new {@link Builder} capable of building a {@link JsonSecurityEventFormatter}.
      *
-     * @return a new builder.
+     * @return a new {@link Builder} capable of building a {@link JsonSecurityEventFormatter}
      */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for JSON security event formatter.
+     */
     public static class Builder {
 
         private Supplier<DateTimeFormatter> dateTimeFormatterSupplier = () -> DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault());
@@ -140,11 +140,11 @@ public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, Strin
         }
 
         /**
-         * Set a {@link Supplier<DateTimeFormatter>} to format any dates in the resulting output.
-         * The supplied DateTimeFormatter has to have a time zone configured.
+         * Set a supplier of formatter to format any dates in the resulting output.
+         * The supplied {@link DateTimeFormatter} has to have a time zone configured.
          *
-         * @param dateTimeFormatterSupplier a {@link Supplier<DateTimeFormatter>} to format any dates in the resulting output.
-         * @return {@code this} builder.
+         * @param dateTimeFormatterSupplier a supplier of formatter to format dates in the resulting output
+         * @return this builder
          */
         public Builder setDateTimeFormatterSupplier(Supplier<DateTimeFormatter> dateTimeFormatterSupplier) {
             this.dateTimeFormatterSupplier = checkNotNullParam("dateTimeFormatterSupplier", dateTimeFormatterSupplier);
@@ -152,13 +152,11 @@ public class JsonSecurityEventFormatter extends SecurityEventVisitor<Void, Strin
         }
 
         /**
-         * Build a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into JSON formatted
-         * Strings.
-         *
+         * Build a new {@link SecurityEventVisitor} which will convert events into JSON formatted strings.
+         * <p>
          * Once built the Builder can continue to be configured to create additional instances.
          *
-         * @return a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into JSON formatted
-         *         Strings.
+         * @return a new {@link SecurityEventVisitor} which will convert events into JSON formatted strings
          */
         public SecurityEventVisitor<?, String> build() {
             return new JsonSecurityEventFormatter(this);

--- a/src/main/java/org/wildfly/security/audit/SimpleSecurityEventFormatter.java
+++ b/src/main/java/org/wildfly/security/audit/SimpleSecurityEventFormatter.java
@@ -33,7 +33,7 @@ import org.wildfly.security.auth.server.event.SecurityEventVisitor;
 import org.wildfly.security.auth.server.event.SecurityPermissionCheckEvent;
 
 /**
- * A formatter for security events that converts the event to a simple String.
+ * A formatter for security events that converts events into human-readable strings.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -41,9 +41,6 @@ public class SimpleSecurityEventFormatter extends SecurityEventVisitor<Void, Str
 
     private final Supplier<DateTimeFormatter> dateFormatSupplier;
 
-    /**
-     *
-     */
     SimpleSecurityEventFormatter(Builder builder) {
         this.dateFormatSupplier = builder.dateTimeFormatterSupplier;
     }
@@ -114,12 +111,15 @@ public class SimpleSecurityEventFormatter extends SecurityEventVisitor<Void, Str
     /**
      * Create a new builder.
      *
-     * @return a new builder.
+     * @return a new builder
      */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for simple security event formatter.
+     */
     public static class Builder {
 
         private Supplier<DateTimeFormatter> dateTimeFormatterSupplier = ()  -> DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).withZone(ZoneId.systemDefault());
@@ -128,11 +128,11 @@ public class SimpleSecurityEventFormatter extends SecurityEventVisitor<Void, Str
         }
 
         /**
-         * Set a {@link Supplier<DateTimeFormatter>} to format any dates in the resulting output.
-         * The supplied DateTimeFormatter has to have a time zone configured.
+         * Set a supplier of formatter to format any dates in the resulting output.
+         * The supplied {@link DateTimeFormatter} has to have a time zone configured.
          *
-         * @param dateTimeFormatterSupplier a {@link Supplier<DateTimeFormatter>} to format any dates in the resulting output.
-         * @return {@code this} builder.
+         * @param dateTimeFormatterSupplier a supplier of formatter to format dates in the resulting output
+         * @return this builder
          */
         public Builder setDateTimeFormatterSupplier(Supplier<DateTimeFormatter> dateTimeFormatterSupplier) {
             this.dateTimeFormatterSupplier = checkNotNullParam("dateTimeFormatterSupplier", dateTimeFormatterSupplier);
@@ -141,12 +141,11 @@ public class SimpleSecurityEventFormatter extends SecurityEventVisitor<Void, Str
         }
 
         /**
-         * Build a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into a simple String
-         *
+         * Build a new {@link SecurityEventVisitor} which will convert events into human-readable strings.
+         * <p>
          * Once built the Builder can continue to be configured to create additional instances.
          *
-         * @return a new {@link SecurityEventVisitor} which will convert {@link SecurityEvent} instances into a simple String
-         *         Strings.
+         * @return a new {@link SecurityEventVisitor} which will convert events into human-readable strings
          */
         public SecurityEventVisitor<Void, String> build() {
             return new SimpleSecurityEventFormatter(this);

--- a/src/main/java/org/wildfly/security/audit/SizeRotatingFileAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/SizeRotatingFileAuditEndpoint.java
@@ -32,8 +32,12 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 import static org.wildfly.security._private.ElytronMessages.audit;
 
 /**
- * An audit endpoint which rotates the log at the size of the log.
- *
+ * An audit endpoint which rotates the log when log file size reach given value.
+ * <p>
+ * Moves old log records into files tagged by index - the older has the higher index.
+ * When index reach {@code maxBackupIndex}, the oldest log file is removed,
+ * so there are at most {@code maxBackupIndex + 1} log files.
+ * <p>
  * Based on {@link org.jboss.logmanager.handlers.PeriodicSizeRotatingFileHandler}.
  *
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
@@ -104,10 +108,18 @@ public class SizeRotatingFileAuditEndpoint extends FileAuditEndpoint {
         setFile(file);
     }
 
+    /**
+     * Obtain a new {@link Builder} capable of building a {@link SizeRotatingFileAuditEndpoint}.
+     *
+     * @return a new {@link Builder} capable of building a {@link SizeRotatingFileAuditEndpoint}.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for size rotating file audit endpoints.
+     */
     public static class Builder extends FileAuditEndpoint.Builder {
 
         private long rotateSize = 0xa0000L; // 10 MB by default
@@ -139,7 +151,7 @@ public class SizeRotatingFileAuditEndpoint extends FileAuditEndpoint {
          * <p/>
          * The suffix must be a string understood by the  {@link java.time.format.DateTimeFormatter}.
          * <p/>
-         * <b>Note:</b> Files will be rotated for the same suffix until reach the maximum backup index configured {@see #setMaxBackupIndex(int)}.
+         * <b>Note:</b> Files will be rotated for the same suffix until reach the maximum backup index configured by {@link #setMaxBackupIndex(int)}.
          * If the suffix is resolved to a new value, any files rotated with a different suffix will not be deleted.
          * For example if the suffix is .yyyy-DD-mm, the maximum size was reached 20 times on the same day and the maxBackupIndex
          * was set to 10, then there will only be 10 files kept. What will not be purged is files from a previous day.

--- a/src/main/java/org/wildfly/security/audit/SyslogAuditEndpoint.java
+++ b/src/main/java/org/wildfly/security/audit/SyslogAuditEndpoint.java
@@ -33,7 +33,7 @@ import org.jboss.logmanager.handlers.TcpOutputStream;
 import javax.net.SocketFactory;
 
 /**
- * An {@link AuditEndpoint} that logs to syslog.
+ * An audit endpoint that logs to syslog server.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -44,7 +44,7 @@ public class SyslogAuditEndpoint implements AuditEndpoint {
     private final SyslogHandler syslogHandler;
 
     /**
-     * Creates a new {@link AuditEndpoint} that logs to syslog.
+     * Creates a new audit endpoint that logs to syslog server.
      */
     SyslogAuditEndpoint(Builder builder) throws IOException {
         SyslogHandler.Protocol protocol = builder.ssl ? Protocol.SSL_TCP : builder.tcp ? Protocol.TCP : Protocol.UDP;
@@ -59,13 +59,13 @@ public class SyslogAuditEndpoint implements AuditEndpoint {
     }
 
     @Override
-    public void accept(EventPriority t, String u) throws IOException {
+    public void accept(EventPriority priority, String message) throws IOException {
         if (!accepting) return;
 
         synchronized(this) {
             if (!accepting) return;
 
-            syslogHandler.doPublish(new ExtLogRecord(toLevel(t), u, SyslogAuditEndpoint.class.getName()));
+            syslogHandler.doPublish(new ExtLogRecord(toLevel(priority), message, SyslogAuditEndpoint.class.getName()));
         }
     }
 
@@ -96,10 +96,18 @@ public class SyslogAuditEndpoint implements AuditEndpoint {
         }
     }
 
+    /**
+     * Obtain a new {@link Builder} capable of building a {@link SyslogAuditEndpoint}.
+     *
+     * @return a new {@link Builder} capable of building a {@link SyslogAuditEndpoint}.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for syslog audit endpoint.
+     */
     public static class Builder {
 
         private InetAddress serverAddress;

--- a/src/main/java/org/wildfly/security/audit/package-info.java
+++ b/src/main/java/org/wildfly/security/audit/package-info.java
@@ -20,13 +20,13 @@
  * Audit logging related resources.
  *
  * Audit logging registers with the {@link org.wildfly.security.auth.server.SecurityDomain} by registering a
- * {@link java.util.function.Consumer<SecurityEvent>} to receive the emitted events.
+ * {@link java.util.function.Consumer} to receive the emitted {@link org.wildfly.security.auth.server.event.SecurityEvent}s.
  *
  * The audit logging framework is comprised of three core components.
  * <ol>
- * <li>Priority Mapper</li>
- * <li>Event Formatter</li>
- * <li>Audit Endpoint</li>
+ * <li>Priority Mapper ({@code Function<SecurityEvent, EventPriority>})</li>
+ * <li>Event Formatter ({@code Function<SecurityEvent, String>})</li>
+ * <li>Audit Endpoint ({@code ExceptionBiConsumer<EventPriority, String, IOException>})</li>
  * </ol>
  *
  * The priority mapper takes an incoming security event and maps it to one of nine priority levels including a level 'OFF' to

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -171,6 +171,7 @@ public final class AuthenticationConfiguration {
     /**
      * An empty configuration which can be used as the basis for any configuration.  This configuration supports no
      * remapping of any kind, and always uses an anonymous principal.
+     * @deprecated to obtain empty configuration use {@link #empty()} method instead
      */
     @Deprecated
     public static final AuthenticationConfiguration EMPTY = new AuthenticationConfiguration();
@@ -638,6 +639,12 @@ public final class AuthenticationConfiguration {
         }
     }
 
+    /**
+     * Create a new configuration which is the same as this configuration, but which uses the given credential to authenticate.
+     *
+     * @param credential the credential to authenticate
+     * @return the new configuration
+     */
     public AuthenticationConfiguration useCredential(Credential credential) {
         if (credential == null) return this;
         final CredentialSource credentialSource = this.credentialSource;

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationContext.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationContext.java
@@ -36,6 +36,8 @@ import org.wildfly.security.SecurityFactory;
 import org.wildfly.security.Version;
 
 /**
+ * A set of rules and authentication configurations to use with a client for establishing a connection.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class AuthenticationContext implements Contextual<AuthenticationContext> {

--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
@@ -335,7 +335,7 @@ public final class AuthenticationContextConfigurationClient {
      * @param uri the target URI (must not be {@code null})
      * @param configuration the authentication configuration (must not be {@code null})
      * @param offeredMechanisms the available mechanisms (must not be {@code null})
-     * @param factoryOperator A {@link UnaryOperator<SaslClientFactory>} to apply to the factory used.
+     * @param factoryOperator a {@link UnaryOperator} to apply to the {@link SaslClientFactory} used
      * @return the SASL client, or {@code null} if no clients were available or could be configured
      */
     public SaslClient createSaslClient(URI uri, AuthenticationConfiguration configuration,  Collection<String> offeredMechanisms, UnaryOperator<SaslClientFactory> factoryOperator) throws SaslException {
@@ -348,7 +348,7 @@ public final class AuthenticationContextConfigurationClient {
      * @param uri the target URI (must not be {@code null})
      * @param configuration the authentication configuration (must not be {@code null})
      * @param offeredMechanisms the available mechanisms (must not be {@code null})
-     * @param factoryOperator A {@link UnaryOperator<SaslClientFactory>} to apply to the factory used.
+     * @param factoryOperator a {@link UnaryOperator} to apply to the {@link SaslClientFactory} used
      * @param sslSession the SSL session active for this connection, or {@code null} for none
      * @return the SASL client, or {@code null} if no clients were available or could be configured
      */

--- a/src/main/java/org/wildfly/security/auth/client/MatchRule.java
+++ b/src/main/java/org/wildfly/security/auth/client/MatchRule.java
@@ -23,6 +23,8 @@ import static org.wildfly.security._private.ElytronMessages.log;
 import java.net.URI;
 
 /**
+ * A rule used for deciding which authentication configuration to use.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public abstract class MatchRule {

--- a/src/main/java/org/wildfly/security/auth/client/package-info.java
+++ b/src/main/java/org/wildfly/security/auth/client/package-info.java
@@ -15,40 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.security.audit;
 
 /**
- * The priority level of an audit event.
- *
- * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * Elytron Client enable remote clients to authenticate using Elytron.
+ * <p>
+ * When a connection is established, the client makes use of an authentication
+ * context, which gives rules that match which authentication configuration
+ * is used with an outbound connection.
  */
-public enum EventPriority {
-
-    /** Emergency - system is unusable */
-    EMERGENCY,
-
-    /** Action must be taken immediately */
-    ALERT,
-
-    /** Critical condition */
-    CRITICAL,
-
-    /** Error condition */
-    ERROR,
-
-    /** Warning condition */
-    WARNING,
-
-    /** Normal but significant condition */
-    NOTICE,
-
-    /** Informational message */
-    INFORMATIONAL,
-
-    /** Message for debugging/troubleshooting */
-    DEBUG,
-
-    /** No message should be emitted */
-    OFF;
-
-}
+package org.wildfly.security.auth.client;

--- a/src/main/java/org/wildfly/security/auth/realm/CachingSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/CachingSecurityRealm.java
@@ -53,7 +53,7 @@ public class CachingSecurityRealm implements SecurityRealm {
     /**
      * Creates a new instance.
      *
-     * @param realm the {@link SecurityRealm} whose {@link RealmIdentity} should be cached..
+     * @param realm the {@link SecurityRealm} whose {@link RealmIdentity} should be cached.
      * @param cache the {@link RealmIdentityCache} instance
      */
     public CachingSecurityRealm(CacheableSecurityRealm realm, RealmIdentityCache cache) {
@@ -255,6 +255,11 @@ public class CachingSecurityRealm implements SecurityRealm {
         cache.clear();
     }
 
+    /**
+     * Gets wrapped backing realm.
+     *
+     * @return the wrapped backing realm
+     */
     protected CacheableSecurityRealm getCacheableRealm() {
         return realm;
     }

--- a/src/main/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/LegacyPropertiesSecurityRealm.java
@@ -252,6 +252,13 @@ public class LegacyPropertiesSecurityRealm implements SecurityRealm {
         return PasswordGuessEvidence.class.isAssignableFrom(evidenceType) ? SupportLevel.SUPPORTED : SupportLevel.UNSUPPORTED;
     }
 
+    /**
+     * Loads this properties security realm from the given user and groups input streams.
+     *
+     * @param usersStream the input stream from which the realm users are loaded
+     * @param groupsStream the input stream from which the roles of realm users are loaded
+     * @throws IOException if there is problem while reading the input streams or invalid content is loaded from streams
+     */
     public void load(InputStream usersStream, InputStream groupsStream) throws IOException {
         Map<String, AccountEntry> accounts = new HashMap<>();
         Properties groups = new Properties();
@@ -333,14 +340,27 @@ public class LegacyPropertiesSecurityRealm implements SecurityRealm {
         loadedState.set(new LoadedState(accounts, realmName, System.currentTimeMillis()));
     }
 
+    /**
+     * Get the time when the realm was last loaded.
+     *
+     * @return the time when the realm was last loaded (number of milliseconds since the standard base time)
+     */
     public long getLoadTime() {
         return loadedState.get().getLoadTime();
     }
 
+    /**
+     * Obtain a new {@link Builder} capable of building a {@link LegacyPropertiesSecurityRealm}.
+     *
+     * @return a new {@link Builder} capable of building a {@link LegacyPropertiesSecurityRealm}.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for legacy properties security realms.
+     */
     public static class Builder {
 
         private Supplier<Provider[]> providers = Security::getProviders;

--- a/src/main/java/org/wildfly/security/auth/server/IdentityCredentials.java
+++ b/src/main/java/org/wildfly/security/auth/server/IdentityCredentials.java
@@ -260,6 +260,15 @@ public abstract class IdentityCredentials implements Iterable<Credential>, Crede
         return without(credentialType, algorithmName, null);
     }
 
+    /**
+     * Return a copy of this credential set without any credentials of the given type, algorithm name and
+     * parameter spec.  If the credential type and algorithm name is not found in this set, return this instance.
+     *
+     * @param credentialType the credential type to remove (must not be {@code null})
+     * @param algorithmName the algorithm name to remove, or {@code null} to match any algorithm name
+     * @param parameterSpec the parameter spec to remove, or {@code null} to match any parameter spec
+     * @return the new credential set (not {@code null})
+     */
     public IdentityCredentials without(final Class<? extends Credential> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) {
         Assert.checkNotNullParam("credentialType", credentialType);
         return without(c -> c.matches(credentialType, algorithmName, parameterSpec));
@@ -296,18 +305,37 @@ public abstract class IdentityCredentials implements Iterable<Credential>, Crede
         return Spliterators.spliterator(iterator(), size(), Spliterator.IMMUTABLE | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.ORDERED | Spliterator.SIZED);
     }
 
+    /**
+     * Test whether some of the credentials in this set can verify an evidence of given class and algorithm name.
+     *
+     * @param evidenceClass the class of the evidence (must not be {@code null})
+     * @param algorithmName the algorithm name (may be {@code null} if the type of evidence does not support algorithm names)
+     * @return {@code true} if the evidence can be verified
+     */
     public boolean canVerify(Class<? extends Evidence> evidenceClass, String algorithmName) {
         return StreamSupport.stream(spliterator(), false)
                 .filter(credential -> credential.canVerify(evidenceClass, algorithmName))
                 .count() != 0;
     }
 
+    /**
+     * Test whether some of the credentials in this set can verify an evidence.
+     *
+     * @param evidence the evidence (must not be {@code null})
+     * @return {@code true} if the evidence can be verified
+     */
     public boolean canVerify(Evidence evidence) {
         return StreamSupport.stream(spliterator(), false)
                 .filter(credential -> credential.canVerify(evidence))
                 .count() != 0;
     }
 
+    /**
+     * Verify the given evidence.
+     *
+     * @param evidence the evidence to verify (must not be {@code null})
+     * @return {@code true} if the evidence is verified, {@code false} otherwise
+     */
     public boolean verify(Evidence evidence) {
         return StreamSupport.stream(spliterator(), false)
                 .filter(credential -> credential.canVerify(evidence))

--- a/src/main/java/org/wildfly/security/auth/server/MechanismConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismConfiguration.java
@@ -155,6 +155,9 @@ public final class MechanismConfiguration {
         return new Builder();
     }
 
+    /**
+     * A builder for authentication mechanism configuration.
+     */
     public static final class Builder {
         private static final MechanismRealmConfiguration[] NO_REALM_CONFIGS = new MechanismRealmConfiguration[0];
 
@@ -171,29 +174,59 @@ public final class MechanismConfiguration {
         Builder() {
         }
 
+        /**
+         * Set a principal transformer to apply before the realm is selected.
+         *
+         * @param preRealmRewriter a principal transformer to apply before the realm is selected
+         * @return this builder
+         */
         public Builder setPreRealmRewriter(final Function<Principal, Principal> preRealmRewriter) {
             checkNotNullParam("preRealmRewriter", preRealmRewriter);
             this.preRealmRewriter = preRealmRewriter;
             return this;
         }
 
+        /**
+         * Set a principal transformer to apply after the realm is selected.  Any previously set credential source will be overwritten.
+         *
+         * @param postRealmRewriter a principal transformer to apply after the realm is selected
+         * @return this builder
+         */
         public Builder setPostRealmRewriter(final Function<Principal, Principal> postRealmRewriter) {
             checkNotNullParam("postRealmRewriter", postRealmRewriter);
             this.postRealmRewriter = postRealmRewriter;
             return this;
         }
 
+        /**
+         * Set a final principal transformer to apply for this mechanism realm.  Any previously set credential source will be overwritten.
+         *
+         * @param finalRewriter a final principal transformer to apply for this mechanism realm
+         * @return this builder
+         */
         public Builder setFinalRewriter(final Function<Principal, Principal> finalRewriter) {
             checkNotNullParam("finalRewriter", finalRewriter);
             this.finalRewriter = finalRewriter;
             return this;
         }
 
+        /**
+         * Sets a realm mapper to be used by the mechanism.  Any previously set credential source will be overwritten.
+         *
+         * @param realmMapper a realm mapper to be used by the mechanism
+         * @return this builder
+         */
         public Builder setRealmMapper(final RealmMapper realmMapper) {
             this.realmMapper = realmMapper;
             return this;
         }
 
+        /**
+         * Adds a configuration for one of realms of this mechanism.
+         *
+         * @param configuration a configuration for one of realms of this mechanism
+         * @return this builder
+         */
         public Builder addMechanismRealm(MechanismRealmConfiguration configuration) {
             checkNotNullParam("configuration", configuration);
             List<MechanismRealmConfiguration> mechanismRealms = this.mechanismRealms;
@@ -242,6 +275,8 @@ public final class MechanismConfiguration {
          * Build a new instance.  If no mechanism realms are offered, an empty collection should be provided for
          * {@code mechanismRealms}; otherwise, if the mechanism only supports one realm, the first will be used.  If the
          * mechanism does not support realms, {@code mechanismRealms} is ignored.
+         *
+         * @return a new instance
          */
         public MechanismConfiguration build() {
             List<MechanismRealmConfiguration> mechanismRealms = this.mechanismRealms;

--- a/src/main/java/org/wildfly/security/auth/server/MechanismConfigurationSelector.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismConfigurationSelector.java
@@ -37,7 +37,7 @@ public interface MechanismConfigurationSelector {
     MechanismConfiguration selectConfiguration(MechanismInformation mechanismInformation);
 
     /**
-     * Create a simple {@link MechanismConfigurationSelector} that is paired with a {@link Predicate<MechanismInformation>} to
+     * Create a simple {@link MechanismConfigurationSelector} that is paired with a {@link Predicate} to
      * test if the configuration should be used for the supplied information.
      *
      * @param predicate the predicate to test the {@code MechanismInformation}
@@ -71,8 +71,8 @@ public interface MechanismConfigurationSelector {
      * Create a constant {@link MechanismConfigurationSelector} which will always return the same {@link MechanismConfiguration}
      * instance.
      *
-     * @param mechanismConfiguration
-     * @return
+     * @param mechanismConfiguration a configuration which will be always returned by created selector
+     * @return the new configuration selector
      */
     static MechanismConfigurationSelector constantSelector(final MechanismConfiguration mechanismConfiguration) {
         return information -> mechanismConfiguration;

--- a/src/main/java/org/wildfly/security/auth/server/MechanismRealmConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/server/MechanismRealmConfiguration.java
@@ -111,6 +111,9 @@ public final class MechanismRealmConfiguration {
         return new Builder();
     }
 
+    /**
+     * A builder for mechanism realm configuration.
+     */
     public static final class Builder {
         private String realmName;
         private Function<Principal, Principal> preRealmRewriter = Function.identity();
@@ -124,12 +127,23 @@ public final class MechanismRealmConfiguration {
         Builder() {
         }
 
+        /**
+         * Sets a name of the realm to be presented by the mechanism.
+         * @param realmName a name of the realm to be presented by the mechanism
+         * @return this builder
+         */
         public Builder setRealmName(final String realmName) {
             this.realmName = realmName;
 
             return this;
         }
 
+        /**
+         * Set a principal transformer to apply before the realm is selected.
+         *
+         * @param preRealmRewriter a principal transformer to apply before the realm is selected
+         * @return this builder
+         */
         public Builder setPreRealmRewriter(final Function<Principal, Principal> preRealmRewriter) {
             Assert.checkNotNullParam("preRealmRewriter", preRealmRewriter);
             this.preRealmRewriter = preRealmRewriter;
@@ -137,6 +151,12 @@ public final class MechanismRealmConfiguration {
             return this;
         }
 
+        /**
+         * Set a principal transformer to apply after the realm is selected.  Any previously set credential source will be overwritten.
+         *
+         * @param postRealmRewriter a principal transformer to apply after the realm is selected
+         * @return this builder
+         */
         public Builder setPostRealmRewriter(final Function<Principal, Principal> postRealmRewriter) {
             Assert.checkNotNullParam("postRealmRewriter", postRealmRewriter);
             this.postRealmRewriter = postRealmRewriter;
@@ -144,6 +164,12 @@ public final class MechanismRealmConfiguration {
             return this;
         }
 
+        /**
+         * Set a final principal transformer to apply for this mechanism realm.  Any previously set credential source will be overwritten.
+         *
+         * @param finalRewriter a final principal transformer to apply for this mechanism realm
+         * @return this builder
+         */
         public Builder setFinalRewriter(final Function<Principal, Principal> finalRewriter) {
             Assert.checkNotNullParam("finalRewriter", finalRewriter);
             this.finalRewriter = finalRewriter;
@@ -151,11 +177,22 @@ public final class MechanismRealmConfiguration {
             return this;
         }
 
+        /**
+         * Sets a realm mapper to be used by the mechanism.  Any previously set credential source will be overwritten.
+         *
+         * @param realmMapper a realm mapper to be used by the mechanism
+         * @return this builder
+         */
         public Builder setRealmMapper(final RealmMapper realmMapper) {
             this.realmMapper = realmMapper;
             return this;
         }
 
+        /**
+         * Build a new instance.
+         *
+         * @return a new instance
+         */
         public MechanismRealmConfiguration build() {
             Assert.checkNotNullParam("realmName", realmName);
             return new MechanismRealmConfiguration(realmName, preRealmRewriter, postRealmRewriter, finalRewriter, realmMapper);

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -465,9 +465,9 @@ public final class SecurityDomain {
      * Determine whether a credential of the given type and algorithm is definitely obtainable, possibly obtainable (for
      * some identities), or definitely not obtainable.
      *
-     * Credential is {@link SupportLevel.SUPPORTED}, if it is supported by all realms of the domain.
-     * Credential is {@link SupportLevel.POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
-     * Otherwise it is {@link SupportLevel.UNSUPPORTED}.
+     * Credential is {@link SupportLevel#SUPPORTED}, if it is supported by all realms of the domain.
+     * Credential is {@link SupportLevel#POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
+     * Otherwise it is {@link SupportLevel#UNSUPPORTED}.
      *
      * @param credentialType the exact credential type (must not be {@code null})
      * @param algorithmName the algorithm name, or {@code null} if any algorithm is acceptable or the credential type does
@@ -491,9 +491,9 @@ public final class SecurityDomain {
      * Determine whether a credential of the given type and algorithm is definitely obtainable, possibly obtainable (for
      * some identities), or definitely not obtainable.
      *
-     * Credential is {@link SupportLevel.SUPPORTED}, if it is supported by all realms of the domain.
-     * Credential is {@link SupportLevel.POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
-     * Otherwise it is {@link SupportLevel.UNSUPPORTED}.
+     * Credential is {@link SupportLevel#SUPPORTED}, if it is supported by all realms of the domain.
+     * Credential is {@link SupportLevel#POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
+     * Otherwise it is {@link SupportLevel#UNSUPPORTED}.
      *
      * @param credentialType the exact credential type (must not be {@code null})
      * @param algorithmName the algorithm name, or {@code null} if any algorithm is acceptable or the credential type does
@@ -508,9 +508,9 @@ public final class SecurityDomain {
      * Determine whether a credential of the given type and algorithm is definitely obtainable, possibly obtainable (for
      * some identities), or definitely not obtainable.
      *
-     * Credential is {@link SupportLevel.SUPPORTED}, if it is supported by all realms of the domain.
-     * Credential is {@link SupportLevel.POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
-     * Otherwise it is {@link SupportLevel.UNSUPPORTED}.
+     * Credential is {@link SupportLevel#SUPPORTED}, if it is supported by all realms of the domain.
+     * Credential is {@link SupportLevel#POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
+     * Otherwise it is {@link SupportLevel#UNSUPPORTED}.
      *
      * @param credentialType the exact credential type (must not be {@code null})
      * @return the level of support for this credential
@@ -523,9 +523,9 @@ public final class SecurityDomain {
      * Determine whether a given type of evidence is definitely verifiable, possibly verifiable (for some identities),
      * or definitely not verifiable.
      *
-     * Evidence is {@link SupportLevel.SUPPORTED}, if it is supported by all realms of the domain.
-     * Evidence is {@link SupportLevel.POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
-     * Otherwise it is {@link SupportLevel.UNSUPPORTED}.
+     * Evidence is {@link SupportLevel#SUPPORTED}, if it is supported by all realms of the domain.
+     * Evidence is {@link SupportLevel#POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
+     * Otherwise it is {@link SupportLevel#UNSUPPORTED}.
      *
      * @param evidenceType the type of evidence to be verified (must not be {@code null})
      * @param algorithmName the algorithm name, or {@code null} if any algorithm is acceptable or the evidence type does
@@ -547,9 +547,9 @@ public final class SecurityDomain {
      * Determine whether a given type of evidence is definitely verifiable, possibly verifiable (for some identities),
      * or definitely not verifiable.
      *
-     * Evidence is {@link SupportLevel.SUPPORTED}, if it is supported by all realms of the domain.
-     * Evidence is {@link SupportLevel.POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
-     * Otherwise it is {@link SupportLevel.UNSUPPORTED}.
+     * Evidence is {@link SupportLevel#SUPPORTED}, if it is supported by all realms of the domain.
+     * Evidence is {@link SupportLevel#POSSIBLY_SUPPORTED} if it is supported or possibly supported by at least one realm of the domain.
+     * Otherwise it is {@link SupportLevel#UNSUPPORTED}.
      *
      * @param evidenceType the type of evidence to be verified (must not be {@code null})
      * @return the level of support for this evidence type
@@ -599,7 +599,7 @@ public final class SecurityDomain {
     /**
      * Get the current security identity for this domain.
      *
-     * Code can be executed with given identity using {@link SecurityIdentity.runAs*} methods.
+     * Code can be executed with given identity using {@code SecurityIdentity.runAs*} methods.
      *
      * @return the current security identity for this domain (not {@code null})
      */
@@ -1132,6 +1132,11 @@ public final class SecurityDomain {
             return this;
         }
 
+        /**
+         * Constructs this realm info and adds it into the domain.
+         *
+         * @return the security domain builder
+         */
         public Builder build() {
             assertNotBuilt();
             return parent.addRealm(this);
@@ -1156,6 +1161,11 @@ public final class SecurityDomain {
         }
     }
 
+    /**
+     * Gets {@link ScheduledExecutorService} for authentication related scheduled task (like authentication timeout).
+     *
+     * @return the executor service
+     */
     public static ScheduledExecutorService getScheduledExecutorService() {
         return ScheduledExecutorServiceProvider.INSTANCE;
     }

--- a/src/main/java/org/wildfly/security/auth/server/event/RealmAuthorizationEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/RealmAuthorizationEvent.java
@@ -23,9 +23,12 @@ import java.security.Principal;
 import org.wildfly.security.authz.AuthorizationIdentity;
 
 /**
+ * A realm authorization event.  The realm identity may be destroyed at some point after the event is handled.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public abstract class RealmAuthorizationEvent extends RealmEvent {
+
     private final AuthorizationIdentity authorizationIdentity;
     private final Principal principal;
 

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityAuthenticationFailedEvent.java
@@ -33,13 +33,19 @@ public final class SecurityAuthenticationFailedEvent extends SecurityAuthenticat
     /**
      * Constructor for a new instance.
      *
-     * @param securityIdentity the {@link SecurityIdentity} that failed authentication.
+     * @param securityIdentity the {@link SecurityIdentity} that failed authentication ({@code null} when identity does not exists)
+     * @param principal the principal used to that failed authentication (filled event if identity does not exists)
      */
     public SecurityAuthenticationFailedEvent(SecurityIdentity securityIdentity, Principal principal) {
         super(securityIdentity, false);
         this.principal = principal;
     }
 
+    /**
+     * Gets the principal used to the failed authentication.
+     *
+     * @return the principal used to that failed authentication (filled event if identity does not exists)
+     */
     public Principal getPrincipal() {
         return principal;
     }

--- a/src/main/java/org/wildfly/security/auth/server/event/SecurityEventVisitor.java
+++ b/src/main/java/org/wildfly/security/auth/server/event/SecurityEventVisitor.java
@@ -24,6 +24,9 @@ package org.wildfly.security.auth.server.event;
  */
 public abstract class SecurityEventVisitor<P, R> {
 
+    /**
+     * Construct a security event visitor.
+     */
     protected SecurityEventVisitor() {
     }
 

--- a/src/main/java/org/wildfly/security/auth/server/package-info.java
+++ b/src/main/java/org/wildfly/security/auth/server/package-info.java
@@ -15,40 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.security.audit;
 
 /**
- * The priority level of an audit event.
- *
- * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * Server side of authentication provided by Elytron.
  */
-public enum EventPriority {
-
-    /** Emergency - system is unusable */
-    EMERGENCY,
-
-    /** Action must be taken immediately */
-    ALERT,
-
-    /** Critical condition */
-    CRITICAL,
-
-    /** Error condition */
-    ERROR,
-
-    /** Warning condition */
-    WARNING,
-
-    /** Normal but significant condition */
-    NOTICE,
-
-    /** Informational message */
-    INFORMATIONAL,
-
-    /** Message for debugging/troubleshooting */
-    DEBUG,
-
-    /** No message should be emitted */
-    OFF;
-
-}
+package org.wildfly.security.auth.server;

--- a/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
@@ -106,10 +106,18 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
         }
     }
 
+    /**
+     * Obtain a new {@link Builder} capable of building a {@link GSSCredentialSecurityFactory}.
+     *
+     * @return a new {@link Builder} capable of building a {@link GSSCredentialSecurityFactory}.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * A builder for GSS credential security factories.
+     */
     public static class Builder {
 
         private boolean built = false;
@@ -272,6 +280,12 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
             return this;
         }
 
+        /**
+         * Construct a new {@link GSSKerberosCredential} security factory instance.
+         *
+         * @return the built factory instance
+         * @throws IOException when unable to use given KeyTab
+         */
         public SecurityFactory<GSSKerberosCredential> build() throws IOException {
             assertNotBuilt();
             if (checkKeyTab) {

--- a/src/main/java/org/wildfly/security/authz/SimplePermissionMapper.java
+++ b/src/main/java/org/wildfly/security/authz/SimplePermissionMapper.java
@@ -43,7 +43,7 @@ import org.wildfly.security.permission.PermissionVerifier;
  *
  * It is possible that multiple mappings could be matched during the call to {@link #mapPermissions(PermissionMappable, Roles)}
  * and this is why the ordering is important, by default only the first match will be used however this can be overridden by
- * calling {@link Builder#setMappingMode(MappingMode)} to choose a different mode to combine the resulting
+ * calling {@link Builder#setMappingMode(SimplePermissionMapper.MappingMode)} to choose a different mode to combine the resulting
  * {@link PermissionVerifier} instances.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
@@ -100,6 +100,9 @@ public class SimplePermissionMapper implements PermissionMapper {
         return new Builder();
     }
 
+    /**
+     * A builder for simple permission mappers.
+     */
     public static class Builder {
 
         private boolean built = false;
@@ -188,6 +191,9 @@ public class SimplePermissionMapper implements PermissionMapper {
 
     }
 
+    /**
+     * Mode defining behaviour when multiple mappings are found.
+     */
     public enum MappingMode {
 
         /**

--- a/src/main/java/org/wildfly/security/digest/TruncatedMessageDigest.java
+++ b/src/main/java/org/wildfly/security/digest/TruncatedMessageDigest.java
@@ -46,23 +46,28 @@ public final class TruncatedMessageDigest extends MessageDigest {
         this.bytes = bytes;
     }
 
+    @Override
     public void update(final byte input) {
         delegate.update(input);
     }
 
+    @Override
     public void update(final byte[] input, final int offset, final int len) {
         delegate.update(input, offset, len);
     }
 
+    @Override
     public void update(final byte[] input) {
         delegate.update(input);
     }
 
+    @Override
     public byte[] digest() {
         final byte[] digest = delegate.digest();
         return digest.length > bytes ? Arrays.copyOf(digest, bytes) : digest;
     }
 
+    @Override
     public int digest(final byte[] buf, final int offset, final int len) throws DigestException {
         Assert.checkNotNullParam("buf", buf);
         if (bytes > len) {
@@ -73,29 +78,36 @@ public final class TruncatedMessageDigest extends MessageDigest {
         return bytes;
     }
 
+    @Override
     public byte[] digest(final byte[] input) {
         update(input);
         return digest();
     }
 
+    @Override
     public void reset() {
         delegate.reset();
     }
 
+    @Override
     public Object clone() throws CloneNotSupportedException {
         return new TruncatedMessageDigest((MessageDigest) delegate.clone(), bytes);
     }
 
+    @Override
     protected void engineUpdate(final byte input) {
     }
 
+    @Override
     protected void engineUpdate(final byte[] input, final int offset, final int len) {
     }
 
+    @Override
     protected byte[] engineDigest() {
         return null;
     }
 
+    @Override
     protected void engineReset() {
     }
 }

--- a/src/main/java/org/wildfly/security/evidence/BearerTokenEvidence.java
+++ b/src/main/java/org/wildfly/security/evidence/BearerTokenEvidence.java
@@ -20,7 +20,7 @@ package org.wildfly.security.evidence;
 import org.wildfly.common.Assert;
 
 /**
- * An {@link Evidence} that usually holds a bearer security token.
+ * A piece of evidence that is comprised of a bearer security token.
  *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -373,10 +373,10 @@ public class HttpAuthenticator {
         }
 
         /**
-         * Set the {@link Supplier<List<HttpServerAuthenticationMechanism>>} to use to obtain the actual {@link HttpServerAuthenticationMechanism} instances based
-         * on the configured policy.
+         * Set the supplier to use to obtain list of {@link HttpServerAuthenticationMechanism} implementations
+         * instances to use, based on the configured policy.
          *
-         * @param mechanismSupplier the {@link Supplier<List<HttpServerAuthenticationMechanism>>} with the configured authentication policy.
+         * @param mechanismSupplier the {@link Supplier} with the configured authentication policy
          * @return the {@link Builder} to allow method call chaining.
          */
         public Builder setMechanismSupplier(Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier) {

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -62,7 +62,7 @@ public class HttpConstants {
     public static final String CONFIG_POST_LOCATION = CONFIG_BASE + ".post-location";
 
     /**
-     * This allos a {@link GSSManager} instance to be passed into the authentication mechanisms.
+     * This allows a {@link GSSManager} instance to be passed into the authentication mechanisms.
      */
     public static final String CONFIG_GSS_MANAGER = CONFIG_BASE + ".gss-manager";
 

--- a/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -45,7 +45,7 @@ public interface HttpExchangeSpi extends HttpServerScopes {
      * Get a list of all of the values set for the specified header within the HTTP request.
      *
      * @param headerName the not {@code null} name of the header the values are required for.
-     * @return a {@link List<String>} of the values set for this header, if the header is not set on the request then {@code null} should be returned.
+     * @return a list of the values set for this header, if the header is not set on the request then {@code null} should be returned.
      */
     List<String> getRequestHeaderValues(final String headerName);
 
@@ -122,15 +122,17 @@ public interface HttpExchangeSpi extends HttpServerScopes {
 
     /**
      * Notification that authentication has failed using the mechanism specified.
-     * @param message
-     * @param mechanismName
+     *
+     * @param message an error message describing the failure
+     * @param mechanismName a failed mechanism name
      */
     void authenticationFailed(final String message, final String mechanismName);
 
     /**
      * Notification that authentication has failed for a specific mechanism due to being a bad request.
-     * @param error
-     * @param mechanismName
+     *
+     * @param error an exception to describe the error.
+     * @param mechanismName a failed mechanism name
      */
     void badRequest(final HttpAuthenticationException error, final String mechanismName);
 

--- a/src/main/java/org/wildfly/security/http/HttpScope.java
+++ b/src/main/java/org/wildfly/security/http/HttpScope.java
@@ -23,8 +23,9 @@ import java.io.InputStream;
 import java.util.function.Consumer;
 
 /**
- * An attachment scope for use by an authentication mechanism, different scopes may be available to share Objects e.g.
- * Application, Session, Connection.
+ * An attachment scope for use by an authentication mechanism.
+ * <p>
+ * Different scopes may be available to share Objects e.g. Application, Session, Connection.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -33,14 +34,14 @@ public interface HttpScope {
     /**
      * Get the ID of this scope or (@code null} if IDs are not supported for this scope or the scope doesn't currently exist.
      *
-     * @return the ID of this scope or (@code null} if IDs are not supported for this scope or the scope doesn't currently exist..
+     * @return the ID of this scope or (@code null} if IDs are not supported for this scope or the scope doesn't currently exist.
      */
     default String getID() {
         return null;
     }
 
     /**
-     * Returns {@code true} if this scope exists.
+     * Tests whether this scope exists.
      *
      * @return {@code true} if this scope exists. Otherwise, {@code false}
      */
@@ -49,7 +50,7 @@ public interface HttpScope {
     }
 
     /**
-     * Create this scope..
+     * Create this scope.
      *
      * @return {@code true} if the scope was created. Otherwise, {@code false} indicating that this scope was already created or that creation is not support.
      */
@@ -58,9 +59,9 @@ public interface HttpScope {
     }
 
     /**
-     * Does this scope support attachments?
+     * Tests whether this scope support attachments.
      *
-     * @return {@code true} if this scope supports attachments, {@code false} otherwise}
+     * @return {@code true} if this scope supports attachments, {@code false} otherwise
      */
     default boolean supportsAttachments() {
         return false;
@@ -127,7 +128,7 @@ public interface HttpScope {
     }
 
     /**
-     * Does this scope support access to scope specific resources?
+     * Tests whether this scope support access to scope specific resources.
      *
      * @return {@code true} if this scope supports access to scope specific resources, {@code false} otherwise.
      */
@@ -139,14 +140,14 @@ public interface HttpScope {
      * Get the resource associated with the path specified.
      *
      * @param path the path to the resource.
-     * @return the {@link InputStream} of the resource or {@code null} if resources not supported or the specified resource is not found.
+     * @return the {@link InputStream} of the resource or {@code null} if resources is not supported or the specified resource is not found.
      */
     default InputStream getResource(final String path) {
         return null;
     }
 
     /**
-     * Does this scope support registration to receive notifications?
+     * Tests whether this scope support registration to receive notifications.
      *
      * @return {@code true} if this scope supports registration for notifications, {@code false} otherwise.
      */
@@ -155,9 +156,9 @@ public interface HttpScope {
     }
 
     /**
-     * Register a {@link Consumer<HttpScopeNotification>} to receive notifications from this scope.
+     * Register a notification consumer to receive notifications from this scope.
      *
-     * @param notificationConsumer the {@link Consumer<HttpScopeNotification>} to receive notifications from this scope.
+     * @param notificationConsumer the consumer to receive notifications from this scope.
      */
     default void registerForNotification(Consumer<HttpScopeNotification> notificationConsumer) {
     }

--- a/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
-import org.wildfly.security.auth.server.SecurityIdentity;
-
 /**
  * Server side representation of a HTTP request.
  *
@@ -41,7 +39,7 @@ public interface HttpServerRequest extends HttpServerScopes {
      * Get a list of all of the values set for the specified header within the HTTP request.
      *
      * @param headerName the not {@code null} name of the header the values are required for.
-     * @return a {@link List<String>} of the values set for this header, if the header is not set on the request then
+     * @return a list of the values set for this header, if the header is not set on the request then
      *         {@code null} should be returned.
      */
     List<String> getRequestHeaderValues(final String headerName);
@@ -125,8 +123,6 @@ public interface HttpServerRequest extends HttpServerScopes {
      * the identity of the request.
      *
      * If this form is called no response is expected from this mechanism.
-     *
-     * @param securityIdentity the {@link SecurityIdentity} established as a result of this authentication.
      */
     default void authenticationComplete() {
         authenticationComplete(null);

--- a/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
+++ b/src/main/java/org/wildfly/security/http/HttpServerRequestWrapper.java
@@ -32,12 +32,22 @@ import javax.net.ssl.SSLSession;
 import org.wildfly.common.Assert;
 
 /**
+ * A wrapper delegating any request to the delegated implementation.
+ * <p>
+ * Determined to be used as base class for {@link HttpServerRequest} without need to implement
+ * methods delegating requests to the delegated implementation.
+ *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 public class HttpServerRequestWrapper implements HttpServerRequest {
 
     private final HttpServerRequest delegate;
 
+    /**
+     * Construct new instance.
+     *
+     * @param delegate a request to which will be delegated any requests
+     */
     public HttpServerRequestWrapper(HttpServerRequest delegate) {
         Assert.checkNotNullParam("delegate", delegate);
         this.delegate = delegate;

--- a/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SecurityIdentityServerMechanismFactory.java
@@ -37,7 +37,9 @@ import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
 import org.wildfly.security.http.HttpServerRequest;
 
 /**
- *
+ * A {@link HttpServerAuthenticationMechanismFactory} that wraps authentication mechanism from delegating factory, so
+ * any request for {@code SECURITY_IDENTITY} negotiated property is caught and {@link SecurityIdentity} from
+ * the callback handler is returned instead.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -45,6 +47,11 @@ public class SecurityIdentityServerMechanismFactory implements HttpServerAuthent
 
     private final HttpServerAuthenticationMechanismFactory delegate;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param delegate the {@link HttpServerAuthenticationMechanismFactory} calls are delegated to.
+     */
     public SecurityIdentityServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate) {
         this.delegate = checkNotNullParam("delegate", delegate);
     }

--- a/src/main/java/org/wildfly/security/http/util/SecurityProviderServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SecurityProviderServerMechanismFactory.java
@@ -51,7 +51,7 @@ public final class SecurityProviderServerMechanismFactory implements HttpServerA
     /**
      * Construct a new instance of {@code SecurityProviderServerMechanismFactory}.
      *
-     * @param providerSupplier a {@link Supplier<Provider>} to supply the providers to use for locating the factories.
+     * @param providerSupplier a supplier of providers to use for locating the factories
      */
     public SecurityProviderServerMechanismFactory(Supplier<Provider[]> providerSupplier) {
         this.providerSupplier = checkNotNullParam("providerSupplier", providerSupplier);

--- a/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -44,6 +44,11 @@ public class SetMechanismInformationMechanismFactory implements HttpServerAuthen
 
     private HttpServerAuthenticationMechanismFactory delegate;
 
+    /**
+     * Construct a wrapping mechanism factory instance.
+     *
+     * @param delegate the wrapped mechanism factory
+     */
     public SetMechanismInformationMechanismFactory(final HttpServerAuthenticationMechanismFactory delegate) {
         this.delegate = delegate;
     }

--- a/src/main/java/org/wildfly/security/http/util/SortedServerMechanismFactory.java
+++ b/src/main/java/org/wildfly/security/http/util/SortedServerMechanismFactory.java
@@ -31,7 +31,7 @@ import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
 
 /**
  * A {@link HttpServerAuthenticationMechanismFactory} which sorts the mechanism names returned using the provided
- * {@link Comparator<String>}.
+ * {@link Comparator}.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */

--- a/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
@@ -28,7 +28,7 @@ import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.cache.CachedIdentity;
 
 /**
- * {@link SignleSignOn} implementation backed by a {@link DefaultSingleSignOnEntry}.
+ * {@link SingleSignOn} implementation backed by a {@link DefaultSingleSignOnEntry}.
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  * @author Paul Ferraro
  */

--- a/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnEntry.java
+++ b/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnEntry.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ConcurrentMap;
 import org.wildfly.security.cache.CachedIdentity;
 
 /**
+ * Single sign-on cache entry.
+ *
  * @author Paul Ferraro
  */
 public interface SingleSignOnEntry {

--- a/src/main/java/org/wildfly/security/manager/action/WriteSecurityPropertyAction.java
+++ b/src/main/java/org/wildfly/security/manager/action/WriteSecurityPropertyAction.java
@@ -31,11 +31,18 @@ public final class WriteSecurityPropertyAction implements PrivilegedAction<Void>
     private final String key;
     private final String value;
 
+    /**
+     * Construct a security action.
+     *
+     * @param key the security property name to set
+     * @param value the security property value to set
+     */
     public WriteSecurityPropertyAction(final String key, final String value) {
         this.key = key;
         this.value = value;
     }
 
+    @Override
     public Void run() {
         Security.setProperty(key, value);
         return null;

--- a/src/main/java/org/wildfly/security/mechanism/MechanismUtil.java
+++ b/src/main/java/org/wildfly/security/mechanism/MechanismUtil.java
@@ -44,6 +44,8 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 
 /**
+ * Utils to be used by authentication mechanism (SASL or HTTP) implementations.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class MechanismUtil {

--- a/src/main/java/org/wildfly/security/package-info.java
+++ b/src/main/java/org/wildfly/security/package-info.java
@@ -15,40 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.security.audit;
 
 /**
- * The priority level of an audit event.
- *
- * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * WildFly security base package.
  */
-public enum EventPriority {
-
-    /** Emergency - system is unusable */
-    EMERGENCY,
-
-    /** Action must be taken immediately */
-    ALERT,
-
-    /** Critical condition */
-    CRITICAL,
-
-    /** Error condition */
-    ERROR,
-
-    /** Warning condition */
-    WARNING,
-
-    /** Normal but significant condition */
-    NOTICE,
-
-    /** Informational message */
-    INFORMATIONAL,
-
-    /** Message for debugging/troubleshooting */
-    DEBUG,
-
-    /** No message should be emitted */
-    OFF;
-
-}
+package org.wildfly.security;

--- a/src/main/java/org/wildfly/security/password/spec/ClearPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/ClearPasswordSpec.java
@@ -20,14 +20,30 @@ package org.wildfly.security.password.spec;
 
 import org.wildfly.common.Assert;
 
+/**
+ * A password specification for clear passwords.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
 public final class ClearPasswordSpec implements PasswordSpec {
+
     private final char[] encodedPassword;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param encodedPassword the password
+     */
     public ClearPasswordSpec(final char[] encodedPassword) {
         Assert.checkNotNullParam("encodedPassword", encodedPassword);
         this.encodedPassword = encodedPassword;
     }
 
+    /**
+     * Get the password characters.
+     *
+     * @return the password characters
+     */
     public char[] getEncodedPassword() {
         return encodedPassword;
     }

--- a/src/main/java/org/wildfly/security/password/spec/DigestPasswordAlgorithmSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/DigestPasswordAlgorithmSpec.java
@@ -35,6 +35,12 @@ public final class DigestPasswordAlgorithmSpec implements AlgorithmParameterSpec
     private final String username;
     private final String realm;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param username the username
+     * @param realm the realm
+     */
     public DigestPasswordAlgorithmSpec(String username, String realm) {
         this.username = username;
         this.realm = realm;

--- a/src/main/java/org/wildfly/security/password/spec/HashPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/HashPasswordSpec.java
@@ -20,14 +20,30 @@ package org.wildfly.security.password.spec;
 
 import org.wildfly.common.Assert;
 
+/**
+ * A password specification for a password represented by a hash.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
 public final class HashPasswordSpec implements PasswordSpec {
+
     private final byte[] digest;
 
+    /**
+     * Construct new instance.
+     *
+     * @param digest the password hash
+     */
     public HashPasswordSpec(final byte[] digest) {
         Assert.checkNotNullParam("digest", digest);
         this.digest = digest;
     }
 
+    /**
+     * Get a password hash.
+     *
+     * @return the password hash
+     */
     public byte[] getDigest() {
         return digest;
     }

--- a/src/main/java/org/wildfly/security/password/spec/IteratedHashPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/IteratedHashPasswordSpec.java
@@ -29,17 +29,34 @@ public class IteratedHashPasswordSpec implements PasswordSpec {
     private final byte[] hash;
     private final int iterationCount;
 
+    /**
+     * Construct new instance.
+     *
+     * @param hash the password hash
+     * @param iterationCount the iteration count or cost
+     */
     public IteratedHashPasswordSpec(byte[] hash, int iterationCount) {
         Assert.checkNotNullParam("hash", hash);
         this.hash = hash;
         this.iterationCount = iterationCount;
     }
 
+    /**
+     * Get a password hash.
+     *
+     * @return the password hash
+     */
     public byte[] getHash() {
         return this.hash;
     }
 
+    /**
+     * Get an iteration count or cost.
+     *
+     * @return the iteration count or cost
+     */
     public int getIterationCount() {
         return this.iterationCount;
     }
+
 }

--- a/src/main/java/org/wildfly/security/password/spec/IteratedSaltedHashPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/IteratedSaltedHashPasswordSpec.java
@@ -30,6 +30,13 @@ public class IteratedSaltedHashPasswordSpec implements PasswordSpec {
     private final byte[] salt;
     private final int iterationCount;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param hash the password hash bytes
+     * @param salt the salt bytes
+     * @param iterationCount the iteration count
+     */
     public IteratedSaltedHashPasswordSpec(byte[] hash, byte[] salt, int iterationCount) {
         Assert.checkNotNullParam("hash", hash);
         Assert.checkNotNullParam("salt", salt);
@@ -38,14 +45,29 @@ public class IteratedSaltedHashPasswordSpec implements PasswordSpec {
         this.iterationCount = iterationCount;
     }
 
+    /**
+     * Get a password hash bytes.
+     *
+     * @return the password hash
+     */
     public byte[] getHash() {
         return this.hash;
     }
 
+    /**
+     * Get the salt bytes.
+     *
+     * @return the salt bytes
+     */
     public byte[] getSalt() {
         return this.salt;
     }
 
+    /**
+     * Get the iteration count.
+     *
+     * @return the iteration count
+     */
     public int getIterationCount() {
         return this.iterationCount;
     }

--- a/src/main/java/org/wildfly/security/password/spec/OneTimePasswordAlgorithmSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/OneTimePasswordAlgorithmSpec.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import org.wildfly.common.Assert;
 
 /**
- * Algorithm parameter specification for one-time password types.
+ * Algorithm parameter specification for one-time password types as defined in RFC 2289.
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
@@ -37,6 +37,13 @@ public final class OneTimePasswordAlgorithmSpec implements AlgorithmParameterSpe
     private final String seed;
     private final int sequenceNumber;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param algorithm the OTP hash algorithm in "otp-<algorithm identifier>" form (see RFC 2289)
+     * @param seed the seed
+     * @param sequenceNumber the sequence number
+     */
     public OneTimePasswordAlgorithmSpec(final String algorithm, final String seed, final int sequenceNumber) {
         Assert.checkNotNullParam("algorithm", algorithm);
         Assert.checkNotNullParam("seed", seed);
@@ -45,14 +52,29 @@ public final class OneTimePasswordAlgorithmSpec implements AlgorithmParameterSpe
         this.sequenceNumber = sequenceNumber;
     }
 
+    /**
+     * Gets the OTP hash algorithm in "otp-<algorithm identifier>" form.
+     *
+     * @return the algorithm
+     */
     public String getAlgorithm() {
         return algorithm;
     }
 
+    /**
+     * Gets the seed.
+     *
+     * @return the seed
+     */
     public String getSeed() {
         return seed;
     }
 
+    /**
+     * Gets the sequence number.
+     *
+     * @return the sequence number
+     */
     public int getSequenceNumber() {
         return sequenceNumber;
     }

--- a/src/main/java/org/wildfly/security/password/spec/OneTimePasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/OneTimePasswordSpec.java
@@ -20,7 +20,7 @@ package org.wildfly.security.password.spec;
 import org.wildfly.common.Assert;
 
 /**
- * A {@link PasswordSpec} for a one-time password.
+ * A {@link PasswordSpec} for a one-time password as defined in RFC 2289.
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
@@ -30,6 +30,13 @@ public final class OneTimePasswordSpec implements PasswordSpec {
     private final String seed;
     private final int sequenceNumber;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param hash the hash bytes
+     * @param seed the seed
+     * @param sequenceNumber the sequence number
+     */
     public OneTimePasswordSpec(final byte[] hash, final String seed, final int sequenceNumber) {
         Assert.checkNotNullParam("hash", hash);
         Assert.checkNotNullParam("seed", seed);
@@ -38,14 +45,29 @@ public final class OneTimePasswordSpec implements PasswordSpec {
         this.sequenceNumber = sequenceNumber;
     }
 
+    /**
+     * Gets the hash.
+     *
+     * @return the hash
+     */
     public byte[] getHash() {
         return hash;
     }
 
+    /**
+     * Gets the seed.
+     *
+     * @return the seed
+     */
     public String getSeed() {
         return seed;
     }
 
+    /**
+     * Gets the sequence number.
+     *
+     * @return the sequence number
+     */
     public int getSequenceNumber() {
         return sequenceNumber;
     }

--- a/src/main/java/org/wildfly/security/password/spec/SaltedHashPasswordSpec.java
+++ b/src/main/java/org/wildfly/security/password/spec/SaltedHashPasswordSpec.java
@@ -29,6 +29,12 @@ public class SaltedHashPasswordSpec implements PasswordSpec {
     private final byte[] hash;
     private final byte[] salt;
 
+    /**
+     * Construct a new instance.
+     *
+     * @param hash the password hash bytes
+     * @param salt the salt bytes
+     */
     public SaltedHashPasswordSpec(final byte[] hash, final byte[] salt) {
         Assert.checkNotNullParam("hash", hash);
         Assert.checkNotNullParam("salt", salt);
@@ -36,10 +42,20 @@ public class SaltedHashPasswordSpec implements PasswordSpec {
         this.salt = salt;
     }
 
+    /**
+     * Get a password hash bytes.
+     *
+     * @return the password hash
+     */
     public byte[] getHash() {
         return this.hash;
     }
 
+    /**
+     * Get the salt bytes.
+     *
+     * @return the salt bytes
+     */
     public byte[] getSalt() {
         return this.salt;
     }

--- a/src/main/java/org/wildfly/security/permission/SimpleActionBitsPermissionCollection.java
+++ b/src/main/java/org/wildfly/security/permission/SimpleActionBitsPermissionCollection.java
@@ -51,6 +51,7 @@ public final class SimpleActionBitsPermissionCollection extends AbstractPermissi
         return permissionsRef.get().length;
     }
 
+    @Override
     protected void doAdd(final AbstractPermission<?> permission) {
         if (permission instanceof AbstractActionSetPermission<?>) {
             doAdd((AbstractActionSetPermission<?>) permission);
@@ -58,6 +59,11 @@ public final class SimpleActionBitsPermissionCollection extends AbstractPermissi
         throw ElytronMessages.log.invalidPermissionType(AbstractActionSetPermission.class, permission);
     }
 
+    /**
+     * Adds a permission.
+     *
+     * @param permission the non-{@code null} permission
+     */
     protected void doAdd(final AbstractActionSetPermission<?> permission) {
         AbstractActionSetPermission<?>[] oldVal, readVal, newVal;
         int count;

--- a/src/main/java/org/wildfly/security/ssl/Protocol.java
+++ b/src/main/java/org/wildfly/security/ssl/Protocol.java
@@ -72,6 +72,12 @@ public enum Protocol {
         this.name = name;
     }
 
+    /**
+     * Gets an enum item for given protocol name.
+     *
+     * @param name the protocol name
+     * @return an enum item
+     */
     public static Protocol forName(final String name) {
         return map.get(name);
     }


### PR DESCRIPTION
~Based on https://github.com/wildfly-security/wildfly-elytron/pull/964 (necessary to generate API-only javadoc)~

* rework of audit javadoc
* fixes of invalid {@link}s with generic types params
* adding javadoc where missing and included in api

https://issues.jboss.org/browse/ELY-134