### PR TITLE
[ELY-1373] SPNEGO - sending bare challenge on not established gssContext

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
@@ -263,7 +263,7 @@ public class SpnegoAuthenticationMechanism implements HttpServerAuthenticationMe
             } else {
                 log.trace("GSSContext establishing - unable to hold GSSContext so continuation will not be possible");
                 handleCallback(AuthenticationCompleteCallback.FAILED);
-                request.authenticationFailed(log.authenticationFailed(SPNEGO_NAME));
+                request.authenticationFailed(log.authenticationFailed(SPNEGO_NAME), this::sendBareChallenge);
                 return;
             }
         }


### PR DESCRIPTION
To be consistent, bare challenge should be sent on not established gssContext too.
(invalid ticket is considered to be reason to not consider gssContext established on IBM, but not on Oracle)

https://issues.jboss.org/browse/ELY-1373
https://issues.jboss.org/browse/JBEAP-12868