### PR TITLE
[ELY-1398] Add support for public API compatibility check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,9 @@
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
         <modular.jdk.args/>
         <modular.jdk.props/>
+        <!-- method signature check -->
+        <!-- omitted org.wildfly.security.auth.server.event - breaks generation -->
+        <public.packages>org.wildfly.security,org.wildfly.security.auth,org.wildfly.security.auth.callback,org.wildfly.security.auth.client,org.wildfly.security.auth.permission,org.wildfly.security.auth.principal,org.wildfly.security.auth.server,org.wildfly.security.auth.util,org.wildfly.security.authz,org.wildfly.security.credential,org.wildfly.security.credential.source,org.wildfly.security.credential.store,org.wildfly.security.evidence,org.wildfly.security.http,org.wildfly.security.key,org.wildfly.security.manager,org.wildfly.security.manager.action,org.wildfly.security.mechanism,org.wildfly.security.password,org.wildfly.security.password.interfaces,org.wildfly.security.password.spec,org.wildfly.security.permission,org.wildfly.security.sasl.util,org.wildfly.security.ssl</public.packages>
     </properties>
 
     <build>
@@ -471,6 +474,51 @@
                 <modular.jdk.props>-Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <version.org.jboss.logging.tools>2.1.0.Beta1</version.org.jboss.logging.tools>
             </properties>
+        </profile>
+        <profile>
+            <id>methodSignatureGenerate</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <packages>${public.packages}</packages>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>methodSignatureCheck</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <packages>${public.packages}</packages>
+                            <releaseVersion>1.1.8.Final</releaseVersion>
+                        </configuration>
+                    </plugin>
+                </plugins>
+             </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1398

Using SigTest tool [1] two profiles were created
1. to generate method signature file *.sigfile into local maven
repository
2. and check against specified version releasedVersion

Usage:
mvn install -PmethodSignatureGenerate -DskipTests
mvn install -PmethodSignatureCheck -DskipTests

This expects during Elytron release process *.sigfile from local maven
repository will be deployed into central maven repository.

[1] http://wiki.netbeans.org/SigTest