### PR TITLE
[ELY-1380] getNegotiatedProperty exception when not complete

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/anonymous/AnonymousSaslClient.java
@@ -94,6 +94,7 @@ public final class AnonymousSaslClient extends AbstractSaslClient {
     }
 
     public Object getNegotiatedProperty(final String propName) {
+        assertComplete();
         // Our principal is always anonymous, even if an authz name was requested.
         return WildFlySasl.PRINCIPAL.equals(propName) ? AnonymousPrincipal.getInstance() : super.getNegotiatedProperty(propName);
     }

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslClient.java
@@ -79,7 +79,11 @@ final class ExternalSaslClient implements SaslClient, SaslWrapper {
     }
 
     public Object getNegotiatedProperty(final String propName) {
-        return null;
+        if (complete) {
+            return null;
+        } else {
+            throw log.mechAuthenticationNotComplete(getMechanismName());
+        }
     }
 
     public void dispose() throws SaslException {

--- a/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/external/ExternalSaslServer.java
@@ -109,7 +109,11 @@ final class ExternalSaslServer implements SaslServer {
     }
 
     public Object getNegotiatedProperty(final String propName) {
-        return null;
+        if (complete) {
+            return null;
+        } else {
+            throw log.mechAuthenticationNotComplete(getMechanismName());
+        }
     }
 
     public void dispose() throws SaslException {

--- a/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
+++ b/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
@@ -120,7 +120,11 @@ class PlainSaslClient implements SaslClient, SaslWrapper {
     }
 
     public Object getNegotiatedProperty(final String propName) {
-        return null;
+        if (complete) {
+            return null;
+        } else {
+            throw log.mechAuthenticationNotComplete(getMechanismName());
+        }
     }
 
     public void dispose() throws SaslException {

--- a/src/main/java/org/wildfly/security/sasl/plain/PlainSaslServer.java
+++ b/src/main/java/org/wildfly/security/sasl/plain/PlainSaslServer.java
@@ -61,7 +61,7 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
 
     @Override
     public String getAuthorizationID() {
-        if (! isComplete()) {
+        if (! complete) {
             throw log.mechAuthenticationNotComplete(getMechanismName());
         }
         return authorizedId;
@@ -178,6 +178,9 @@ final class PlainSaslServer implements SaslServer, SaslWrapper {
 
     @Override
     public Object getNegotiatedProperty(final String propName) {
+        if (! complete) {
+            throw log.mechAuthenticationNotComplete(getMechanismName());
+        }
         return null;
     }
 

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractSaslParticipant.java
@@ -269,6 +269,7 @@ public abstract class AbstractSaslParticipant implements SaslWrapper {
      * @return the property value or {@code null} if not defined
      */
     public Object getNegotiatedProperty(final String propName) {
+        assertComplete();
         return null;
     }
 

--- a/src/main/java/org/wildfly/security/sasl/util/LocalPrincipalSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/LocalPrincipalSaslClientFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
@@ -133,6 +135,9 @@ public final class LocalPrincipalSaslClientFactory extends AbstractDelegatingSas
         }
 
         public Object getNegotiatedProperty(final String propName) {
+            if (! isComplete()) {
+                throw log.mechAuthenticationNotComplete(getMechanismName());
+            }
             // The mechanism might be smart enough to know its principal; if so, use their value instead of our guess.
             final Object value = super.getNegotiatedProperty(propName);
             return value == null && WildFlySasl.PRINCIPAL.equals(propName) ? principalSupplier.get() : value;

--- a/src/main/java/org/wildfly/security/sasl/util/SecurityIdentitySaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/SecurityIdentitySaslServerFactory.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.sasl.util;
 
+import static org.wildfly.security._private.ElytronMessages.log;
+
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -65,6 +67,9 @@ public final class SecurityIdentitySaslServerFactory extends AbstractDelegatingS
             }
 
             public Object getNegotiatedProperty(final String propName) {
+                if (! isComplete()) {
+                    throw log.mechAuthenticationNotComplete(getMechanismName());
+                }
                 return propName.equals(WildFlySasl.SECURITY_IDENTITY) ? securityIdentity : super.getNegotiatedProperty(propName);
             }
 


### PR DESCRIPTION
SaslServer/SaslClient.getNegotiatedProperty should by contract throw illegal state exception when calling before negotiation is complete.

https://issues.jboss.org/browse/ELY-1380
https://issues.jboss.org/browse/JBEAP-13265