### PR TITLE
[ELY-1371] Verify a username is available before continuing to generate the digest.

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/AbstractDigestMechanism.java
@@ -522,6 +522,10 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
                 throw log.mechCallbackHandlerFailedForUnknownReason(getMechanismName(), e).toSaslException();
             }
         }
+        String username = readOnlyRealmUsername ? nameCallback.getDefaultName() : nameCallback.getName();
+        if (username == null) {
+            return null;
+        }
         TwoWayPassword password = credentialCallback.applyToCredential(PasswordCredential.class, c -> c.getPassword().castAs(TwoWayPassword.class));
         char[] passwordChars;
         try {
@@ -535,7 +539,6 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
             log.credentialDestroyingFailed(e);
         }
         String realm = readOnlyRealmUsername ? realmCallback.getDefaultText() : realmCallback.getText();
-        String username = readOnlyRealmUsername ? nameCallback.getDefaultName() : nameCallback.getName();
         byte[] digest_urp = userRealmPasswordDigest(messageDigest, username, realm, passwordChars);
         Arrays.fill(passwordChars, (char)0); // wipe out the password
         return digest_urp;
@@ -558,6 +561,10 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
                 throw log.mechCallbackHandlerFailedForUnknownReason(getMechanismName(), e).toSaslException();
             }
         }
+        String username = readOnlyRealmUsername ? nameCallback.getDefaultName() : nameCallback.getName();
+        if (username == null) {
+            return null;
+        }
         char[] passwordChars = passwordCallback.getPassword();
         passwordCallback.clearPassword();
         if (passwordChars == null) {
@@ -567,7 +574,6 @@ abstract class AbstractDigestMechanism extends AbstractSaslParticipant {
             throw log.mechNotProvidedUserName(getMechanismName()).toSaslException();
         }
         String realm = readOnlyRealmUsername ? realmCallback.getDefaultText() : realmCallback.getText();
-        String username = readOnlyRealmUsername ? nameCallback.getDefaultName() : nameCallback.getName();
         byte[] digest_urp = userRealmPasswordDigest(messageDigest, username, realm, passwordChars);
         Arrays.fill(passwordChars, (char)0); // wipe out the password
         return digest_urp;

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestSaslClient.java
@@ -233,14 +233,14 @@ class DigestSaslClient extends AbstractDigestMechanism implements SaslClient {
         if (digest_urp == null) {
             digest_urp = getSaltedPasswordFromPasswordCallback(realmCallback, nameCallback, false, false);
         }
-        if (digest_urp == null) {
-            throw log.mechCallbackHandlerDoesNotSupportCredentialAcquisition(getMechanismName(), null).toSaslException();
-        }
-        realm = realmCallback.getText();
         String userName = nameCallback.getName();
         if (userName == null) {
             throw log.mechNotProvidedUserName(getMechanismName()).toSaslException();
         }
+        if (digest_urp == null) {
+            throw log.mechCallbackHandlerDoesNotSupportCredentialAcquisition(getMechanismName(), null).toSaslException();
+        }
+        realm = realmCallback.getText();
 
         // username
         digestResponse.append("username=\"");


### PR DESCRIPTION
This is just an initial fix focused on checking for null to avoid the NPE.

I have also changed the order we check if we have a username or digest as TBH no username would always have failed and even now will always result in no digest so we have the more specific error first.

https://issues.jboss.org/browse/ELY-1371

This contributes to https://issues.jboss.org/browse/JBEAP-13214 but does not resolve it.