### PR TITLE
[ELY-1523] JAPICMP checking level independent on version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -567,7 +567,8 @@
                                 </file>
                             </newVersion>
                             <parameter>
-                                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                                <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                                <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                                 <includes>
                                     <include>org.wildfly.security</include>
                                     <include>org.wildfly.security.asn1</include>


### PR DESCRIPTION
1.2.x backport of https://github.com/wildfly-security/wildfly-elytron/pull/1105
https://issues.jboss.org/browse/ELY-1523