### PR TITLE
[ELY-1404] Fixed ClassCastException getting SASL property com.sun.security.sasl.digest.utf8

### DIFF
--- a/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestClientFactory.java
@@ -68,8 +68,8 @@ public class DigestClientFactory extends AbstractDigestFactory implements SaslCl
         String selectedMech = select(mechanisms);
         if (selectedMech == null) return null;
 
-        Boolean utf8 = (Boolean)props.get(WildFlySasl.USE_UTF8);
-        Charset charset = (utf8==null || utf8.booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
+        final String utf8 = (String)props.get(WildFlySasl.USE_UTF8);
+        Charset charset = (utf8 == null || Boolean.valueOf(utf8).booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
 
         String qopsString = (String)props.get(Sasl.QOP);
         String[] qops = qopsString==null ? null : qopsString.split(",");

--- a/src/main/java/org/wildfly/security/sasl/digest/DigestServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/digest/DigestServerFactory.java
@@ -94,8 +94,8 @@ public class DigestServerFactory extends AbstractDigestFactory implements SaslSe
             defaultRealm = false;
         }
 
-        Boolean utf8 = (Boolean)props.get(WildFlySasl.USE_UTF8);
-        Charset charset = (utf8==null || utf8.booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
+        final String utf8 = (String)props.get(WildFlySasl.USE_UTF8);
+        Charset charset = (utf8 == null || Boolean.valueOf(utf8).booleanValue()) ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
 
         String qopsString = (String)props.get(Sasl.QOP);
         String[] qops = qopsString==null ? null : qopsString.split(",");


### PR DESCRIPTION
If com.sun.security.sasl.digest.utf8 is used, a class cast exception is thrown. This patch fixes this problem.

Issue: https://issues.jboss.org/browse/ELY-1404
JBEAP issue: https://issues.jboss.org/browse/JBEAP-13356