### PR TITLE
[ELY-1533] Prevent SNAPSHOT versions of json-smart from being downloaded when building Elytron

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <version.jmockit>1.33</version.jmockit>
         <version.hsqldb>2.4.0</version.hsqldb>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
+        <version.net.minidev.json-smart>2.3</version.net.minidev.json-smart>
         <version.com.nimbusds.nimbus-jose-jwt>4.39.2</version.com.nimbusds.nimbus-jose-jwt>
         <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.6.Final</version.org.wildfly.checkstyle-config>
@@ -441,10 +442,23 @@
         </dependency>
 
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>${version.net.minidev.json-smart}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${version.com.nimbusds.nimbus-jose-jwt}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Mock Web Server -->


### PR DESCRIPTION
(7.1.x) JBEAP: https://issues.jboss.org/browse/JBEAP-14394

Upstream: https://issues.jboss.org/browse/ELY-1533 (PR: https://github.com/wildfly-security/wildfly-elytron/pull/1103)