### PR TITLE
[ELY-1552] Coverity, Reliance on default encoding in DigestAuthenticationMechanism.

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/DigestAuthenticationMechanism.java
@@ -251,7 +251,7 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
         }
 
         java.net.URI requestURI = request.getRequestURI();
-        String digestUriStr = new String(digestUri);
+        String digestUriStr = new String(digestUri, UTF_8);
 
         if (requestURI.toString().equals(digestUriStr)) {
             return true;


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1552