### PR TITLE
[ELY-1589][ELY-1568] fixed CRL from resource/uri, XSD fix of provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,36 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+                <configuration>
+                    <validationSets>
+                        <validationSet>
+                            <dir>src/test/resources/</dir>
+                            <includes>
+                                <include>**/*-v1_0.xml</include>
+                            </includes>
+                            <systemId>src/test/resources/schema/wrapped-elytron-1_0.xsd</systemId>
+                        </validationSet>
+                        <validationSet>
+                            <dir>src/test/resources/</dir>
+                            <includes>
+                                <include>**/*-v1_1.xml</include>
+                            </includes>
+                            <systemId>src/test/resources/schema/wrapped-elytron-client-1_1.xsd</systemId>
+                        </validationSet>
+                    </validationSets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>validate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/src/main/resources/schema/elytron-1_0.xsd
+++ b/src/main/resources/schema/elytron-1_0.xsd
@@ -122,7 +122,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element ref="abstract-user-spec"/>
+            <xsd:element ref="abstract-user-spec" minOccurs="0"/>
             <xsd:element name="set-mechanism-realm" type="optional-name-type" minOccurs="0"/>
             <xsd:element name="rewrite-user-name-regex" type="regex-substitution-type" minOccurs="0"/>
             <xsd:element name="sasl-mechanism-selector" type="selector-type" minOccurs="0"/>
@@ -182,8 +182,8 @@
 
     <xsd:complexType name="providers-type">
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type" />
-            <xsd:element name="use-service-loader" type="module-ref-type" />
+            <xsd:element name="global" type="empty-type" minOccurs="0" />
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0" />
         </xsd:all>
     </xsd:complexType>
 
@@ -247,7 +247,7 @@
     </xsd:complexType>
 
     <xsd:complexType name="oauth2-bearer-token-type">
-        <xsd:choice minOccurs="1">
+        <xsd:choice maxOccurs="unbounded">
             <xsd:element name="client-credentials" type="oauth2-client-credentials-type" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="resource-owner-credentials" type="resource-owner-credentials-type" minOccurs="0" maxOccurs="1"/>
         </xsd:choice>

--- a/src/main/resources/schema/elytron-1_0_1.xsd
+++ b/src/main/resources/schema/elytron-1_0_1.xsd
@@ -122,7 +122,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element ref="abstract-user-spec"/>
+            <xsd:element ref="abstract-user-spec" minOccurs="0"/>
             <xsd:element name="set-mechanism-realm" type="optional-name-type" minOccurs="0"/>
             <xsd:element name="rewrite-user-name-regex" type="regex-substitution-type" minOccurs="0"/>
             <xsd:element name="sasl-mechanism-selector" type="selector-type" minOccurs="0"/>
@@ -182,8 +182,8 @@
 
     <xsd:complexType name="providers-type">
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type" />
-            <xsd:element name="use-service-loader" type="module-ref-type" />
+            <xsd:element name="global" type="empty-type" minOccurs="0" />
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0" />
         </xsd:all>
     </xsd:complexType>
 
@@ -249,7 +249,7 @@
     </xsd:complexType>
 
     <xsd:complexType name="oauth2-bearer-token-type">
-        <xsd:choice minOccurs="1">
+        <xsd:choice maxOccurs="unbounded">
             <xsd:element name="client-credentials" type="oauth2-client-credentials-type" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="resource-owner-credentials" type="resource-owner-credentials-type" minOccurs="0" maxOccurs="1"/>
         </xsd:choice>

--- a/src/main/resources/schema/elytron-client-1_1.xsd
+++ b/src/main/resources/schema/elytron-client-1_1.xsd
@@ -243,7 +243,7 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element ref="abstract-user-spec"/>
+            <xsd:element ref="abstract-user-spec" minOccurs="0"/>
             <xsd:element name="set-mechanism-realm" type="optional-name-type" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
@@ -424,14 +424,14 @@
             </xsd:documentation>
         </xsd:annotation>
         <xsd:all minOccurs="0">
-            <xsd:element name="global" type="empty-type">
+            <xsd:element name="global" type="empty-type" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         The providers from java.security.Security.getProviders()
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="use-service-loader" type="module-ref-type">
+            <xsd:element name="use-service-loader" type="module-ref-type" minOccurs="0">
                 <xsd:annotation>
                     <xsd:documentation>
                         Providers loaded using service loader discovery from the module specified, 
@@ -464,24 +464,26 @@
                 The presence of this element enabled checking the peer's certificate against a certificate revocation list.
             </xsd:documentation>
         </xsd:annotation>
+        <xsd:all>
+            <xsd:element name="uri" type="uri-type" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        URI of certificate revocation list file. Alternative to "path" and "resource".
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="resource" type="resource-type" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        The module resource to use as certificate revocation list. Alternative to "path" and "uri".
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
         <xsd:attribute name="path" type="xsd:string" use="optional">
             <xsd:annotation>
                 <xsd:documentation>
                     Path to the certificate revocation list. Alternative to "resource" and "uri".
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="resource" type="resource-type" use="optional">
-            <xsd:annotation>
-                <xsd:documentation>
-                    The module resource to use as certificate revocation list. Alternative to "path" and "uri".
-                </xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
-        <xsd:attribute name="uri" type="uri-type" use="optional">
-            <xsd:annotation>
-                <xsd:documentation>
-                    URI of certificate revocation list file. Alternative to "path" and "resource".
                 </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
@@ -690,7 +692,7 @@
                 An OAuth 2 bearer token.
             </xsd:documentation>
         </xsd:annotation>
-        <xsd:choice minOccurs="1">
+        <xsd:choice maxOccurs="unbounded">
             <xsd:element name="client-credentials" type="oauth2-client-credentials-type" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="resource-owner-credentials" type="resource-owner-credentials-type" minOccurs="0" maxOccurs="1"/>
         </xsd:choice>
@@ -703,6 +705,9 @@
                 An OAuth 2 bearer token client credentials.
             </xsd:documentation>
         </xsd:annotation>
+        <xsd:choice>
+            <xsd:element name="credential-store-reference" type="credential-store-reference-type" minOccurs="0"/>
+        </xsd:choice>
         <xsd:attribute name="client-id" type="xsd:string" use="required">
             <xsd:annotation>
                 <xsd:documentation>
@@ -725,6 +730,9 @@
                 An OAuth 2 bearer token resource owner credentials.
             </xsd:documentation>
         </xsd:annotation>
+        <xsd:choice>
+            <xsd:element name="credential-store-reference" type="credential-store-reference-type" minOccurs="0"/>
+        </xsd:choice>
         <xsd:attribute name="name" type="xsd:string" use="required">
             <xsd:annotation>
                 <xsd:documentation>

--- a/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
+++ b/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
@@ -28,7 +28,7 @@ public class ElytronXmlParserTest {
      */
     @Test
     public void testKeyStoreClearPassword() throws ConfigXMLParseException, URISyntaxException {
-        URL config = getClass().getResource("test-wildfly-config.xml");
+        URL config = getClass().getResource("test-wildfly-config-v1_1.xml");
         SecurityFactory<AuthenticationContext> authContext = ElytronXmlParser.parseAuthenticationClientConfiguration(config.toURI());
         Assert.assertNotNull(authContext);
     }

--- a/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -205,7 +205,7 @@ public class SSLAuthenticationTest {
     }
 
     private SecurityIdentity performConnectionTest(SSLContext serverContext, String clientUri, boolean expectValid) throws Exception {
-        System.setProperty("wildfly.config.url", SSLAuthenticationTest.class.getResource("wildfly-ssl-test-config.xml").toExternalForm());
+        System.setProperty("wildfly.config.url", SSLAuthenticationTest.class.getResource("wildfly-ssl-test-config-v1_1.xml").toExternalForm());
         AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Security.insertProviderAt(new WildFlyElytronProvider(), 1));
 
         AuthenticationContext context = AuthenticationContext.getContextManager().get();

--- a/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-v1_1.xml
+++ b/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-v1_1.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 -->
 <configuration>
-    <authentication-client xmlns="urn:elytron:1.0">
+    <authentication-client xmlns="urn:elytron:client:1.1">
         <key-stores>
             <key-store name="client-keystore" type="JKS">
                 <file name="./target/keystore/client.keystore"/>

--- a/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
+++ b/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
@@ -51,6 +51,12 @@
                 <trust-store key-store-name="ca"/>
                 <certificate-revocation-list path="target/test-classes/ca/crl/ica-revoked.pem"/>
             </ssl-context>
+            <ssl-context name="one-way-resource-revocation-list">
+                <trust-store key-store-name="ca"/>
+                <certificate-revocation-list maximum-cert-path="2">
+                    <resource name="ca/crl/ica-revoked.pem"/>
+                </certificate-revocation-list>
+            </ssl-context>
             <ssl-context name="two-way-ssl">
                 <key-store-ssl-certificate key-store-name="ladybird" alias="ladybird">
                     <key-store-clear-password password="Elytron"/>

--- a/src/test/resources/schema/wrapped-elytron-1_0.xsd
+++ b/src/test/resources/schema/wrapped-elytron-1_0.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ elytron-1_0.xsd wrapped into <configuration> element for needs of tests XML validation.
+  ~ THIS XSD IS TEST ONLY
+  -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:el="urn:elytron:1.0"
+            version="1.0">
+
+    <xsd:import namespace="urn:elytron:1.0" schemaLocation="src/main/resources/schema/elytron-1_0.xsd"/>
+
+    <xsd:element name="configuration">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element ref="el:authentication-client" />
+            </xsd:all>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>

--- a/src/test/resources/schema/wrapped-elytron-client-1_1.xsd
+++ b/src/test/resources/schema/wrapped-elytron-client-1_1.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ elytron-client-1_1.xsd wrapped into <configuration> element for needs of tests XML validation.
+  ~ THIS XSD IS TEST ONLY
+  -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:el="urn:elytron:client:1.1"
+            version="1.0">
+
+    <xsd:import namespace="urn:elytron:client:1.1" schemaLocation="src/main/resources/schema/elytron-client-1_1.xsd"/>
+
+    <xsd:element name="configuration">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element ref="el:authentication-client" />
+            </xsd:all>
+        </xsd:complexType>
+    </xsd:element>
+
+</xsd:schema>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1589
https://issues.jboss.org/browse/ELY-1568

Parsing of certificate-revocation-list was broken - parsing element as attribute.
I confirm there is no chance to use "resource" or "uri" attributes without parsing error in current version - fixing should be safe.

Opened for 1.3.x as discussed in https://github.com/wildfly-security/wildfly-elytron/pull/1141