### PR TITLE
[ELY-1480] Coverity, Explicit null dereferenced in FileSystemSecurityRealm

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -928,6 +928,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             parseCredential(streamReader, (algorithm, format, text) -> {
                 try {
                     if (BASE64_FORMAT.equals(format)) {
+                        if (algorithm == null) {
+                            throw ElytronMessages.log.fileSystemRealmMissingAttribute("algorithm", path, streamReader.getLocation().getLineNumber(), name);
+                        }
                         byte[] passwordBytes = CodePointIterator.ofChars(text.toCharArray()).base64Decode().drain();
                         PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
                         PasswordSpec passwordSpec = BasicPasswordSpecEncoding.decode(passwordBytes);
@@ -982,6 +985,9 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             }
 
             try {
+                if (algorithm == null) {
+                    throw ElytronMessages.log.fileSystemRealmMissingAttribute("algorithm", path, streamReader.getLocation().getLineNumber(), name);
+                }
                 PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
                 Password password = passwordFactory.generatePassword(new OneTimePasswordSpec(hash, seed, sequenceNumber));
                 credentials.add(new PasswordCredential(password));


### PR DESCRIPTION
The "algorithm" property is required for passwords.

wildfly-elytron: https://issues.jboss.org/browse/ELY-1480
