### PR TITLE
[ELY-1430] WARN logged during server shutdown when Elytron JACC is set

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -60,7 +60,6 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.logging.annotations.Once;
 import org.jboss.logging.annotations.Param;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.client.config.ConfigurationXMLStreamReader;
@@ -1725,13 +1724,13 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 8508, value = "Could not obtain authorized identity.")
     void authzCouldNotObtainSecurityIdentity(@Cause Throwable cause);
 
-    @Once
-    @LogMessage(level = WARN)
-    @Message(id = 8509, value = "Calling any of the Policy.getPermissions() methods is not supported; please see the "
-        + "Java Authorization Contract for Containers (JACC) specification (section \"1.4 Requirements\", item 1) and "
-        + "the Java SE API specification for the Policy.getPermissions() methods for more information.  Instead, use "
-        + "the Policy.implies() method for authorization checking.")
-    void getPermissionsNotSupported();
+    // @Once
+    // @LogMessage(level = WARN)
+    // @Message(id = 8509, value = "Calling any of the Policy.getPermissions() methods is not supported; please see the "
+    //     + "Java Authorization Contract for Containers (JACC) specification (section \"1.4 Requirements\", item 1) and "
+    //     + "the Java SE API specification for the Policy.getPermissions() methods for more information.  Instead, use "
+    //     + "the Policy.implies() method for authorization checking.")
+    // void getPermissionsNotSupported();
 
     /* credential package */
 

--- a/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
@@ -119,7 +119,6 @@ public class JaccDelegatingPolicy extends Policy {
 
     @Override
     public PermissionCollection getPermissions(ProtectionDomain domain) {
-        log.getPermissionsNotSupported();
         return new PermissionCollection() {
             @Override
             public void add(Permission permission) {


### PR DESCRIPTION
JBEAP (7.1.z): https://issues.jboss.org/browse/JBEAP-13656
Upstream issue: https://issues.jboss.org/browse/ELY-1430
Upstream PR: wildfly-security/wildfly-elytron#1028