### PR TITLE
[ELY-1418] CLIENT_CERT without certificates in security realm

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -46,7 +46,9 @@ public class HttpConstants {
     private static final String CONFIG_BASE = HttpConstants.class.getPackage().getName();
     public static final String CONFIG_CONTEXT_PATH = CONFIG_BASE + ".context-path";
     public static final String CONFIG_REALM = CONFIG_BASE + ".realm";
+
     public static final String CONFIG_VALIDATE_DIGEST_URI = CONFIG_BASE + ".validate-digest-uri";
+    public static final String CONFIG_SKIP_CERTIFICATE_VERIFICATION = CONFIG_BASE + ".skip-certificate-verification";
 
     /**
      * The context relative path of the login page.

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -24,6 +24,7 @@ import static org.wildfly.security.http.HttpConstants.BEARER_TOKEN;
 import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
 import static org.wildfly.security.http.HttpConstants.CONFIG_CONTEXT_PATH;
 import static org.wildfly.security.http.HttpConstants.CONFIG_REALM;
+import static org.wildfly.security.http.HttpConstants.CONFIG_SKIP_CERTIFICATE_VERIFICATION;
 import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
 import static org.wildfly.security.http.HttpConstants.DIGEST_SHA256_NAME;
 import static org.wildfly.security.http.HttpConstants.DIGEST_SHA512_256_NAME;
@@ -108,7 +109,7 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
             case BASIC_NAME:
                 return new BasicAuthenticationMechanism(callbackHandler, (String) properties.get(CONFIG_REALM), false);
             case CLIENT_CERT_NAME:
-                return new ClientCertAuthenticationMechanism(callbackHandler);
+                return new ClientCertAuthenticationMechanism(callbackHandler, Boolean.parseBoolean((String) properties.get(CONFIG_SKIP_CERTIFICATE_VERIFICATION)));
             case DIGEST_NAME:
                 return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), DIGEST_NAME, MD5, providers, (String) properties.get(HttpConstants.CONFIG_VALIDATE_DIGEST_URI));
             case DIGEST_SHA256_NAME:


### PR DESCRIPTION
Added possibility to skip X509Evidence verification against realm - the mechanism check only the presence of the evidence (which also mean validity against SSL truststore) in such case.

https://issues.jboss.org/browse/ELY-1418
https://issues.jboss.org/browse/JBEAP-12417

Usage described in blogspot: https://hkalina.github.io/2017/10/18/client-cert/