### PR TITLE
[ELY-1456] Minimise hits to database from JDBC realm during authentication.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/jdbc/KeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/realm/jdbc/KeyMapper.java
@@ -65,16 +65,6 @@ public interface KeyMapper extends ColumnMapper {
         return SupportLevel.UNSUPPORTED;
     }
 
-    /**
-     * Determine whether a given credential is definitely obtainable, possibly obtainable (for some identities), or definitely not
-     * obtainable based on the given {@link ResultSet}.
-     *
-     * <p>In this case the support is defined based on the query result, usually related with a specific account.
-     *
-     * @param resultSet the result set
-     * @return the level of support for a credential based on the given result set
-     */
-    SupportLevel getCredentialSupport(ResultSet resultSet, Supplier<Provider[]> providers);
 
     Credential map(ResultSet resultSet, Supplier<Provider[]> providers) throws SQLException;
 }

--- a/src/main/java/org/wildfly/security/auth/realm/jdbc/mapper/PasswordKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/realm/jdbc/mapper/PasswordKeyMapper.java
@@ -82,21 +82,6 @@ public class PasswordKeyMapper implements KeyMapper {
     }
 
     @Override
-    public SupportLevel getCredentialSupport(ResultSet resultSet, Supplier<Provider[]> providers) {
-        try {
-            Credential map = map(resultSet, providers);
-
-            if (map != null) {
-                return SupportLevel.SUPPORTED;
-            }
-
-            return SupportLevel.UNSUPPORTED;
-        } catch (SQLException cause) {
-            throw log.couldNotObtainCredentialWithCause(cause);
-        }
-    }
-
-    @Override
     public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) {
         return PasswordCredential.class.isAssignableFrom(credentialType) ? SupportLevel.POSSIBLY_SUPPORTED : SupportLevel.UNSUPPORTED;
     }


### PR DESCRIPTION
Prior to this change a single username / password authentication attempt could result in the same JDBC query being executed three times by the database if that same query is configured to load credentials and attributes - this change reduces that down to 1.

1. All Credentials are loaded into an IdentityCredential which is subsequently used for all acquisition and validation.
2. The identity loading loop is now optimised to re-use the ResultSet instead of creating it once for attribute loading and then again for credential loading.

This does have a side effect that a single query can now load multiple credentials but that does make sense as one of the columns read specifies the algorithm.