### PR TITLE
[ELY-1588] credential-store-reference: handled missing alias, xsd doc

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -1633,6 +1633,8 @@ public final class ElytronXmlParser {
         final String finalStoreName = storeName;
         final String finalClearText = clearText;
         final String finalAlias = alias;
+        if (finalStoreName == null && finalClearText == null) throw xmlLog.xmlInvalidCredentialStoreRef(reader.getLocation());
+        if (finalStoreName != null && finalAlias == null) throw missingAttribute(reader, "alias");
         return () -> {
             if (finalStoreName != null) {
                 final ExceptionSupplier<CredentialStore, ConfigXMLParseException> supplier = credentialStoresMap.get(finalStoreName);
@@ -1641,11 +1643,9 @@ public final class ElytronXmlParser {
                 }
                 final CredentialStore credentialStore = supplier.get();
                 return new CredentialStoreCredentialSource(credentialStore, finalAlias);
-            } else if (finalClearText != null) {
+            } else {
                 final PasswordCredential passwordCredential = new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, finalClearText.toCharArray()));
                 return IdentityCredentials.NONE.withCredential(passwordCredential);
-            } else {
-                throw xmlLog.xmlInvalidCredentialStoreRef(finalLocation);
             }
         };
     }

--- a/src/main/resources/schema/elytron-client-1_1.xsd
+++ b/src/main/resources/schema/elytron-client-1_1.xsd
@@ -613,6 +613,7 @@
             <xsd:annotation>
                 <xsd:documentation>
                     Credential store name.
+                    When used, attribute "alias" need to be specified.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
@@ -620,6 +621,7 @@
             <xsd:annotation>
                 <xsd:documentation>
                     Alias in the credential store.
+                    Ignored if "store" is not specified.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
@@ -627,6 +629,7 @@
             <xsd:annotation>
                 <xsd:documentation>
                     Credential store password in clear text.
+                    Supersedes "store" and "alias" attributes.
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1588

* handled missing alias in parsing (with info about xml line)
* handled missing store/clear-text already on parsing
* doc into xsd