### PR TITLE
[ELY-1398] Add support for public API compatibility check using japicmp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,56 @@
                 <version.surefire.plugin>2.19.1</version.surefire.plugin>
             </properties>
         </profile>
+        <profile>
+            <id>compatibilityCheck</id>
+            <activation>
+                <property>
+                    <name>!skipCompatibility</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.siom79.japicmp</groupId>
+                        <artifactId>japicmp-maven-plugin</artifactId>
+                        <version>0.11.0</version>
+                        <configuration>
+                            <oldVersion>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron</artifactId>
+                                    <version>1.1.7.Final</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </oldVersion>
+                            <newVersion>
+                                <file>
+                                    <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+                                </file>
+                            </newVersion>
+                            <parameter>
+                                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                                <!-- Update based on ELY-1483 -->
+                                <includes>org.wildfly.security,org.wildfly.security.auth,org.wildfly.security.auth.callback,org.wildfly.security.auth.client,org.wildfly.security.auth.permission,org.wildfly.security.auth.principal,org.wildfly.security.auth.server,org.wildfly.security.auth.util,org.wildfly.security.authz,org.wildfly.security.credential,org.wildfly.security.credential.source,org.wildfly.security.credential.store,org.wildfly.security.evidence,org.wildfly.security.http,org.wildfly.security.key,org.wildfly.security.manager,org.wildfly.security.manager.action,org.wildfly.security.mechanism,org.wildfly.security.password,org.wildfly.security.password.interfaces,org.wildfly.security.password.spec,org.wildfly.security.permission,org.wildfly.security.sasl.util,org.wildfly.security.ssl,org.wildfly.security.auth.server.event</includes>
+                                <excludes>
+                                    <!-- false positive ELY-1453 -->
+                                    <exclude>org.wildfly.security.auth.server.event.RealmDefiniteOutcomeAuthenticationEvent#RealmDefiniteOutcomeAuthenticationEvent(org.wildfly.security.auth.server.RealmIdentity,org.wildfly.security.credential.Credential,org.wildfly.security.evidence.Evidence)</exclude>
+                                </excludes>
+                                <includeExclusively>true</includeExclusively>
+                            </parameter>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>cmp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -562,7 +562,33 @@
                             <parameter>
                                 <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
                                 <!-- Update based on ELY-1483 -->
-                                <includes>org.wildfly.security,org.wildfly.security.auth,org.wildfly.security.auth.callback,org.wildfly.security.auth.client,org.wildfly.security.auth.permission,org.wildfly.security.auth.principal,org.wildfly.security.auth.server,org.wildfly.security.auth.util,org.wildfly.security.authz,org.wildfly.security.credential,org.wildfly.security.credential.source,org.wildfly.security.credential.store,org.wildfly.security.evidence,org.wildfly.security.http,org.wildfly.security.key,org.wildfly.security.manager,org.wildfly.security.manager.action,org.wildfly.security.mechanism,org.wildfly.security.password,org.wildfly.security.password.interfaces,org.wildfly.security.password.spec,org.wildfly.security.permission,org.wildfly.security.sasl.util,org.wildfly.security.ssl,org.wildfly.security.auth.server.event</includes>
+                                <includes>
+                                    <include>org.wildfly.security</include>
+                                    <include>org.wildfly.security.auth</include>
+                                    <include>org.wildfly.security.auth.callback</include>
+                                    <include>org.wildfly.security.auth.client</include>
+                                    <include>org.wildfly.security.auth.permission</include>
+                                    <include>org.wildfly.security.auth.principal</include>
+                                    <include>org.wildfly.security.auth.server</include>
+                                    <include>org.wildfly.security.auth.util</include>
+                                    <include>org.wildfly.security.authz</include>
+                                    <include>org.wildfly.security.credential</include>
+                                    <include>org.wildfly.security.credential.source</include>
+                                    <include>org.wildfly.security.credential.store</include>
+                                    <include>org.wildfly.security.evidence</include>
+                                    <include>org.wildfly.security.http</include>
+                                    <include>org.wildfly.security.key</include>
+                                    <include>org.wildfly.security.manager</include>
+                                    <include>org.wildfly.security.manager.action</include>
+                                    <include>org.wildfly.security.mechanism</include>
+                                    <include>org.wildfly.security.password</include>
+                                    <include>org.wildfly.security.password.interfaces</include>
+                                    <include>org.wildfly.security.password.spec</include>
+                                    <include>org.wildfly.security.permission</include>
+                                    <include>org.wildfly.security.sasl.util</include>
+                                    <include>org.wildfly.security.ssl</include>
+                                    <include>org.wildfly.security.auth.server.event</include>
+                                </includes>
                                 <excludes>
                                     <!-- false positive ELY-1453 -->
                                     <exclude>org.wildfly.security.auth.server.event.RealmDefiniteOutcomeAuthenticationEvent#RealmDefiniteOutcomeAuthenticationEvent(org.wildfly.security.auth.server.RealmIdentity,org.wildfly.security.credential.Credential,org.wildfly.security.evidence.Evidence)</exclude>


### PR DESCRIPTION
This contains Martin's PR but I have added a commit to split the packages into their own line so we can see future modifications more easily.

Using japicmp tool [1] profile was created to compare two jars of library:

last 1.1.x released jar (currently 1.1.7.Final)
currently SNAPSHOT version (e.g. 1.2.0.Beta12-SNAPSHOT)
Tool comes with lots of options to specify what to check [2]
In this initial version breakBuildBasedOnSemanticVersioning is turned
on. And set of public packages is specified.

This is alternative to #1066

Usage:
mvn verify -DskipTests -PcompatibilityCheck

[1] https://github.com/siom79/japicmp
[2] https://siom79.github.io/japicmp/MavenPlugin.html