### PR TITLE
[ELY-1462] Moving programatic authentication to Elytron

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -135,7 +135,7 @@ public class HttpAuthenticator {
                 if (authenticationContext.authorize()) {
                     SecurityIdentity authorizedIdentity = authenticationContext.getAuthorizedIdentity();
                     HttpScope sessionScope = httpExchangeSpi.getScope(Scope.SESSION);
-                    if (sessionScope != null && sessionScope.supportsAttachments()) {
+                    if (sessionScope != null && sessionScope.supportsAttachments() && (sessionScope.exists() || sessionScope.create())) {
                         sessionScope.setAttachment(AUTHENTICATED_PRINCIPAL_KEY, username);
                     }
                     setupProgramaticLogout(sessionScope);

--- a/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/FormAuthenticationMechanism.java
@@ -113,11 +113,11 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
         }
     }
 
-    private IdentityCache createIdentityCache(HttpServerRequest request, boolean createSession) {
+    private IdentityCache createIdentityCache(HttpServerRequest request) {
         return new IdentityCache() {
             @Override
             public void put(SecurityIdentity  identity) {
-                HttpScope session = getSessionScope(request, createSession);
+                HttpScope session = getSessionScope(request, true);
 
                 if (session == null || !session.exists()) {
                     return;
@@ -128,7 +128,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
 
             @Override
             public CachedIdentity get() {
-                HttpScope session = getSessionScope(request, createSession);
+                HttpScope session = getSessionScope(request, false);
 
                 if (session == null || !session.exists()) {
                     return null;
@@ -139,7 +139,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
 
             @Override
             public CachedIdentity remove() {
-                HttpScope session = getSessionScope(request, createSession);
+                HttpScope session = getSessionScope(request, false);
 
                 if (session == null || !session.exists()) {
                     return null;
@@ -170,7 +170,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
         char[] passwordChars = password.toCharArray();
         try {
             if (authenticate(null, username, passwordChars)) {
-                IdentityCache identityCache = createIdentityCache(request, true);
+                IdentityCache identityCache = createIdentityCache(request);
                 if (authorize(username, request, identityCache)) {
                     httpForm.debugf("User [%s] authenticated successfully", username);
                     succeed();
@@ -249,7 +249,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             }
         }
 
-        IdentityCache identityCache = createIdentityCache(request, false);
+        IdentityCache identityCache = createIdentityCache(request);
         if (identityCache != null) {
             CachedIdentityAuthorizeCallback authorizeCallback = new CachedIdentityAuthorizeCallback(identityCache);
             try {
@@ -272,7 +272,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
     }
 
     private void failAndRedirectToErrorPage(HttpServerRequest request, String username) throws IOException, UnsupportedCallbackException {
-        IdentityCache identityCache = createIdentityCache(request, false);
+        IdentityCache identityCache = createIdentityCache(request);
         if (identityCache != null) {
             identityCache.remove();
         }


### PR DESCRIPTION
Also includes ELY-1463 to ensure we create a session if we are persisting an identity, and ELY-1489 to simplify this within the FormAuthenticationMechanism.

The Elytron Web side of the change can be found here: - https://github.com/wildfly-security/elytron-web/pull/118

The following branch also contains an updated test in the WildFly testsuite to reproduce this error / verify the fix https://github.com/wildfly/wildfly/compare/master...darranl:WFLY-9561