### PR TITLE
[ELY-1422] SASL Scram+GS2 - posibility to not force channel binding

### DIFF
--- a/src/main/java/org/wildfly/security/mechanism/scram/ScramServer.java
+++ b/src/main/java/org/wildfly/security/mechanism/scram/ScramServer.java
@@ -99,7 +99,7 @@ public final class ScramServer {
                 bindingType = null;
                 bindingData = null;
             }
-            if (cbindFlag == 'p') {
+            if (cbindFlag == 'p') { // channel binding used
                 if (! mechanism.isPlus()) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotSupported(), ScramServerErrorCode.SERVER_DOES_NOT_SUPPORT_CHANNEL_BINDING);
                 }
@@ -113,7 +113,7 @@ public final class ScramServer {
                     throw new ScramServerException(saslScram.mechChannelBindingTypeMismatch(), ScramServerErrorCode.UNSUPPORTED_CHANNEL_BINDING_TYPE);
                 }
                 binding = true;
-            } else if (cbindFlag == 'y') {
+            } else if (cbindFlag == 'y') { // client believes server does not support channel binding
                 if (mechanism.isPlus()) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
@@ -121,11 +121,8 @@ public final class ScramServer {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
                 binding = true;
-            } else if (cbindFlag == 'n') {
+            } else if (cbindFlag == 'n') { // client does not support channel binding
                 if (mechanism.isPlus()) {
-                    throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
-                }
-                if (bindingType != null || bindingData != null) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
                 binding = false;
@@ -257,7 +254,7 @@ public final class ScramServer {
             final String bindingType = initialResponse.getBindingType();
             final byte[] bindingData = initialResponse.getRawBindingData();
             final boolean binding = initialResponse.isBinding();
-            if (cbindFlag == 'p') {
+            if (cbindFlag == 'p') { // channel binding used
                 if (! binding) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotSupported(), ScramServerErrorCode.CHANNEL_BINDING_NOT_SUPPORTED);
                 }
@@ -270,14 +267,14 @@ public final class ScramServer {
                 if (! bindingType.equals(ibi.delimitedBy(',').asUtf8String().drainToString())) {
                     throw new ScramServerException(saslScram.mechChannelBindingTypeMismatch(), ScramServerErrorCode.UNSUPPORTED_CHANNEL_BINDING_TYPE);
                 }
-            } else if (cbindFlag == 'y') {
+            } else if (cbindFlag == 'y') { // client believes server does not support channel binding
                 if (mechanism.isPlus()) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
                 if (bindingType != null || bindingData != null) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
-            } else if (cbindFlag == 'n') {
+            } else if (cbindFlag == 'n') { // client does not support channel binding
                 if (binding) {
                     throw new ScramServerException(saslScram.mechChannelBindingNotProvided(), ScramServerErrorCode.SERVER_DOES_SUPPORT_CHANNEL_BINDING);
                 }
@@ -312,7 +309,7 @@ public final class ScramServer {
             }
 
             // channel binding data
-            if (bindingData != null && ! ibi.contentEquals(ByteIterator.ofBytes(bindingData))) {
+            if (binding && bindingData != null && ! ibi.contentEquals(ByteIterator.ofBytes(bindingData))) {
                 throw new ScramServerException(saslScram.mechChannelBindingChanged(), ScramServerErrorCode.CHANNEL_BINDINGS_DONT_MATCH);
             }
 

--- a/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
+++ b/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
@@ -82,10 +82,17 @@ public final class WildFlySasl {
 
     /**
      * A flag indicating that a mechanism which supports channel binding is required.  A value of "true" indicates that
-     * channel binding is required; any other value (or lack of this property) indicates that channel binding is not
-     * required.
+     * channel binding is required and all non-PLUS SCRAM and GS2 SASL mechanisms should be disabled; any other value
+     * (or lack of this property) indicates that channel binding is not required.
      */
     public static final String CHANNEL_BINDING_REQUIRED = "wildfly.sasl.channel-binding-required";
+
+    /**
+     * A flag allowing to use non-PLUS SCRAM mechanism even when channel binding is available (authenticating over SSL)
+     * and PLUS mechanisms are supported by server. A value of "true" indicates that PLUS SCRAM and GS2 mechanisms
+     * should be disabled; any other value (or lack of this property) indicates that channel binding can be used.
+     */
+    public static final String CHANNEL_BINDING_UNSUPPORTED = "wildfly.sasl.channel-binding-unsupported";
 
     /**
      * A flag indicating that all possible supported mechanism names should be returned, regardless of the presence

--- a/src/main/java/org/wildfly/security/sasl/gs2/Gs2Util.java
+++ b/src/main/java/org/wildfly/security/sasl/gs2/Gs2Util.java
@@ -33,7 +33,7 @@ import org.wildfly.security.util.ByteStringBuilder;
  */
 class Gs2Util {
 
-    public static final int TOKEN_HEADER_TAG = 0x60;
+    static final int TOKEN_HEADER_TAG = 0x60;
 
     /**
      * Get the array of supported SASL mechanism names that corresponds to the given array of GSS-API
@@ -44,7 +44,7 @@ class Gs2Util {
      * mechanism object identifiers
      * @throws GSSException if an error occurs while mapping the GSS-API object identifiers to SASL names
      */
-    public static String[] getSupportedSaslNamesForMechanisms(Oid[] mechanismOids) throws GSSException {
+    static String[] getSupportedSaslNamesForMechanisms(Oid[] mechanismOids) throws GSSException {
         if (mechanismOids == null) {
             return WildFlySasl.NO_NAMES;
         }
@@ -72,7 +72,7 @@ class Gs2Util {
      * @return {@code true} if the given name is among the given mechanism names and
      * {@code false} otherwise
      */
-    public static boolean isIncluded(String name, String[] mechanisms) {
+    static boolean isIncluded(String name, String[] mechanisms) {
         if ((name == null) || (mechanisms == null)) {
             return false;
         }
@@ -84,10 +84,20 @@ class Gs2Util {
         return false;
     }
 
-    public static String[] getPlusMechanisms(String[] mechanisms) {
+    static String[] getPlusMechanisms(String[] mechanisms) {
         ArrayList<String> plusMechanisms = new ArrayList<String>();
         for (String mechanism : mechanisms) {
             if (mechanism.endsWith(PLUS_SUFFIX)) {
+                plusMechanisms.add(mechanism);
+            }
+        }
+        return plusMechanisms.toArray(new String[plusMechanisms.size()]);
+    }
+
+    static String[] getNonPlusMechanisms(String[] mechanisms) {
+        ArrayList<String> plusMechanisms = new ArrayList<String>();
+        for (String mechanism : mechanisms) {
+            if (! mechanism.endsWith(PLUS_SUFFIX)) {
                 plusMechanisms.add(mechanism);
             }
         }
@@ -103,7 +113,7 @@ class Gs2Util {
      * @param bindingData the channel binding data
      * @return the {@code ChannelBinding}
      */
-    public static ChannelBinding createChannelBinding(byte[] header, boolean gs2CbFlagPUsed, byte[] bindingData) {
+    static ChannelBinding createChannelBinding(byte[] header, boolean gs2CbFlagPUsed, byte[] bindingData) {
         ByteStringBuilder appData = new ByteStringBuilder(header);
         if (gs2CbFlagPUsed) {
             appData.append(bindingData);

--- a/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/scram/ScramSaslClientFactory.java
@@ -62,20 +62,28 @@ public final class ScramSaslClientFactory implements SaslClientFactory {
     public SaslClient createSaslClient(final String[] mechanisms, final String authorizationId, final String protocol, final String serverName, Map<String, ?> props, final CallbackHandler cbh) throws SaslException {
         Assert.checkNotNullParam("cbh", cbh);
         if (props == null) props = Collections.emptyMap();
-        final ChannelBindingCallback callback = new ChannelBindingCallback();
-        try {
-            cbh.handle(new Callback[] { callback });
-        } catch (SaslException e) {
-            throw e;
-        } catch (IOException e) {
-            throw saslScram.mechFailedToDetermineChannelBindingStatus(e).toSaslException();
-        } catch (UnsupportedCallbackException e) {
-            // ignored
-        }
-        final String bindingType = callback.getBindingType();
-        final byte[] bindingData = callback.getBindingData();
-        boolean bindingOk = bindingType != null && bindingData != null;
+
         boolean bindingRequired = "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED));
+        boolean bindingUnsupported = "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_UNSUPPORTED));
+
+        ChannelBindingCallback callback = null;
+        boolean bindingOk = false;
+        if (! bindingUnsupported) {
+            callback = new ChannelBindingCallback();
+            try {
+                cbh.handle(new Callback[] { callback });
+            } catch (SaslException e) {
+                throw e;
+            } catch (IOException e) {
+                throw saslScram.mechFailedToDetermineChannelBindingStatus(e).toSaslException();
+            } catch (UnsupportedCallbackException e) {
+                // ignored
+            }
+            final String bindingType = callback.getBindingType();
+            final byte[] bindingData = callback.getBindingData();
+            bindingOk = bindingType != null && bindingData != null;
+        }
+
         int minimumIterationCount = ScramUtil.getIntProperty(props, WildFlySasl.SCRAM_MIN_ITERATION_COUNT, 4096);
         int maximumIterationCount = ScramUtil.getIntProperty(props, WildFlySasl.SCRAM_MAX_ITERATION_COUNT, 32768);
         try {
@@ -130,15 +138,28 @@ public final class ScramSaslClientFactory implements SaslClientFactory {
     }
 
     public String[] getMechanismNames(final Map<String, ?> props) {
-        if (props != null && !"true".equals(props.get(WildFlySasl.MECHANISM_QUERY_ALL)) && "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
-            return new String[] {
-                SaslMechanismInformation.Names.SCRAM_SHA_512_PLUS,
-                SaslMechanismInformation.Names.SCRAM_SHA_384_PLUS,
-                SaslMechanismInformation.Names.SCRAM_SHA_256_PLUS,
-                SaslMechanismInformation.Names.SCRAM_SHA_1_PLUS
-            };
-        } else {
-            return new String[] {
+        if (props != null && !"true".equals(props.get(WildFlySasl.MECHANISM_QUERY_ALL))) {
+            if ("true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED)) && "true".equals(props.get(WildFlySasl.CHANNEL_BINDING_UNSUPPORTED))) {
+                return WildFlySasl.NO_NAMES;
+            }
+            if ("true".equals(props.get(WildFlySasl.CHANNEL_BINDING_REQUIRED))) {
+                return new String[] {
+                        SaslMechanismInformation.Names.SCRAM_SHA_512_PLUS,
+                        SaslMechanismInformation.Names.SCRAM_SHA_384_PLUS,
+                        SaslMechanismInformation.Names.SCRAM_SHA_256_PLUS,
+                        SaslMechanismInformation.Names.SCRAM_SHA_1_PLUS
+                };
+            }
+            if ("true".equals(props.get(WildFlySasl.CHANNEL_BINDING_UNSUPPORTED))) {
+                return new String[] {
+                        SaslMechanismInformation.Names.SCRAM_SHA_512,
+                        SaslMechanismInformation.Names.SCRAM_SHA_384,
+                        SaslMechanismInformation.Names.SCRAM_SHA_256,
+                        SaslMechanismInformation.Names.SCRAM_SHA_1
+                };
+            }
+        }
+        return new String[] {
                 SaslMechanismInformation.Names.SCRAM_SHA_512_PLUS,
                 SaslMechanismInformation.Names.SCRAM_SHA_384_PLUS,
                 SaslMechanismInformation.Names.SCRAM_SHA_256_PLUS,
@@ -147,7 +168,6 @@ public final class ScramSaslClientFactory implements SaslClientFactory {
                 SaslMechanismInformation.Names.SCRAM_SHA_384,
                 SaslMechanismInformation.Names.SCRAM_SHA_256,
                 SaslMechanismInformation.Names.SCRAM_SHA_1
-            };
-        }
+        };
     }
 }


### PR DESCRIPTION
Added SASL property for Scram and GS2 allowing to use non-PLUS variant of mechanism
event when binding data are present - for situations when PLUS variant is disabled by mechanism selector, but without this property client thinks non-PLUS variant was chosen because PLUS is not supported by server - and when tell it to the server, server kills connection as downgrade attack, because it supports PLUS.

The same property is needed on server side when PLUS is disabled on server.

https://issues.jboss.org/browse/ELY-1422
https://issues.jboss.org/browse/JBEAP-12894