### PR TITLE
1.2.x [ELY-1526] Add back the ability for security providers to be loaded using the service loader mechanism but ensure that we skip any provider that is already an installed provider

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationConfiguration.java
@@ -168,8 +168,8 @@ public final class AuthenticationConfiguration {
     private static final Supplier<Provider[]> DEFAULT_PROVIDER_SUPPLIER = ProviderUtil.aggregate(
             () -> new Provider[] { new WildFlyElytronProvider() },
             WildFlySecurityManager.isChecking() ?
-                    AccessController.doPrivileged((PrivilegedAction<ProviderServiceLoaderSupplier>) () -> new ProviderServiceLoaderSupplier(AuthenticationConfiguration.class.getClassLoader())) :
-                    new ProviderServiceLoaderSupplier(AuthenticationConfiguration.class.getClassLoader()),
+                    AccessController.doPrivileged((PrivilegedAction<ProviderServiceLoaderSupplier>) () -> new ProviderServiceLoaderSupplier(AuthenticationConfiguration.class.getClassLoader(), true)) :
+                    new ProviderServiceLoaderSupplier(AuthenticationConfiguration.class.getClassLoader(), true),
             INSTALLED_PROVIDERS);
 
     /**

--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -130,8 +130,8 @@ public final class ElytronXmlParser {
     private static final Supplier<Provider[]> ELYTRON_PROVIDER_SUPPLIER = ProviderUtil.aggregate(
             () -> new Provider[] { new WildFlyElytronProvider() },
             WildFlySecurityManager.isChecking() ?
-                    AccessController.doPrivileged((PrivilegedAction<ProviderServiceLoaderSupplier>) () -> new ProviderServiceLoaderSupplier(ElytronXmlParser.class.getClassLoader())) :
-                    new ProviderServiceLoaderSupplier(ElytronXmlParser.class.getClassLoader()));
+                    AccessController.doPrivileged((PrivilegedAction<ProviderServiceLoaderSupplier>) () -> new ProviderServiceLoaderSupplier(ElytronXmlParser.class.getClassLoader(), true)) :
+                    new ProviderServiceLoaderSupplier(ElytronXmlParser.class.getClassLoader(), true));
 
     private static final Supplier<Provider[]> DEFAULT_PROVIDER_SUPPLIER = ProviderUtil.aggregate(ELYTRON_PROVIDER_SUPPLIER, INSTALLED_PROVIDERS);
 

--- a/src/main/java/org/wildfly/security/util/ProviderServiceLoaderSupplier.java
+++ b/src/main/java/org/wildfly/security/util/ProviderServiceLoaderSupplier.java
@@ -39,14 +39,23 @@ import java.util.Set;
  */
 public class ProviderServiceLoaderSupplier extends ServiceLoaderSupplier<Provider> {
 
+    final boolean elytronProviderStaticallyAdded;
+
     public ProviderServiceLoaderSupplier(final ClassLoader classLoader) {
+        this(classLoader, false);
+    }
+
+    public ProviderServiceLoaderSupplier(final ClassLoader classLoader, final boolean elytronProviderStaticallyAdded) {
         super(Provider.class, classLoader);
+        this.elytronProviderStaticallyAdded = elytronProviderStaticallyAdded;
     }
 
     Provider[] loadServices(final Class<Provider> service, final ClassLoader classLoader) {
         Provider[] providers = INSTALLED_PROVIDERS.get();
-        Set<Class<?>> installedProvidersSet = new HashSet<>((providers != null ? providers.length : 0) + 1);
-        installedProvidersSet.add(WildFlyElytronProvider.class);
+        Set<Class<?>> installedProvidersSet = new HashSet<>((providers != null ? providers.length : 0) + (elytronProviderStaticallyAdded ? 1 : 0));
+        if (elytronProviderStaticallyAdded) {
+            installedProvidersSet.add(WildFlyElytronProvider.class);
+        }
         if (providers != null) {
             for (int i = 0; i < providers.length; i++) {
                 installedProvidersSet.add(providers[i].getClass());

--- a/src/main/java/org/wildfly/security/util/ProviderServiceLoaderSupplier.java
+++ b/src/main/java/org/wildfly/security/util/ProviderServiceLoaderSupplier.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.util;
+
+import static org.wildfly.security.util.ProviderUtil.INSTALLED_PROVIDERS;
+
+import org.wildfly.security.WildFlyElytronProvider;
+
+import java.security.Provider;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+/**
+ * A supplier which uses a service loader to find all {@link Provider} instances that aren't in the list of
+ * installed security providers and returns them as an array. The result is then cached.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ * @since 1.2.2
+ */
+public class ProviderServiceLoaderSupplier extends ServiceLoaderSupplier<Provider> {
+
+    public ProviderServiceLoaderSupplier(final ClassLoader classLoader) {
+        super(Provider.class, classLoader);
+    }
+
+    Provider[] loadServices(final Class<Provider> service, final ClassLoader classLoader) {
+        Provider[] providers = INSTALLED_PROVIDERS.get();
+        Set<Class<?>> installedProvidersSet = new HashSet<>((providers != null ? providers.length : 0) + 1);
+        installedProvidersSet.add(WildFlyElytronProvider.class);
+        if (providers != null) {
+            for (int i = 0; i < providers.length; i++) {
+                installedProvidersSet.add(providers[i].getClass());
+            }
+        }
+        ArrayList<Provider> list = new ArrayList<>();
+        ServiceLoader<Provider> loader = ServiceLoader.load(service, classLoader);
+        Iterator<Provider> iterator = loader.iterator();
+        for (;;) try {
+            if (! iterator.hasNext()) {
+                return list.toArray(new Provider[list.size()]);
+            }
+            Provider provider = iterator.next();
+            if (! installedProvidersSet.contains(provider.getClass())) {
+                list.add(provider);
+            }
+        } catch (ServiceConfigurationError ignored) {
+            // explicitly ignored
+        }
+    }
+
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    public boolean equals(final Object obj) {
+        return obj instanceof ProviderServiceLoaderSupplier && equals((ProviderServiceLoaderSupplier) obj);
+    }
+
+    private boolean equals(final ProviderServiceLoaderSupplier other) {
+        return other == this || other.classLoader == classLoader;
+    }
+}

--- a/src/main/java/org/wildfly/security/util/ServiceLoaderSupplier.java
+++ b/src/main/java/org/wildfly/security/util/ServiceLoaderSupplier.java
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 public class ServiceLoaderSupplier<E> implements Supplier<E[]> {
 
     private final Class<E> service;
-    private final ClassLoader classLoader;
+    final ClassLoader classLoader;
     private int hashCode;
     private volatile E[] result;
     private final AccessControlContext acc;
@@ -65,7 +65,7 @@ public class ServiceLoaderSupplier<E> implements Supplier<E[]> {
         return result.clone();
     }
 
-    private E[] loadServices(final Class<E> service, final ClassLoader classLoader) {
+    E[] loadServices(final Class<E> service, final ClassLoader classLoader) {
         ArrayList<E> list = new ArrayList<>();
         ServiceLoader<E> loader = ServiceLoader.load(service, classLoader);
         Iterator<E> iterator = loader.iterator();


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1526
https://issues.jboss.org/browse/WFLY-9899