### PR TITLE
[ELY-1487] fix of HTTP Digest mechs registration

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
@@ -23,7 +23,6 @@ import static org.wildfly.security.http.HttpConstants.ALGORITHM;
 import static org.wildfly.security.http.HttpConstants.AUTH;
 import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
 import static org.wildfly.security.http.HttpConstants.CNONCE;
-import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
 import static org.wildfly.security.http.HttpConstants.NC;
 import static org.wildfly.security.http.HttpConstants.QOP;
 import static org.wildfly.security.http.HttpConstants.URI;
@@ -84,20 +83,22 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
     private final NonceManager nonceManager;
     private final String configuredRealm;
     private final String domain;
+    private final String mechanismName;
     private final String algorithm;
 
-    DigestAuthenticationMechanism(CallbackHandler callbackHandler, NonceManager nonceManager, String configuredRealm, String domain, String algorithm, Supplier<Provider[]> providers) {
+    DigestAuthenticationMechanism(CallbackHandler callbackHandler, NonceManager nonceManager, String configuredRealm, String domain, String mechanismName, String algorithm, Supplier<Provider[]> providers) {
         this.callbackHandler = callbackHandler;
         this.nonceManager = nonceManager;
         this.configuredRealm = configuredRealm;
         this.domain = domain;
+        this.mechanismName = mechanismName;
         this.algorithm = algorithm;
         this.providers = providers;
     }
 
     @Override
     public String getMechanismName() {
-        return DIGEST_NAME;
+        return mechanismName;
     }
 
     @Override

--- a/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -85,6 +85,8 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
         mechanismNames.add(BASIC_NAME);
         mechanismNames.add(CLIENT_CERT_NAME);
         mechanismNames.add(DIGEST_NAME);
+        mechanismNames.add(DIGEST_SHA256_NAME);
+        mechanismNames.add(DIGEST_SHA512_256_NAME);
         mechanismNames.add(FORM_NAME);
         mechanismNames.add(SPNEGO_NAME);
         mechanismNames.add(BEARER_TOKEN);
@@ -107,11 +109,11 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
             case CLIENT_CERT_NAME:
                 return new ClientCertAuthenticationMechanism(callbackHandler);
             case DIGEST_NAME:
-                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), MD5, providers);
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), DIGEST_NAME, MD5, providers);
             case DIGEST_SHA256_NAME:
-                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), SHA256, providers);
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), DIGEST_SHA256_NAME, SHA256, providers);
             case DIGEST_SHA512_256_NAME:
-                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), SHA512_256, providers);
+                return new DigestAuthenticationMechanism(callbackHandler, nonceManager, (String) properties.get(CONFIG_REALM), (String) properties.get(CONFIG_CONTEXT_PATH), DIGEST_SHA512_256_NAME, SHA512_256, providers);
             case FORM_NAME:
                 return new FormAuthenticationMechanism(callbackHandler, properties);
             case SPNEGO_NAME:


### PR DESCRIPTION
fix of: DIGEST-SHA-* not registered correctly
(unable to use DIGEST-SHA-* in Undertow because of this)
https://issues.jboss.org/browse/ELY-1487