### PR TITLE
[ELY-1490] Use supported hash algorithm in DER encoder test DSA section

### DIFF
--- a/src/test/java/org/wildfly/security/asn1/DEREncoderTest.java
+++ b/src/test/java/org/wildfly/security/asn1/DEREncoderTest.java
@@ -402,7 +402,9 @@ public class DEREncoderTest {
 
     @Test
     public void testEncodeDSAKey() throws Exception {
-        KeyPair keyPair = KeyPairGenerator.getInstance("DSA").generateKeyPair();
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("DSA");
+        keyPairGenerator.initialize(1024);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
         PublicKey publicKey = keyPair.getPublic();
         KeyFactory keyFactory = KeyFactory.getInstance("DSA");
         DSAPublicKeySpec keySpec = keyFactory.getKeySpec(publicKey, DSAPublicKeySpec.class);


### PR DESCRIPTION
(7.1.x) https://issues.jboss.org/browse/JBEAP-14395

Upstream: https://issues.jboss.org/browse/ELY-1490