### PR TITLE
[ELY-1475] Empty username for FormAuthenticationMechanism causes IllegalArgumentException

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -162,7 +162,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
         String username = request.getFirstParameterValue(USERNAME);
         String password = request.getFirstParameterValue(PASSWORD);
 
-        if (username == null || password == null) {
+        if (username == null || username.length() == 0 || password == null) {
             error(httpForm.usernameOrPasswordMissing(), request);
             return;
         }


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1475
JBEAP: https://issues.jboss.org/browse/JBEAP-14031