### PR TITLE
[ELY-728] SimpleMapBackedSecurityRealm.setPasswordMap to setIdentityMap

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/SimpleMapBackedSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/SimpleMapBackedSecurityRealm.java
@@ -95,40 +95,54 @@ public class SimpleMapBackedSecurityRealm implements SecurityRealm {
     }
 
     /**
-     * Set the realm entry map.  Note that the entry map must <b>not</b> be modified after calling this method.
+     * Set the realm identity map.  Note that the entry map must <b>not</b> be modified after calling this method.
      * If it needs to be changed, pass in a new map that is a copy of the old map with the required changes.
      *
-     * @param map the password map
+     * @param map the identity map where key is an identity name and value is an identity entry
      */
-    public void setPasswordMap(final Map<String, SimpleRealmEntry> map) {
+    public void setIdentityMap(final Map<String, SimpleRealmEntry> map) {
         Assert.checkNotNullParam("map", map);
         this.map = map;
     }
 
     /**
-     * Set the password map to contain a single entry.
+     * Set the realm identity map.  Note that the entry map must <b>not</b> be modified after calling this method.
+     * If it needs to be changed, pass in a new map that is a copy of the old map with the required changes.
+     *
+     * @param map the identity map
+     * @deprecated Use {@link #setIdentityMap(Map)} instead.
+     */
+    @Deprecated
+    public void setPasswordMap(final Map<String, SimpleRealmEntry> map) {
+        setIdentityMap(map);
+    }
+
+    /**
+     * Set the realm identity map to contain a single entry.
      *
      * @param name the entry name
      * @param password the password
      * @param attributes the identity attributes
+     * @deprecated Use {@link #setIdentityMap(Map)} instead.
      */
+    @Deprecated
     public void setPasswordMap(final String name, final Password password, final Attributes attributes) {
-        Assert.checkNotNullParam("name", name);
-        Assert.checkNotNullParam("password", password);
-        Assert.checkNotNullParam("attributes", attributes);
-        map = Collections.singletonMap(name, new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(password)), attributes));
+        setIdentityMap(Collections.singletonMap(name, new SimpleRealmEntry(
+                Collections.singletonList(new PasswordCredential(password)),
+                attributes
+        )));
     }
 
     /**
-     * Set the password map to contain a single entry.
+     * Set the realm identity map to contain a single entry.
      *
      * @param name the entry name
      * @param password the password
+     * @deprecated Use {@link #setIdentityMap(Map)} instead.
      */
+    @Deprecated
     public void setPasswordMap(final String name, final Password password) {
-        Assert.checkNotNullParam("name", name);
-        Assert.checkNotNullParam("password", password);
-        map = Collections.singletonMap(name, new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(password))));
+        setPasswordMap(name, password, Attributes.EMPTY);
     }
 
     @Override

--- a/src/test/java/org/wildfly/security/auth/realm/cache/SecurityRealmIdentityCacheTest.java
+++ b/src/test/java/org/wildfly/security/auth/realm/cache/SecurityRealmIdentityCacheTest.java
@@ -128,7 +128,7 @@ public class SecurityRealmIdentityCacheTest {
         addUser(users, "joe", "User");
         addUser(users, "bob", "User");
 
-        realm.setPasswordMap(users);
+        realm.setIdentityMap(users);
 
         if (cache == null) {
             cache = new RealmIdentityCache() {

--- a/src/test/java/org/wildfly/security/auth/server/IdentityPropagationTest.java
+++ b/src/test/java/org/wildfly/security/auth/server/IdentityPropagationTest.java
@@ -69,13 +69,13 @@ public class IdentityPropagationTest {
         Map<String, SimpleRealmEntry> users = new HashMap<>();
         addUser(users, "joe", "User");
         addUser(users, "bob", "User");
-        realm1.setPasswordMap(users);
+        realm1.setIdentityMap(users);
 
         SimpleMapBackedSecurityRealm realm2 = new SimpleMapBackedSecurityRealm();
         users = new HashMap<>();
         addUser(users, "sam", "Manager");
         addUser(users, "bob", "Manager");
-        realm2.setPasswordMap(users);
+        realm2.setIdentityMap(users);
 
         // domain1 contains both realms
         SecurityDomain.Builder builder = SecurityDomain.builder();

--- a/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/ElytronPolicyEnforcementTest.java
@@ -88,7 +88,7 @@ public class ElytronPolicyEnforcementTest extends AbstractAuthorizationTestCase 
         addUser(users, "user-manager", "Manager");
         addUser(users, "user-user", "User");
 
-        securityRealm.setPasswordMap(users);
+        securityRealm.setIdentityMap(users);
 
         builder.addRealm("default", securityRealm).build();
         builder.setDefaultRealmName("default");

--- a/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
+++ b/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
@@ -25,12 +25,15 @@ import org.junit.Test;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.realm.SimpleRealmEntry;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.auth.server.ServerAuthenticationContext;
 import org.wildfly.security.authz.MapAttributes;
 import org.wildfly.security.authz.RoleDecoder;
 import org.wildfly.security.authz.RoleMapper;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
@@ -45,6 +48,7 @@ import java.security.ProtectionDomain;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -168,11 +172,17 @@ public class LinkPolicyConfigurationTest {
     private SecurityDomain createSecurityDomain(String userName, String... roles) throws Exception {
         SecurityDomain.Builder builder = SecurityDomain.builder();
         SimpleMapBackedSecurityRealm realm = new SimpleMapBackedSecurityRealm();
-        MapAttributes attributes = new MapAttributes();
 
+        Password password = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(new ClearPasswordSpec(userName.toCharArray()));
+
+        MapAttributes attributes = new MapAttributes();
         attributes.addAll(RoleDecoder.KEY_ROLES, Arrays.asList(roles));
 
-        realm.setPasswordMap(userName, PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR).generatePassword(new ClearPasswordSpec(userName.toCharArray())), attributes);
+
+        realm.setIdentityMap(Collections.singletonMap(userName, new SimpleRealmEntry(
+                Collections.singletonList(new PasswordCredential(password)),
+                attributes
+        )));
 
         builder.setDefaultRealmName("default");
 

--- a/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -50,6 +50,7 @@ import org.wildfly.security.auth.server.ModifiableRealmIdentity;
 import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.Password;
@@ -338,9 +339,12 @@ public class SaslServerBuilder {
             });
 
             if (passwordMap != null) {
-                mainRealm.setPasswordMap(passwordMap);
+                mainRealm.setIdentityMap(passwordMap);
             } else if (username != null) {
-                mainRealm.setPasswordMap(username, password);
+                mainRealm.setIdentityMap(Collections.singletonMap(username, new SimpleRealmEntry(
+                        Collections.singletonList(new PasswordCredential(password)),
+                        Attributes.EMPTY
+                )));
             }
         } else {
             final Path root = Paths.get(".", "target", "test-domains", String.valueOf(System.currentTimeMillis())).normalize();


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-728

- setPasswordMap(Map) renamed to setIdentityMap(Map) (original deprecated)
- as setPasswordMap(...) for single identity maps was used only in tests, I has deprecated them completely to minimize public api