### PR TITLE
[ELY-1478] Use System.lineSeparator() when generating PEM content to avoid issues on Windows

### DIFF
--- a/src/main/java/org/wildfly/security/pem/Pem.java
+++ b/src/main/java/org/wildfly/security/pem/Pem.java
@@ -199,9 +199,9 @@ public final class Pem {
         if (matcher.find()) {
             throw log.invalidPemType("<any valid PEM type>", type);
         }
-        target.append("-----BEGIN ").append(type).append("-----\n");
-        target.append(content.base64Encode().drainToString('\n', 64));
-        target.append("\n-----END ").append(type).append("-----\n");
+        target.append("-----BEGIN ").append(type).append("-----");
+        target.append(content.base64Encode().drainToString(System.lineSeparator(), 64)); // insert the line separator before every 64 code points
+        target.append(System.lineSeparator()).append("-----END ").append(type).append("-----").append(System.lineSeparator());
     }
 
     /**

--- a/src/test/java/org/wildfly/security/util/PemTest.java
+++ b/src/test/java/org/wildfly/security/util/PemTest.java
@@ -22,12 +22,15 @@ import org.junit.Test;
 import org.wildfly.security.pem.Pem;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyPairGenerator;
 import java.security.PublicKey;
+import java.security.cert.X509Certificate;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -85,4 +88,36 @@ public class PemTest {
         assertArrayEquals(publicKey.getEncoded(), parsedKey.getEncoded());
     }
 
+    @Test
+    public void testGeneratePemX509Certificate() throws Exception {
+        String expectedPemCertificate = "-----BEGIN CERTIFICATE-----" + System.lineSeparator() +
+                "MIIDjTCCAnWgAwIBAgIJANOjc2u+sqarMA0GCSqGSIb3DQEBBQUAMH0xEzARBgNV" + System.lineSeparator() +
+                "BAMMCkVseXRyb24gQ0ExEDAOBgNVBAgMB0VseXRyb24xCzAJBgNVBAYTAlVLMSIw" + System.lineSeparator() +
+                "IAYJKoZIhvcNAQkBFhNlbHl0cm9uQHdpbGRmbHkub3JnMSMwIQYDVQQKDBpSb290" + System.lineSeparator() +
+                "IENlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0xNjAxMjgxOTA3MTRaFw0yNjAxMjUx" + System.lineSeparator() +
+                "OTA3MTRaMH0xEzARBgNVBAMMCkVseXRyb24gQ0ExEDAOBgNVBAgMB0VseXRyb24x" + System.lineSeparator() +
+                "CzAJBgNVBAYTAlVLMSIwIAYJKoZIhvcNAQkBFhNlbHl0cm9uQHdpbGRmbHkub3Jn" + System.lineSeparator() +
+                "MSMwIQYDVQQKDBpSb290IENlcnRpZmljYXRlIEF1dGhvcml0eTCCASIwDQYJKoZI" + System.lineSeparator() +
+                "hvcNAQEBBQADggEPADCCAQoCggEBANid0js/NWlA8HUtysx/AWHy/u8bnifacoGO" + System.lineSeparator() +
+                "FjozbfElfSa601CATKp1eGqV0B6s179XuIj6UMwJqK6oM05eFZm353Tt7+G5C2/u" + System.lineSeparator() +
+                "gaU7HW9hMVf91Si3OK6CunK9EWj19OrUBx7eO376cwPUulCs51puTKAjezMCKbTS" + System.lineSeparator() +
+                "RJPdPwZiB/I+LqZdopa2eQgQzsJqIGf93YWjpX3UHnqObuvaieUdTIyM89LR1Vej" + System.lineSeparator() +
+                "rASdz5aWD62A5si/gl4t+1pRywDiFkQ8PWhLkm7QIoainchF2UtsSOZgG5aKqtd9" + System.lineSeparator() +
+                "c63N+3uwxMP5qSf0UoYJiQ925mjlNKoUOWj27fQAqMvV9EX2NLkCAwEAAaMQMA4w" + System.lineSeparator() +
+                "DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOCAQEA0mZZlY10nniGr3OLYZ5V" + System.lineSeparator() +
+                "8QvlEShllrwg3KlKPU5Lk/U0zG1stYWGeorkmYIuyVevxrHCIYpEAf3fmbZRbZlC" + System.lineSeparator() +
+                "lEE4gVK6QCISqbkdPQrgdPSEq7hyLt/Ays0RsRApiddMQ/humMxFZgIfYXPiA4c4" + System.lineSeparator() +
+                "6pjjMKLbikcd1lKAmcJSynixFoThqn8gAOkHbZZ9+/S0Bi+HLt1gVnbAsmrKqtdi" + System.lineSeparator() +
+                "14d/WJdpLxpUmgAA39oVl5oasG8ImIXnXIU7tyE9pNBDtfOcxwpF/Cnh6kqcGoHL" + System.lineSeparator() +
+                "ArwwQuSo6w9fpOQ1AsbjTz4xnWHTPewWCfcfKS6qmEn93c0Dfs/FVc1f2QEXdsLH" + System.lineSeparator() +
+                "Mg==" + System.lineSeparator() +
+                "-----END CERTIFICATE-----" + System.lineSeparator();
+
+        URL url = PemTest.class.getResource("/ca/cacert.pem");
+        byte[] bytes = Files.readAllBytes(Paths.get(url.toURI()));
+        X509Certificate certificate = Pem.parsePemX509Certificate(CodePointIterator.ofUtf8Bytes(bytes));
+        ByteStringBuilder target = new ByteStringBuilder();
+        Pem.generatePemX509Certificate(target, certificate);
+        assertEquals(expectedPemCertificate, new String(target.toArray(), StandardCharsets.UTF_8));
+    }
 }

--- a/src/test/java/org/wildfly/security/x500/cert/PKCS10CertificateSigningRequestTest.java
+++ b/src/test/java/org/wildfly/security/x500/cert/PKCS10CertificateSigningRequestTest.java
@@ -175,24 +175,24 @@ public class PKCS10CertificateSigningRequestTest {
 
     @Test
     public void testCsrPem() throws Exception {
-        String expectedCsr = "-----BEGIN CERTIFICATE REQUEST-----\n" +
-                "MIIC5zCCAc8CAQAwcjELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9s\n" +
-                "aW5hMRAwDgYDVQQHEwdSYWxlaWdoMRAwDgYDVQQKEwdSZWQgSGF0MQ4wDAYDVQQL\n" +
-                "EwVKQm9zczEWMBQGA1UEAxMNVGVzdCBDbGllbnQgMTCCASIwDQYJKoZIhvcNAQEB\n" +
-                "BQADggEPADCCAQoCggEBAINleeVmU3ojW+thblXmLNcJKi8GSlHoD1jC9Ai1tv36\n" +
-                "kaNCULxHU3evzvK8kamrgpGTZv++zSSWow/jWJBlo5lttlHiHtGB6AVlgnQcXD8m\n" +
-                "E93Z6jhoPlDWvDRPLr0DKvU1YM4AVQcPG50gppBMav5TE4giEMC+Q2IGCu8oGzrV\n" +
-                "JCVs8j/MMRz0GnExWXFv6aIMPXtbe47aTWVm2GEW9C0ZAJAuVaMJ1bujBmybISn4\n" +
-                "sQWSp6IynXmMeJqHSzjRDE45YsadY43nZ5gHdNrorBuQo8oWCVQz0uXlEVIqXDKL\n" +
-                "CjzNg9t97kUr2mpKXrNifKnFpbeu0m2hiUKjW/h7BbECAwEAAaAwMC4GCSqGSIb3\n" +
-                "DQEJDjEhMB8wHQYDVR0OBBYEFLvOCZ2EA8nLRr/cy3/Y6I/QhhG6MA0GCSqGSIb3\n" +
-                "DQEBCwUAA4IBAQCBPsS0wHCSUqwM7VHMKYjEoxzTypp8eh6K4igOW6ezYbpRNmSS\n" +
-                "v6WWzboW4GdKBAK0Oh4O3NhLtTWLG+xhB2a9wIQrYRR/7rDEARWLf64yeBPaAqZ4\n" +
-                "oB1snVVkr+fHHvUmdSJoI+xcFakCo08tKzUsQPIELnrAXAgBnhb3y63dIiPPViQG\n" +
-                "3+AE5yQYBS9pGa9OyrcW1aAsqKkEsQNyZxjkG8gAGZRWpYaYbPO6QN+861fa7BPn\n" +
-                "sYCDfiE/UYxHEvEVs4Y1jXnJ71bG7MFYh/WCdRRWLvaZaslUqpAEMWXxHuyBrZmd\n" +
-                "HnxjeMuW0Z0kQQ9qcl27T5egSgP0vlGiY6cY\n" +
-                "-----END CERTIFICATE REQUEST-----\n";
+        String expectedCsr = "-----BEGIN CERTIFICATE REQUEST-----" + System.lineSeparator() +
+                "MIIC5zCCAc8CAQAwcjELMAkGA1UEBhMCVVMxFzAVBgNVBAgTDk5vcnRoIENhcm9s" + System.lineSeparator() +
+                "aW5hMRAwDgYDVQQHEwdSYWxlaWdoMRAwDgYDVQQKEwdSZWQgSGF0MQ4wDAYDVQQL" + System.lineSeparator() +
+                "EwVKQm9zczEWMBQGA1UEAxMNVGVzdCBDbGllbnQgMTCCASIwDQYJKoZIhvcNAQEB" + System.lineSeparator() +
+                "BQADggEPADCCAQoCggEBAINleeVmU3ojW+thblXmLNcJKi8GSlHoD1jC9Ai1tv36" + System.lineSeparator() +
+                "kaNCULxHU3evzvK8kamrgpGTZv++zSSWow/jWJBlo5lttlHiHtGB6AVlgnQcXD8m" + System.lineSeparator() +
+                "E93Z6jhoPlDWvDRPLr0DKvU1YM4AVQcPG50gppBMav5TE4giEMC+Q2IGCu8oGzrV" + System.lineSeparator() +
+                "JCVs8j/MMRz0GnExWXFv6aIMPXtbe47aTWVm2GEW9C0ZAJAuVaMJ1bujBmybISn4" + System.lineSeparator() +
+                "sQWSp6IynXmMeJqHSzjRDE45YsadY43nZ5gHdNrorBuQo8oWCVQz0uXlEVIqXDKL" + System.lineSeparator() +
+                "CjzNg9t97kUr2mpKXrNifKnFpbeu0m2hiUKjW/h7BbECAwEAAaAwMC4GCSqGSIb3" + System.lineSeparator() +
+                "DQEJDjEhMB8wHQYDVR0OBBYEFLvOCZ2EA8nLRr/cy3/Y6I/QhhG6MA0GCSqGSIb3" + System.lineSeparator() +
+                "DQEBCwUAA4IBAQCBPsS0wHCSUqwM7VHMKYjEoxzTypp8eh6K4igOW6ezYbpRNmSS" + System.lineSeparator() +
+                "v6WWzboW4GdKBAK0Oh4O3NhLtTWLG+xhB2a9wIQrYRR/7rDEARWLf64yeBPaAqZ4" + System.lineSeparator() +
+                "oB1snVVkr+fHHvUmdSJoI+xcFakCo08tKzUsQPIELnrAXAgBnhb3y63dIiPPViQG" + System.lineSeparator() +
+                "3+AE5yQYBS9pGa9OyrcW1aAsqKkEsQNyZxjkG8gAGZRWpYaYbPO6QN+861fa7BPn" + System.lineSeparator() +
+                "sYCDfiE/UYxHEvEVs4Y1jXnJ71bG7MFYh/WCdRRWLvaZaslUqpAEMWXxHuyBrZmd" + System.lineSeparator() +
+                "HnxjeMuW0Z0kQQ9qcl27T5egSgP0vlGiY6cY" + System.lineSeparator() +
+                "-----END CERTIFICATE REQUEST-----" + System.lineSeparator();
 
         PKCS10CertificateSigningRequest  csr = populateBasicBuilder().build();
         assertEquals(expectedCsr, new String(csr.getPem(), StandardCharsets.UTF_8));


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1478