### PR TITLE
[ELY-1564] In PasswordKeyMapper an exception is logged with a wrong algorithm name.

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/jdbc/mapper/PasswordKeyMapper.java
+++ b/src/main/java/org/wildfly/security/auth/realm/jdbc/mapper/PasswordKeyMapper.java
@@ -303,7 +303,7 @@ public class PasswordKeyMapper implements KeyMapper {
             }
             return new PasswordCredential(password);
         } catch (InvalidKeySpecException e) {
-            throw log.invalidPasswordKeySpecificationForAlgorithm(this.defaultAlgorithm, e);
+            throw log.invalidPasswordKeySpecificationForAlgorithm(algorithmName, e);
         }
     }
 


### PR DESCRIPTION
wildfly-elytron: https://issues.jboss.org/browse/ELY-1564