### PR TITLE
[ELY-1589][ELY-1568] fixed CRL from resource/uri, XSD fix of provider

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -614,22 +614,6 @@ public final class ElytronXmlParser {
                     path = reader.getAttributeValueResolved(i);
                     break;
                 }
-                case "resource": {
-                    if (gotSource || !xmlVersion.isAtLeast(Version.VERSION_1_1)) {
-                        throw reader.unexpectedAttribute(i);
-                    }
-                    gotSource = true;
-                    resourceSource = parseResourceType(reader, xmlVersion);
-                    break;
-                }
-                case "uri": {
-                    if (gotSource || !xmlVersion.isAtLeast(Version.VERSION_1_1)) {
-                        throw reader.unexpectedAttribute(i);
-                    }
-                    gotSource = true;
-                    uriSource = parseUriType(reader);
-                    break;
-                }
                 case "maximum-cert-path": {
                     if (maxCertPath != 0) throw reader.unexpectedAttribute(i);
                     maxCertPath = reader.getIntAttributeValueResolved(i, 1, Integer.MAX_VALUE);
@@ -641,7 +625,26 @@ public final class ElytronXmlParser {
         while (reader.hasNext()) {
             final int tag = reader.nextTag();
             if (tag == START_ELEMENT) {
-                throw reader.unexpectedElement();
+                checkElementNamespace(reader, xmlVersion);
+                switch (reader.getLocalName()) {
+                    case "resource": {
+                        if (gotSource || !xmlVersion.isAtLeast(Version.VERSION_1_1)) {
+                            throw reader.unexpectedElement();
+                        }
+                        gotSource = true;
+                        resourceSource = parseResourceType(reader, xmlVersion);
+                        break;
+                    }
+                    case "uri": {
+                        if (gotSource || !xmlVersion.isAtLeast(Version.VERSION_1_1)) {
+                            throw reader.unexpectedElement();
+                        }
+                        gotSource = true;
+                        uriSource = parseUriType(reader);
+                        break;
+                    }
+                    default: throw reader.unexpectedElement();
+                }
             } else if (tag == END_ELEMENT) {
                 builder.setCrl();
                 if (gotSource) {

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -182,8 +182,8 @@
 
     <xsd:complexType name="providers-type">
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type" />
-            <xsd:element name="use-service-loader" type="module-ref-type" />
+            <xsd:element name="global" type="empty-type" minOccurs="0" />
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0" />
         </xsd:all>
     </xsd:complexType>
 

--- a/src/main/resources/schema/elytron-1_0_1.xsd
+++ b/src/main/resources/schema/elytron-1_0_1.xsd
@@ -182,8 +182,8 @@
 
     <xsd:complexType name="providers-type">
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type" />
-            <xsd:element name="use-service-loader" type="module-ref-type" />
+            <xsd:element name="global" type="empty-type" minOccurs="0" />
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0" />
         </xsd:all>
     </xsd:complexType>
 

--- a/src/main/resources/schema/elytron-client-1_1.xsd
+++ b/src/main/resources/schema/elytron-client-1_1.xsd
@@ -424,14 +424,14 @@
             </xsd:documentation>
         </xsd:annotation>
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type">
+            <xsd:element name="global" type="empty-type" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         The providers from java.security.Security.getProviders()
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="use-service-loader" type="module-ref-type">
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         Providers loaded using service loader discovery from the module specified, 
@@ -464,24 +464,26 @@
                 The presence of this element enabled checking the peer's certificate against a certificate revocation list.
             </xsd:documentation>
         </xsd:annotation>
+        <xsd:all minOccurs="0">
+            <xsd:element name="uri" type="uri-type">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        URI of certificate revocation list file. Alternative to "path" and "resource".
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="resource" type="resource-type">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        The module resource to use as certificate revocation list. Alternative to "path" and "uri".
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
         <xsd:attribute name="path" type="xsd:string" use="optional">
             <xsd:annotation>
                 <xsd:documentation>
                     Path to the certificate revocation list. Alternative to "resource" and "uri".
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="resource" type="resource-type" use="optional">
-            <xsd:annotation>
-                <xsd:documentation>
-                    The module resource to use as certificate revocation list. Alternative to "path" and "uri".
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="uri" type="uri-type" use="optional">
-            <xsd:annotation>
-                <xsd:documentation>
-                    URI of certificate revocation list file. Alternative to "path" and "resource".
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>

--- a/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config.xml
+++ b/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config.xml
@@ -51,6 +51,12 @@
                 <trust-store key-store-name="ca"/>
                 <certificate-revocation-list path="target/test-classes/ca/crl/ica-revoked.pem"/>
             </ssl-context>
+            <ssl-context name="one-way-resource-revocation-list">
+                <trust-store key-store-name="ca"/>
+                <certificate-revocation-list maximum-cert-path="2">
+                    <resource name="ca/crl/ica-revoked.pem"/>
+                </certificate-revocation-list>
+            </ssl-context>
             <ssl-context name="two-way-ssl">
                 <key-store-ssl-certificate key-store-name="ladybird" alias="ladybird">
                     <key-store-clear-password password="Elytron"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1589
https://issues.jboss.org/browse/ELY-1568

Parsing of certificate-revocation-list was broken - parsing element as attribute.
The same problem was causing invalidity of XSD -> maybe should be considered higher priority? 