### PR TITLE
[ELY-1460] External CS, PKCS11 can't be configured with externalPath

### DIFF
--- a/src/main/java/org/wildfly/security/_private/ElytronMessages.java
+++ b/src/main/java/org/wildfly/security/_private/ElytronMessages.java
@@ -1828,6 +1828,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 9527, value = "Invalid credential store reference")
     ConfigXMLParseException xmlInvalidCredentialStoreRef(@Param Location location);
 
+    @Message(id = 9528, value = "The externalPath attribute for key store type %s is missing.")
+    CredentialStoreException externalPathMissing(String keyStoreType);
+
 
     /* X.500 exceptions */
 

--- a/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -142,7 +142,7 @@ import org.wildfly.security.x500.X500;
  *     <li>{@code keyStoreType}: specifies the key store type to use (defaults to {@link KeyStore#getDefaultType()})</li>
  *     <li>{@code keyAlias}: specifies the secret key alias within the key store to use for encrypt/decrypt of data in external storage (defaults to {@code cs_key})</li>
  *     <li>{@code external}: specifies whether to store data to external storage and encrypted by {@code keyAlias} key (defaults to {@code false})</li>
- *     <li>{@code externalPath}: specifies path to the external storage. It has to be used in conjunction with {@code external=true} and it defaults to value of {@code location} when {@code keyStoreType} is PKCS11.</li>
+ *     <li>{@code externalPath}: specifies path to the external storage. It has to be used in conjunction with {@code external=true}</li>
  *     <li>{@code cryptoAlg}: cryptographic algorithm name to be used to encrypt decrypt entries at external storage ({@code external} has to be set to {@code true})</li>
  * </ul>
  */
@@ -200,8 +200,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             if (useExternalStorage) {
                 final String externalPathName = attributes.get(EXTERNALPATH);
                 if (externalPathName == null) {
-                    externalPath = location;
-                    location = null;
+                    throw log.externalPathMissing(keyStoreType);
                 } else {
                     externalPath = Paths.get(externalPathName);
                     if (externalPath.equals(location)) {


### PR DESCRIPTION
Implemented: "When useExternalStorage=true and externalPath is null we should not default externalPath to location, but throw an exception."

(7.1.x) JBEAP: https://issues.jboss.org/browse/JBEAP-13441
Upstream: https://issues.jboss.org/browse/ELY-1460 (PR: #1051)