### PR TITLE
[ELY-85] GSSAPI+SPNEGO workaround for JDK-8194073 (native Kerberos)

### DIFF
--- a/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
+++ b/src/main/java/org/wildfly/security/auth/util/GSSCredentialSecurityFactory.java
@@ -393,11 +393,11 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
             if (IS_IBM) {
                 options.put("noAddress", "true");
                 options.put("credsType", (isServer && !obtainKerberosTicket) ? "acceptor" : "both");
-                options.put("useKeytab", keyTab.toURI().toURL().toString());
+                if (keyTab != null) options.put("useKeytab", keyTab.toURI().toURL().toString());
             } else {
                 options.put("storeKey", "true");
                 options.put("useKeyTab", "true");
-                options.put("keyTab", keyTab.getAbsolutePath());
+                if (keyTab != null) options.put("keyTab", keyTab.getAbsolutePath());
                 options.put("isInitiator", (isServer && !obtainKerberosTicket) ? "false" : "true");
             }
 

--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -67,6 +67,13 @@ public class HttpConstants {
     public static final String CONFIG_GSS_MANAGER = CONFIG_BASE + ".gss-manager";
 
     /**
+     * This enables workaround for native GSS, where createName() needs to be called for correct GSSContext initialization.
+     * Set to "true" to call createName() as part of GSSContext initialization.
+     * This is workaround of JDK-8194073.
+     */
+    public static final String CONFIG_CREATE_NAME_GSS_INIT = CONFIG_BASE + ".create-name-gss-init";
+
+    /**
      * A comma separated list of scopes in preferred order the mechanism should attempt to use to persist state including the
      * caching of any previously authenticated identity.
      *

--- a/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
+++ b/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
@@ -156,5 +156,13 @@ public final class WildFlySasl {
      */
     public static final String AUTHENTICATION_TIMEOUT = "wildfly.sasl.authentication-timeout";
 
+    /**
+     * A property used to enable workaround for native GSS, where createName() needs to be called for correct GSSContext initialization.
+     * Set to "true" to call createName() as part of GSSContext initialization.
+     * This is workaround of JDK-8194073.
+     *
+     * Note: This is a server only property and is not used client side.
+     */
+    public static final String GSSAPI_CREATE_NAME_GSS_INIT = "wildfly.sasl.gssapi.server.create-name-gss-init";
 
 }

--- a/src/main/java/org/wildfly/security/sasl/gssapi/AbstractGssapiMechanism.java
+++ b/src/main/java/org/wildfly/security/sasl/gssapi/AbstractGssapiMechanism.java
@@ -28,7 +28,6 @@ import javax.security.sasl.SaslException;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.MessageProp;
-import org.ietf.jgss.Oid;
 import org.wildfly.common.Assert;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
@@ -50,17 +49,6 @@ abstract class AbstractGssapiMechanism extends AbstractSaslParticipant {
     private static final byte INTEGRITY_PROTECTION = (byte) 0x02;
     private static final byte CONFIDENTIALITY_PROTECTION = (byte) 0x04;
     protected static final int DEFAULT_MAX_BUFFER_SIZE = (int) 0xFFFFFF; // 3 bytes
-    protected static final Oid KERBEROS_V5;
-
-    // Kerberos V5 OID
-
-    static {
-        try {
-            KERBEROS_V5 = new Oid("1.2.840.113554.1.2.2");
-        } catch (GSSException e) {
-            throw saslGssapi.unableToInitialiseOid(e);
-        }
-    }
 
     protected GSSContext gssContext;
     protected final int configuredMaxReceiveBuffer;

--- a/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
+++ b/src/main/java/org/wildfly/security/sasl/gssapi/GssapiClient.java
@@ -19,6 +19,8 @@
 package org.wildfly.security.sasl.gssapi;
 
 import static org.wildfly.security._private.ElytronMessages.saslGssapi;
+import static org.wildfly.security.auth.util.GSSCredentialSecurityFactory.KERBEROS_V5;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Added workaround to make native Kerberos working with GSSAPI and SPNEGO mechanisms.
(GS2 mechanism is blocked by another not-workaroundable JDK issue too, so kept without this.)

Also allowed null keyTab in GSSCredentialFactory (when checkKeyTab = false) - set keyTab is ignored when native Kerberos is used.

https://issues.jboss.org/browse/ELY-85