### PR TITLE
[ELY-1406] GSSCredential lastFailTime volatile

### DIFF
--- a/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
@@ -131,7 +131,7 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
         private boolean debug;
         private boolean wrapGssCredential;
         private boolean checkKeyTab;
-        private long lastFailTime = 0;
+        private volatile long lastFailTime = 0;
         private long failCache = 0;
         private Map<String, Object> options;
 


### PR DESCRIPTION
Fixed problem noticed by @mchoma in https://github.com/wildfly-security/wildfly-elytron/pull/1013#discussion_r147129398

Time of last fail, which is long, should be volatile.