### PR TITLE
[ELY-1369] non-MD5 algorithms into HTTP Digest + qop=auth support

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -122,6 +122,8 @@ public class HttpConstants {
     public static final String BASIC_NAME = "BASIC";
     public static final String CLIENT_CERT_NAME = "CLIENT_CERT";
     public static final String DIGEST_NAME = "DIGEST";
+    public static final String DIGEST_SHA256_NAME = "DIGEST-SHA-256";
+    public static final String DIGEST_SHA512_256_NAME = "DIGEST-SHA-512-256";
     public static final String FORM_NAME = "FORM";
     public static final String SPNEGO_NAME = "SPNEGO";
     public static final String BEARER_TOKEN = "BEARER_TOKEN";
@@ -149,7 +151,6 @@ public class HttpConstants {
 
     public static final String MD5 = "MD5";
     public static final String SHA256 = "SHA-256";
-
+    public static final String SHA512_256 = "SHA-512-256";
 
 }
-

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -25,8 +25,12 @@ import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
 import static org.wildfly.security.http.HttpConstants.CONFIG_CONTEXT_PATH;
 import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
 import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
+import static org.wildfly.security.http.HttpConstants.DIGEST_SHA256_NAME;
+import static org.wildfly.security.http.HttpConstants.DIGEST_SHA512_256_NAME;
 import static org.wildfly.security.http.HttpConstants.FORM_NAME;
+import static org.wildfly.security.http.HttpConstants.MD5;
 import static org.wildfly.security.http.HttpConstants.SHA256;
+import static org.wildfly.security.http.HttpConstants.SHA512_256;
 import static org.wildfly.security.http.HttpConstants.SPNEGO_NAME;
 
 import java.security.Provider;
@@ -103,7 +107,11 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
             case CLIENT_CERT_NAME:
                 return new ClientCertAuthenticationMechanism(callbackHandler);
             case DIGEST_NAME:
-                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), providers);
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), MD5, providers);
+            case DIGEST_SHA256_NAME:
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), SHA256, providers);
+            case DIGEST_SHA512_256_NAME:
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), SHA512_256, providers);
             case FORM_NAME:
                 return new FormAuthenticationMechanism(callbackHandler, properties);
             case SPNEGO_NAME:

--- a/src/test/java/org/wildfly/security/http/DigestAuthenticationMechanismTest.java
+++ b/src/test/java/org/wildfly/security/http/DigestAuthenticationMechanismTest.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http;
+
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
+import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
+import static org.wildfly.security.http.HttpConstants.SHA256;
+import static org.wildfly.security.http.HttpConstants.UNAUTHORIZED;
+
+/**
+ * Test of server side of the Digest HTTP mechanism.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+@RunWith(JMockit.class)
+public class DigestAuthenticationMechanismTest extends AbstractBaseHttpTest {
+
+    @Test
+    public void testRfc2617() throws Exception {
+        mockDigestNonce("AAAAAQABsxiWa25/kpFxsPCrpDCFsjkTzs/Xr7RPsi/VVN6faYp21Hia3h4=");
+        Map<String, Object> props = new HashMap<>();
+        props.put(CONFIG_REALM, "testrealm@host.com");
+        HttpServerAuthenticationMechanism mechanism = mechanismFactory.createAuthenticationMechanism(DIGEST_NAME, props, getCallbackHandler("Mufasa", "testrealm@host.com", "Circle Of Life"));
+
+        TestingHttpServerRequest request1 = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request1);
+        Assert.assertEquals(Status.NO_AUTH, request1.getResult());
+        TestingHttpServerResponse response = request1.getResponse();
+        Assert.assertEquals(UNAUTHORIZED, response.getStatusCode());
+        Assert.assertEquals("Digest realm=\"testrealm@host.com\", nonce=\"AAAAAQABsxiWa25/kpFxsPCrpDCFsjkTzs/Xr7RPsi/VVN6faYp21Hia3h4=\", opaque=\"00000000000000000000000000000000\", algorithm=MD5, qop=auth", response.getAuthenticateHeader());
+
+        TestingHttpServerRequest request2 = new TestingHttpServerRequest(new String[] {
+                "Digest username=\"Mufasa\",\n" +
+                "                 realm=\"testrealm@host.com\",\n" +
+                "                 nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",\n" +
+                "                 uri=\"/dir/index.html\",\n" +
+                "                 qop=auth,\n" +
+                "                 nc=00000001,\n" +
+                "                 cnonce=\"0a4f113b\",\n" +
+                "                 response=\"6629fae49393a05397450978507c4ef1\",\n" +
+                "                 opaque=\"00000000000000000000000000000000\",\n" +
+                "                 algorithm=MD5"
+        });
+        mechanism.evaluateRequest(request2);
+        Assert.assertEquals(Status.COMPLETE, request2.getResult());
+    }
+
+    @Test
+    public void testRfc7616sha256() throws Exception {
+        mockDigestNonce("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v");
+        Map<String, Object> props = new HashMap<>();
+        props.put(CONFIG_REALM, "http-auth@example.org");
+        HttpServerAuthenticationMechanism mechanism = mechanismFactory.createAuthenticationMechanism(DIGEST_NAME + "-" + SHA256, props, getCallbackHandler("Mufasa", "http-auth@example.org", "Circle of Life"));
+
+        TestingHttpServerRequest request1 = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request1);
+        Assert.assertEquals(Status.NO_AUTH, request1.getResult());
+        TestingHttpServerResponse response = request1.getResponse();
+        Assert.assertEquals(UNAUTHORIZED, response.getStatusCode());
+        Assert.assertEquals("Digest realm=\"http-auth@example.org\", nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\", opaque=\"00000000000000000000000000000000\", algorithm=SHA-256, qop=auth", response.getAuthenticateHeader());
+
+        TestingHttpServerRequest request2 = new TestingHttpServerRequest(new String[] {
+                "Digest username=\"Mufasa\",\n" +
+                "       realm=\"http-auth@example.org\",\n" +
+                "       uri=\"/dir/index.html\",\n" +
+                "       algorithm=SHA-256,\n" +
+                "       nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\",\n" +
+                "       nc=00000001,\n" +
+                "       cnonce=\"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ\",\n" +
+                "       qop=auth,\n" +
+                "       response=\"753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\",\n" +
+                "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\""
+        });
+        mechanism.evaluateRequest(request2);
+        Assert.assertEquals(Status.COMPLETE, request2.getResult());
+    }
+
+}

--- a/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
+++ b/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http;
+
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
+import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
+import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
+import static org.wildfly.security.http.HttpConstants.SHA256;
+import static org.wildfly.security.http.HttpConstants.UNAUTHORIZED;
+
+/**
+ * Test of using multiple HTTP authentication mechanisms.
+ *
+ * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
+ */
+@RunWith(JMockit.class)
+public class HttpAuthenticatorTest extends AbstractBaseHttpTest {
+
+    private TestingHttpExchangeSpi exchangeSpi = new TestingHttpExchangeSpi();
+    private HttpAuthenticator authenticator;
+
+    private void testOneOfThree() throws Exception {
+        mockDigestNonce("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v");
+
+        Map<String, Object> digestProps = new HashMap<>();
+        digestProps.put(CONFIG_REALM, "http-auth@example.org");
+
+        CallbackHandler callbackHandler = getCallbackHandler("Mufasa", "http-auth@example.org", "Circle of Life");
+
+        final List<HttpServerAuthenticationMechanism> mechanisms = new LinkedList<>();
+        mechanisms.add(mechanismFactory.createAuthenticationMechanism(DIGEST_NAME, digestProps, callbackHandler));
+        mechanisms.add(mechanismFactory.createAuthenticationMechanism(BASIC_NAME, Collections.emptyMap(), callbackHandler));
+        mechanisms.add(mechanismFactory.createAuthenticationMechanism(DIGEST_NAME + "-" + SHA256, digestProps, callbackHandler));
+
+        authenticator = HttpAuthenticator.builder()
+                .setMechanismSupplier(() -> mechanisms)
+                .setHttpExchangeSpi(exchangeSpi)
+                .setRequired(true)
+                .build();
+        Assert.assertFalse(authenticator.authenticate());
+
+        List<String> responses = exchangeSpi.getResponseAuthenticateHeaders();
+        assertEquals("All three mechanisms provided authenticate response", 3, responses.size());
+        Assert.assertEquals(UNAUTHORIZED, exchangeSpi.getStatusCode());
+        Assert.assertEquals(null, exchangeSpi.getResult());
+        exchangeSpi.setStatusCode(0);
+    }
+
+    @Test
+    public void testDigestMd5() throws Exception {
+        testOneOfThree();
+
+        exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList(
+                "Digest username=\"Mufasa\",\n" +
+                        "       realm=\"http-auth@example.org\",\n" +
+                        "       uri=\"/dir/index.html\",\n" +
+                        "       algorithm=MD5,\n" +
+                        "       nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\",\n" +
+                        "       nc=00000001,\n" +
+                        "       cnonce=\"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ\",\n" +
+                        "       qop=auth,\n" +
+                        "       response=\"8ca523f5e9506fed4657c9700eebdbec\",\n" +
+                        "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\""
+        ));
+        Assert.assertTrue("Digest-MD5 successful", authenticator.authenticate());
+        Assert.assertEquals(0, exchangeSpi.getStatusCode());
+        Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        testOneOfThree();
+
+        exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList(
+                "Basic TXVmYXNhOkNpcmNsZSBvZiBMaWZl"
+        ));
+        Assert.assertTrue("Basic successful", authenticator.authenticate());
+        Assert.assertEquals(0, exchangeSpi.getStatusCode());
+        Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());
+    }
+
+    @Test
+    public void testDigestSha256() throws Exception {
+        testOneOfThree();
+
+        exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList(
+                "Digest username=\"Mufasa\",\n" +
+                        "       realm=\"http-auth@example.org\",\n" +
+                        "       uri=\"/dir/index.html\",\n" +
+                        "       algorithm=SHA-256,\n" +
+                        "       nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\",\n" +
+                        "       nc=00000001,\n" +
+                        "       cnonce=\"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ\",\n" +
+                        "       qop=auth,\n" +
+                        "       response=\"753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\",\n" +
+                        "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\""
+        ));
+        Assert.assertTrue("Digest-SHA-256 successful", authenticator.authenticate());
+        Assert.assertEquals(0, exchangeSpi.getStatusCode());
+        Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());
+    }
+
+}

--- a/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -1,0 +1,415 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.impl;
+
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
+import org.wildfly.security.auth.callback.AvailableRealmsCallback;
+import org.wildfly.security.auth.callback.CredentialCallback;
+import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
+import org.wildfly.security.auth.callback.IdentityCredentialCallback;
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpExchangeSpi;
+import org.wildfly.security.http.HttpScope;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.HttpServerMechanismsResponder;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.http.HttpServerResponse;
+import org.wildfly.security.http.Scope;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.sasl.test.BaseTestCase;
+
+import javax.net.ssl.SSLSession;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wildfly.security.http.HttpConstants.AUTHENTICATION_INFO;
+import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
+import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
+
+public class AbstractBaseHttpTest extends BaseTestCase {
+
+    protected HttpServerAuthenticationMechanismFactory mechanismFactory = new ServerMechanismFactoryImpl();
+
+    protected void mockDigestNonce(final String nonce){
+        new MockUp<NonceManager>(){
+            @Mock
+            String generateNonce(byte[] salt) {
+                return nonce;
+            }
+            @Mock
+            boolean useNonce(final String nonce, byte[] salt, int nonceCount) {
+                return true;
+            }
+        };
+    }
+
+    protected enum Status {
+        NO_AUTH,
+        IN_PROGRESS,
+        BAD_REQUEST,
+        COMPLETE,
+        FAILED;
+    }
+
+    protected class TestingHttpServerRequest implements HttpServerRequest {
+
+        private String[] authorization;
+        private Status result;
+        private HttpServerMechanismsResponder responder;
+
+        public TestingHttpServerRequest(String[] authorization) {
+            this.authorization = authorization;
+        }
+
+        public Status getResult() {
+            return result;
+        }
+
+        public TestingHttpServerResponse getResponse() throws HttpAuthenticationException {
+            TestingHttpServerResponse response = new TestingHttpServerResponse();
+            responder.sendResponse(response);
+            return response;
+        }
+
+        public List<String> getRequestHeaderValues(String headerName) {
+            if (AUTHORIZATION.equals(headerName)) {
+                return authorization == null ? null : Arrays.asList(authorization);
+            }
+            return null;
+        }
+
+        public String getFirstRequestHeaderValue(String headerName) {
+            throw new IllegalStateException();
+        }
+
+        public SSLSession getSSLSession() {
+            throw new IllegalStateException();
+        }
+
+        public Certificate[] getPeerCertificates() {
+            throw new IllegalStateException();
+        }
+
+        public void noAuthenticationInProgress(HttpServerMechanismsResponder responder) {
+            result = Status.NO_AUTH;
+            this.responder = responder;
+        }
+
+        public void authenticationInProgress(HttpServerMechanismsResponder responder) {
+            result = Status.IN_PROGRESS;
+            this.responder = responder;
+        }
+
+        public void authenticationComplete(HttpServerMechanismsResponder responder) {
+            result = Status.COMPLETE;
+            this.responder = responder;
+        }
+
+        public void authenticationComplete(HttpServerMechanismsResponder responder, Runnable logoutHandler) {
+            throw new IllegalStateException();
+        }
+
+        public void authenticationFailed(String message, HttpServerMechanismsResponder responder) {
+            result = Status.FAILED;
+            this.responder = responder;
+        }
+
+        public void badRequest(HttpAuthenticationException failure, HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        public String getRequestMethod() {
+            return "GET";
+        }
+
+        public URI getRequestURI() {
+            throw new IllegalStateException();
+        }
+
+        public String getRequestPath() {
+            throw new IllegalStateException();
+        }
+
+        public Map<String, List<String>> getParameters() {
+            throw new IllegalStateException();
+        }
+
+        public Set<String> getParameterNames() {
+            throw new IllegalStateException();
+        }
+
+        public List<String> getParameterValues(String name) {
+            throw new IllegalStateException();
+        }
+
+        public String getFirstParameterValue(String name) {
+            throw new IllegalStateException();
+        }
+
+        public List<HttpServerCookie> getCookies() {
+            throw new IllegalStateException();
+        }
+
+        public InputStream getInputStream() {
+            throw new IllegalStateException();
+        }
+
+        public InetSocketAddress getSourceAddress() {
+            throw new IllegalStateException();
+        }
+
+        public boolean suspendRequest() {
+            throw new IllegalStateException();
+        }
+
+        public boolean resumeRequest() {
+            throw new IllegalStateException();
+        }
+
+        public HttpScope getScope(Scope scope) {
+            throw new IllegalStateException();
+        }
+
+        public Collection<String> getScopeIds(Scope scope) {
+            throw new IllegalStateException();
+        }
+
+        public HttpScope getScope(Scope scope, String id) {
+            throw new IllegalStateException();
+        }
+    }
+
+    protected class TestingHttpServerResponse implements HttpServerResponse {
+
+        private int statusCode;
+        private String authenticate;
+
+        public void setStatusCode(int statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        public void addResponseHeader(String headerName, String headerValue) {
+            if (WWW_AUTHENTICATE.equals(headerName)) {
+                authenticate = headerValue;
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+
+        public String getAuthenticateHeader() {
+            return authenticate;
+        }
+
+        public void setResponseCookie(HttpServerCookie cookie) {
+            throw new IllegalStateException();
+        }
+
+        public OutputStream getOutputStream() {
+            throw new IllegalStateException();
+        }
+
+        public boolean forward(String path) {
+            throw new IllegalStateException();
+        }
+    }
+
+    protected CallbackHandler getCallbackHandler(String username, String realm, String password) {
+        return callbacks -> {
+            for(Callback callback : callbacks) {
+                if (callback instanceof AvailableRealmsCallback) {
+                    ((AvailableRealmsCallback) callback).setRealmNames(realm);
+                } else if (callback instanceof RealmCallback) {
+                    Assert.assertEquals(realm, ((RealmCallback) callback).getDefaultText());
+                } else if (callback instanceof NameCallback) {
+                    Assert.assertEquals(username, ((NameCallback) callback).getDefaultName());
+                } else if (callback instanceof CredentialCallback) {
+                    if (!ClearPassword.ALGORITHM_CLEAR.equals(((CredentialCallback) callback).getAlgorithm())) {
+                        throw new UnsupportedCallbackException(callback);
+                    }
+                    try {
+                        PasswordFactory factory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+                        Password pass = factory.generatePassword(new ClearPasswordSpec(password.toCharArray()));
+                        ((CredentialCallback) callback).setCredential(new PasswordCredential(pass));
+                    } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                        throw new IllegalStateException(e);
+                    }
+                } else if (callback instanceof EvidenceVerifyCallback) {
+                    PasswordGuessEvidence evidence = (PasswordGuessEvidence) ((EvidenceVerifyCallback) callback).getEvidence();
+                    ((EvidenceVerifyCallback) callback).setVerified(Arrays.equals(evidence.getGuess(), password.toCharArray()));
+                } else if (callback instanceof AuthenticationCompleteCallback) {
+                    // NO-OP
+                } else if (callback instanceof IdentityCredentialCallback) {
+                    // NO-OP
+                } else if (callback instanceof AuthorizeCallback) {
+                    Assert.assertEquals(username, ((AuthorizeCallback) callback).getAuthenticationID());
+                    Assert.assertEquals(username, ((AuthorizeCallback) callback).getAuthorizationID());
+                    ((AuthorizeCallback) callback).setAuthorized(true);
+                } else {
+                    throw new UnsupportedCallbackException(callback);
+                }
+            }
+        };
+    }
+
+    public class TestingHttpExchangeSpi implements HttpExchangeSpi {
+
+        private List<String> requestAuthorizationHeaders = Collections.emptyList();
+        private List<String> responseAuthenticateHeaders = new LinkedList<>();
+        private List<String> responseAuthenticationInfoHeaders = new LinkedList<>();
+        private int statusCode;
+        private Status result;
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        public Status getResult() {
+            return result;
+        }
+
+        public List<String> getResponseAuthenticateHeaders() {
+            return responseAuthenticateHeaders;
+        }
+
+        public List<String> getResponseAuthenticationInfoHeaders() {
+            return responseAuthenticationInfoHeaders;
+        }
+
+        public void setRequestAuthorizationHeaders(List<String> requestAuthorizationHeaders) {
+            this.requestAuthorizationHeaders = requestAuthorizationHeaders;
+        }
+
+        // ------
+
+        public List<String> getRequestHeaderValues(String headerName) {
+            if (AUTHORIZATION.equals(headerName)) {
+                return requestAuthorizationHeaders;
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+
+        public void addResponseHeader(String headerName, String headerValue) {
+            if (WWW_AUTHENTICATE.equals(headerName)) {
+                responseAuthenticateHeaders.add(headerValue);
+            } else if (AUTHENTICATION_INFO.equals(headerName)) {
+                responseAuthenticationInfoHeaders.add(headerValue);
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+
+        public void setStatusCode(int statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public void authenticationComplete(SecurityIdentity securityIdentity, String mechanismName) {
+            result = Status.COMPLETE;
+        }
+
+        public void authenticationFailed(String message, String mechanismName) {
+            result = Status.FAILED;
+        }
+
+        public void badRequest(HttpAuthenticationException error, String mechanismName) {
+            result = Status.BAD_REQUEST;
+        }
+
+        public String getRequestMethod() {
+            return "GET";
+        }
+
+        public URI getRequestURI() {
+            throw new IllegalStateException();
+        }
+
+        public String getRequestPath() {
+            throw new IllegalStateException();
+        }
+
+        public Map<String, List<String>> getRequestParameters() {
+            throw new IllegalStateException();
+        }
+
+        public List<HttpServerCookie> getCookies() {
+            throw new IllegalStateException();
+        }
+
+        public InputStream getRequestInputStream() {
+            throw new IllegalStateException();
+        }
+
+        public InetSocketAddress getSourceAddress() {
+            throw new IllegalStateException();
+        }
+
+        public void setResponseCookie(HttpServerCookie cookie) {
+            throw new IllegalStateException();
+        }
+
+        public OutputStream getResponseOutputStream() {
+            throw new IllegalStateException();
+        }
+
+        public HttpScope getScope(Scope scope) {
+            throw new IllegalStateException();
+        }
+
+        public Collection<String> getScopeIds(Scope scope) {
+            throw new IllegalStateException();
+        }
+
+        public HttpScope getScope(Scope scope, String id) {
+            throw new IllegalStateException();
+        }
+    }
+
+}


### PR DESCRIPTION
* correct digest response calculation for specified qop=auth
* added custom hashing algorithm support  (more algorithms in one mechanism instance not supported)
* covered by compatibility test against RFC examples
* NonceManager made public to allow mocking (stays in private part of elytron module - impl package)

https://issues.jboss.org/browse/ELY-1369
https://issues.jboss.org/browse/JBEAP-10920