### PR TITLE
[ELY-1471] Rework the WildFlyElytronProvider to be a static definition instead of a dynamically generated definition.

### DIFF
--- a/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -95,40 +95,21 @@ import static org.wildfly.security.password.interfaces.UnixMD5CryptPassword.ALGO
 import static org.wildfly.security.password.interfaces.UnixSHACryptPassword.ALGORITHM_CRYPT_SHA_256;
 import static org.wildfly.security.password.interfaces.UnixSHACryptPassword.ALGORITHM_CRYPT_SHA_512;
 
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
-import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceConfigurationError;
-import java.util.ServiceLoader;
-
-import javax.security.sasl.SaslClientFactory;
-import javax.security.sasl.SaslServerFactory;
 
 import org.kohsuke.MetaInfServices;
-import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.credential.store.impl.MapCredentialStore;
 import org.wildfly.security.credential.store.impl.VaultCredentialStore;
-import org.wildfly.security.digest.Sha512_256MessageDigest;
-import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
-import org.wildfly.security.http.impl.ServerMechanismFactoryImpl;
-import org.wildfly.security.key.RSAParameterSpiImpl;
-import org.wildfly.security.key.RawSecretKeyFactory;
-import org.wildfly.security.keystore.PasswordKeyStoreSpi;
-import org.wildfly.security.password.PasswordFactory;
-import org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl;
-import org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl;
-import org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl;
-import org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl;
-import org.wildfly.security.password.impl.PasswordFactorySpiImpl;
-import org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl;
-import org.wildfly.security.sasl.WildFlySasl;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
 
 /**
@@ -142,15 +123,15 @@ public class WildFlyElytronProvider extends Provider {
 
     private static final long serialVersionUID = 1267015094996624988L;
 
-    private static final String HTTP_SERVER_FACTORY_TYPE = HttpServerAuthenticationMechanismFactory.class.getSimpleName();
+    private static final String HTTP_SERVER_FACTORY_TYPE = "HttpServerAuthenticationMechanismFactory";
 
-    private static final String SASL_CLIENT_FACTORY_TYPE = SaslClientFactory.class.getSimpleName();
+    private static final String SASL_CLIENT_FACTORY_TYPE = "SaslClientFactory";
 
-    private static final String SASL_SERVER_FACTORY_TYPE = SaslServerFactory.class.getSimpleName();
+    private static final String SASL_SERVER_FACTORY_TYPE = "SaslServerFactory";
 
-    private static final String PASSWORD_FACTORY_TYPE = PasswordFactory.class.getSimpleName();
+    private static final String PASSWORD_FACTORY_TYPE = "PasswordFactory";
 
-    private static final String ALG_PARAMS_TYPE = AlgorithmParameters.class.getSimpleName();
+    private static final String ALG_PARAMS_TYPE = "AlgorithmParameters";
 
     /**
      * Default constructor for this security provider.
@@ -165,261 +146,294 @@ public class WildFlyElytronProvider extends Provider {
         putCredentialStoreProviderImplementations();
         putAlgorithmParametersImplementations();
         put("Alg.Alias.Data.OID.1.2.840.113549.1.7.1", "Data");
-        putService(new Service(this, "SecretKeyFactory", "1.2.840.113549.1.7.1", RawSecretKeyFactory.class.getName(), Collections.emptyList(), Collections.emptyMap()));
-        putService(new Service(this, "MessageDigest", "SHA-512-256", Sha512_256MessageDigest.class.getName(), Collections.emptyList(), Collections.emptyMap()));
+        putService(new Service(this, "SecretKeyFactory", "1.2.840.113549.1.7.1", "org.wildfly.security.key.RawSecretKeyFactory", Collections.emptyList(), Collections.emptyMap()));
+        putService(new Service(this, "MessageDigest", "SHA-512-256", "org.wildfly.security.digest.SHA512_256MessageDigest", Collections.emptyList(), Collections.emptyMap()));
     }
 
     private void putAlgorithmParametersImplementations() {
         final List<String> emptyList = Collections.emptyList();
         final Map<String, String> emptyMap = Collections.emptyMap();
 
-        putService(new Service(this, ALG_PARAMS_TYPE, "RSA", RSAParameterSpiImpl.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, "RSA", "org.wildfly.security.key.RSAParameterSpiImpl", emptyList, emptyMap));
 
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_MD5, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SUN_CRYPT_MD5, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SUN_CRYPT_MD5_BARE_SALT, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_SHA_256, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_SHA_512, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_MD5, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_256, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_384, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_512, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_512_256, DigestPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_MD5, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_MD5, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_DES, SaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_BSD_CRYPT_DES, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_BCRYPT, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_1, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_256, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_384, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_512, IteratedSaltedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_MD5, OneTimePasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA1, OneTimePasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_256, OneTimePasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_384, OneTimePasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_512, OneTimePasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_DES, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_DES_CBC_PKCS5, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_3DES, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_3DES_CBC_PKCS5, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE_CBC_PKCS5, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_40, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_40_CBC_PKCS5, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_128_CBC_PKCS5, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_40, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_40_ECB, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_128_ECB, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_128, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_256, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_256, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_256, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_256, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA1, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA224, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA256, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA384, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA512, MaskedPasswordAlgorithmParametersSpiImpl.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_MD5, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SUN_CRYPT_MD5, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SUN_CRYPT_MD5_BARE_SALT, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_SHA_256, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_SHA_512, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_MD5, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_256, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_384, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_512, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_DIGEST_SHA_512_256, "org.wildfly.security.password.impl.DigestPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_MD5, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_CRYPT_DES, "org.wildfly.security.password.impl.SaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_BSD_CRYPT_DES, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_BCRYPT, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_1, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_256, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_384, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_SCRAM_SHA_512, "org.wildfly.security.password.impl.IteratedSaltedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_MD5, "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA1, "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_256, "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_384, "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_OTP_SHA_512, "org.wildfly.security.password.impl.OneTimePasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_DES, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_DES_CBC_PKCS5, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_3DES, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_MD5_3DES_CBC_PKCS5, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE_CBC_PKCS5, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_40, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_40_CBC_PKCS5, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC2_128_CBC_PKCS5, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_40, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_40_ECB, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_SHA1_RC4_128_ECB, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_128, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_256, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_256, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_256, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_256, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA1, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA224, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA256, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA384, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
+        putService(new Service(this, ALG_PARAMS_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA512, "org.wildfly.security.password.impl.MaskedPasswordAlgorithmParametersSpiImpl", emptyList, emptyMap));
     }
 
     private void putKeyStoreImplementations() {
         final List<String> emptyList = Collections.emptyList();
         final Map<String, String> emptyMap = Collections.emptyMap();
 
-        putService(new Service(this, "KeyStore", "PasswordFile", PasswordKeyStoreSpi.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, "KeyStore", "PasswordFile", "org.wildfly.security.keystore.PasswordKeyStoreSpi", emptyList, emptyMap));
     }
 
     private void putHttpAuthenticationMechanismImplementations() {
         final List<String> emptyList = Collections.emptyList();
         final Map<String, String> emptyMap = Collections.emptyMap();
 
-        ExceptionSupplier<Object, Exception> supplier = toSupplier(ServerMechanismFactoryImpl.class);
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, BASIC_NAME, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, CLIENT_CERT_NAME, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, DIGEST_NAME, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, FORM_NAME, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, SPNEGO_NAME, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
-        putService(new SupplierService(this, HTTP_SERVER_FACTORY_TYPE, BEARER_TOKEN, ServerMechanismFactoryImpl.class.getName(), emptyList, emptyMap, supplier));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, BASIC_NAME, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, CLIENT_CERT_NAME, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, DIGEST_NAME, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, FORM_NAME, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, SPNEGO_NAME, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
+
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, BEARER_TOKEN, "org.wildfly.security.http.impl.ServerMechanismFactoryImpl", emptyList, emptyMap));
     }
 
     private void putPasswordImplementations() {
         final List<String> emptyList = Collections.emptyList();
         final Map<String, String> emptyMap = Collections.emptyMap();
 
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CLEAR, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SUN_CRYPT_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SUN_CRYPT_MD5_BARE_SALT, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_MD2, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_512_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_DES, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_BSD_CRYPT_DES, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_BCRYPT, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_MD5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_DES, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_DES_CBC_PKCS5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_3DES, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_3DES_CBC_PKCS5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE_CBC_PKCS5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_40, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_40_CBC_PKCS5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_128_CBC_PKCS5, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_40, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_40_ECB, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_128_ECB, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA256_AES_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_128, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA256_AES_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA1, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA224, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA256, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA384, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA512, PasswordFactorySpiImpl.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CLEAR, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SUN_CRYPT_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SUN_CRYPT_MD5_BARE_SALT, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_MD2, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SIMPLE_DIGEST_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_DIGEST_SHA_512_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_PASSWORD_SALT_DIGEST_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SALT_PASSWORD_DIGEST_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_CRYPT_DES, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_BSD_CRYPT_DES, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_BCRYPT, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_SCRAM_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_MD5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_OTP_SHA_512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_DES, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_DES_CBC_PKCS5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_3DES, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_MD5_3DES_CBC_PKCS5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_DES_EDE_CBC_PKCS5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_40, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_40_CBC_PKCS5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC2_128_CBC_PKCS5, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_40, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_40_ECB, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_SHA1_RC4_128_ECB, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA256_AES_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_128, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA1_AES_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA224_AES_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA256_AES_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA384_AES_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_HMAC_SHA512_AES_256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA1, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA224, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA256, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA384, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
+        putService(new Service(this, PASSWORD_FACTORY_TYPE, ALGORITHM_MASKED_PBKDF_HMAC_SHA512, "org.wildfly.security.password.impl.PasswordFactorySpiImpl", emptyList, emptyMap));
     }
 
     private void putSaslMechanismImplementations() {
-        final List<String> noAliases = Collections.emptyList();
-        final Map<String, String> noProperties = Collections.emptyMap();
-        final ClassLoader myClassLoader = WildFlyElytronProvider.class.getClassLoader();
-        final String myClassName = WildFlyElytronProvider.class.getName();
-        final String myPackageWithDot = myClassName.substring(0, myClassName.lastIndexOf('.') + 1);
-        final ServiceLoader<SaslClientFactory> clientLoader = ServiceLoader.load(SaslClientFactory.class, myClassLoader);
-        final Iterator<SaslClientFactory> clientIterator = clientLoader.iterator();
-        final Map<String, String> props = Collections.singletonMap(WildFlySasl.MECHANISM_QUERY_ALL, "true");
-        for (;;) try {
-            if (! clientIterator.hasNext()) break;
-            final SaslClientFactory factory = clientIterator.next();
-            if (factory.getClass().getClassLoader() != myClassLoader) {
-                continue;
-            }
-            final String className = factory.getClass().getName();
-            if (!className.startsWith(myPackageWithDot)) {
-                continue;
-            }
-            final String[] names = factory.getMechanismNames(props);
-            ExceptionSupplier<Object, Exception> supplier = toSupplier(factory.getClass());
-            for (String name : names) {
-                putService(new SupplierService(this, SASL_CLIENT_FACTORY_TYPE, name, className, noAliases, noProperties, supplier));
-            }
-        } catch (ServiceConfigurationError | RuntimeException ignored) {}
-        final ServiceLoader<SaslServerFactory> serverLoader = ServiceLoader.load(SaslServerFactory.class, myClassLoader);
-        final Iterator<SaslServerFactory> serverIterator = serverLoader.iterator();
-        for (;;) try {
-            if (!(serverIterator.hasNext())) break;
-            final SaslServerFactory factory = serverIterator.next();
-            if (factory.getClass().getClassLoader() != myClassLoader) {
-                continue;
-            }
-            final String className = factory.getClass().getName();
-            if (!className.startsWith(myPackageWithDot)) {
-                continue;
-            }
-            final String[] names = factory.getMechanismNames(props);
-            ExceptionSupplier<Object, Exception> supplier = toSupplier(factory.getClass());
-            for (String name : names) {
-                putService(new SupplierService(this, SASL_SERVER_FACTORY_TYPE, name, className, noAliases, noProperties, supplier));
-            }
-        } catch (ServiceConfigurationError | RuntimeException ignored) {}
-    }
+        final List<String> emptyList = Collections.emptyList();
+        final Map<String, String> emptyMap = Collections.emptyMap();
 
-    private ExceptionSupplier<Object, Exception> toSupplier(final Class<?> clazz) {
-        Constructor<?>[] constructors = clazz.getDeclaredConstructors();
-        Constructor<?> found = null;
-        for (Constructor<?> current : constructors) {
-            Class<?>[] parameterTypes = current.getParameterTypes();
-            if (parameterTypes.length == 1 && parameterTypes[0].isAssignableFrom(Provider.class)) {
-                found = current;
-                break;
-            }
-        }
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.ANONYMOUS,  "org.wildfly.security.sasl.anonymous.AnonymousServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_512,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_512_256,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_256,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_384,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_MD5,  "org.wildfly.security.sasl.digest.DigestServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_RSA_SHA1_ENC,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_RSA_SHA1_ENC,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_DSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_DSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_ECDSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_ECDSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.EXTERNAL,  "org.wildfly.security.sasl.external.ExternalSaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, "GS2-KRB5-PLUS",  "org.wildfly.security.sasl.gs2.Gs2SaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, "GS2-KRB5",  "org.wildfly.security.sasl.gs2.Gs2SaslServerFactory", emptyList, emptyMap));
 
-        if (found != null) {
-            final Constructor<?> constructor = found;
-            return () -> constructor.newInstance(WildFlyElytronProvider.this);
-        } else {
-            return clazz::newInstance;
-        }
+        //final Map<String, String> props = Collections.singletonMap(WildFlySasl.MECHANISM_QUERY_ALL, "true");
+        //SaslServerFactory gs2 = new Gs2SaslServerFactory();
+        //for (String name : gs2.getMechanismNames(props)) {
+        //    putService(new Service(this, SASL_SERVER_FACTORY_TYPE, name,  "org.wildfly.security.sasl.gs2.Gs2SaslServerFactory", emptyList, emptyMap));
+        //}
+
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.GSSAPI,  "org.wildfly.security.sasl.gssapi.GssapiServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, "JBOSS-LOCAL-USER",  "org.wildfly.security.sasl.localuser.LocalUserServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.OAUTHBEARER,  "org.wildfly.security.sasl.oauth2.OAuth2SaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.OTP,  "org.wildfly.security.sasl.otp.OTPSaslServerFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.PLAIN,  "org.wildfly.security.sasl.plain.PlainSaslServerFactory", emptyList, emptyMap));
+
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_512_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_384_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_256_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_1_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_512,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_384,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_256,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_SERVER_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_1,  "org.wildfly.security.sasl.scram.ScramSaslServerFactory", emptyList, emptyMap));
+
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.ANONYMOUS,  "org.wildfly.security.sasl.anonymous.AnonymousClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_512,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_512_256,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_256,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA_384,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_SHA,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.DIGEST_MD5,  "org.wildfly.security.sasl.digest.DigestClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_RSA_SHA1_ENC,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_RSA_SHA1_ENC,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_DSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_DSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_U_ECDSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.IEC_ISO_9798_M_ECDSA_SHA1,  "org.wildfly.security.sasl.entity.EntitySaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.EXTERNAL,  "org.wildfly.security.sasl.external.ExternalSaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, "GS2-KRB5-PLUS",  "org.wildfly.security.sasl.gs2.Gs2SaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, "GS2-KRB5",  "org.wildfly.security.sasl.gs2.Gs2SaslClientFactory", emptyList, emptyMap));
+
+        //SaslClientFactory gs2Client = new Gs2SaslClientFactory();
+        //for (String name : gs2Client.getMechanismNames(props)) {
+        //    putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, name,  "org.wildfly.security.sasl.gs2.Gs2SaslClientFactory", emptyList, emptyMap));
+        //}
+
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.GSSAPI,  "org.wildfly.security.sasl.gssapi.GssapiClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, "JBOSS-LOCAL-USER",  "org.wildfly.security.sasl.localuser.LocalUserClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.OAUTHBEARER,  "org.wildfly.security.sasl.oauth2.OAuth2SaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.OTP,  "org.wildfly.security.sasl.otp.OTPSaslClientFactory", emptyList, emptyMap));
+        putService(new Service(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.PLAIN,  "org.wildfly.security.sasl.plain.PlainSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_512_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_384_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_256_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_1_PLUS,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_512,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_384,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_256,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
+        putService(new ProviderService(this, SASL_CLIENT_FACTORY_TYPE, SaslMechanismInformation.Names.SCRAM_SHA_1,  "org.wildfly.security.sasl.scram.ScramSaslClientFactory", emptyList, emptyMap));
     }
 
     private void putCredentialStoreProviderImplementations() {
         final List<String> emptyList = Collections.emptyList();
         final Map<String, String> emptyMap = Collections.emptyMap();
-        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE, KeyStoreCredentialStore.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, VaultCredentialStore.VAULT_CREDENTIAL_STORE, VaultCredentialStore.class.getName(), emptyList, emptyMap));
-        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, MapCredentialStore.MAP_CREDENTIAL_STORE, MapCredentialStore.class.getName(), emptyList, emptyMap));
+        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE, "org.wildfly.security.credential.store.impl.KeyStoreCredentialStore", emptyList, emptyMap));
+        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, VaultCredentialStore.VAULT_CREDENTIAL_STORE, "org.wildfly.security.credential.store.impl.VaultCredentialStore", emptyList, emptyMap));
+        putService(new Service(this, CredentialStore.CREDENTIAL_STORE_TYPE, MapCredentialStore.MAP_CREDENTIAL_STORE, "org.wildfly.security.credential.store.impl.MapCredentialStore", emptyList, emptyMap));
     }
 
-    static class SupplierService extends Service {
+    class ProviderService extends Service {
 
-        private final ExceptionSupplier<Object, Exception> supplier;
+        private volatile Reference<Class<?>> implementationClassRef;
 
-        SupplierService(Provider provider, String type, String algorithm, String className, List<String> aliases, Map<String,String> attributes, ExceptionSupplier<Object, Exception> supplier) {
+        ProviderService(Provider provider, String type, String algorithm, String className, List<String> aliases, Map<String,String> attributes) {
             super(provider, type, algorithm, className, aliases, attributes);
-            this.supplier = supplier;
         }
 
         @Override
         public Object newInstance(Object constructorParameter) throws NoSuchAlgorithmException {
+            Class<?> implementationClass = getImplementationClass();
+
             try {
-                return supplier.get();
+                Constructor<?> constructor = implementationClass.getConstructor(Provider.class);
+                return constructor.newInstance(WildFlyElytronProvider.this);
             } catch (Exception e) {
                 throw log.noSuchAlgorithmCreateService(getType(), getAlgorithm(), e);
             }
+        }
+
+        private Class<?> getImplementationClass() throws NoSuchAlgorithmException {
+            Reference<Class<?>> implementationClassRef = this.implementationClassRef;
+            Class<?> implementationClass = implementationClassRef != null ? implementationClassRef.get() : null;
+            if (implementationClass == null) {
+                ClassLoader classLoader = WildFlyElytronProvider.class.getClassLoader();
+                try {
+                    implementationClass = classLoader.loadClass(getClassName());
+                } catch (ClassNotFoundException e) {
+                    throw log.noSuchAlgorithmCreateService(getType(), getAlgorithm(), e);
+                }
+                this.implementationClassRef = new WeakReference<Class<?>>(implementationClass);
+            }
+
+            return implementationClass;
         }
 
     }

--- a/src/main/java/org/wildfly/security/digest/SHA512_256MessageDigest.java
+++ b/src/main/java/org/wildfly/security/digest/SHA512_256MessageDigest.java
@@ -27,7 +27,7 @@ import java.security.MessageDigestSpi;
 /**
  * SHA-512/256 hashing implementation as defined in FIPS PUB 180-4 Secure Hash Standard
  */
-public class Sha512_256MessageDigest extends MessageDigestSpi {
+public class SHA512_256MessageDigest extends MessageDigestSpi {
 
     private static final long[] K = {
             0x428a2f98d728ae22L, 0x7137449123ef65cdL, 0xb5c0fbcfec4d3b2fL, 0xe9b5dba58189dbbcL,
@@ -57,12 +57,12 @@ public class Sha512_256MessageDigest extends MessageDigestSpi {
     private final byte[] tempByte = new byte[1];
     private final long[] H = new long[8];
     private final long[] W = new long[80];
-    private final byte[] block = new byte[Sha512_256MessageDigest.BLOCK_SIZE];
+    private final byte[] block = new byte[SHA512_256MessageDigest.BLOCK_SIZE];
 
     private long messageLength; // total length of the message
     private int bytesLoaded; // amount of used bytes in current block
 
-    public Sha512_256MessageDigest() {
+    public SHA512_256MessageDigest() {
         engineReset();
     }
 

--- a/src/main/java/org/wildfly/security/sasl/util/AbstractDelegatingSaslServerFactory.java
+++ b/src/main/java/org/wildfly/security/sasl/util/AbstractDelegatingSaslServerFactory.java
@@ -20,6 +20,8 @@ package org.wildfly.security.sasl.util;
 
 import java.util.Map;
 
+import static org.wildfly.common.Assert.checkNotNullParam;
+
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
@@ -43,7 +45,7 @@ public abstract class AbstractDelegatingSaslServerFactory implements SaslServerF
      * @param delegate the delegate server factory
      */
     protected AbstractDelegatingSaslServerFactory(final SaslServerFactory delegate) {
-        this.delegate = delegate;
+        this.delegate = checkNotNullParam("delegate", delegate);
     }
 
     /**


### PR DESCRIPTION
This drastically reduces the class loading overhead just to initialise the Provider.