### PR TITLE
[ELY-1287] Scope.SSL_SESSION into CLIENT_CERT instead of SSLSession

### DIFF
--- a/src/main/java/org/wildfly/security/cache/CachedIdentity.java
+++ b/src/main/java/org/wildfly/security/cache/CachedIdentity.java
@@ -93,4 +93,9 @@ public final class CachedIdentity implements Serializable {
     public SecurityIdentity getSecurityIdentity() {
         return this.securityIdentity;
     }
+
+    @Override
+    public String toString() {
+        return "CachedIdentity{" + mechanismName + ", '" + name + "', " + securityIdentity + "}";
+    }
 }

--- a/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/ClientCertAuthenticationMechanism.java
@@ -22,12 +22,12 @@ import static org.wildfly.security.http.HttpConstants.CLIENT_CERT_NAME;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
-import javax.net.ssl.SSLSession;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
@@ -42,11 +42,12 @@ import org.wildfly.security.cache.CachedIdentity;
 import org.wildfly.security.cache.IdentityCache;
 import org.wildfly.security.evidence.X509PeerCertificateChainEvidence;
 import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpScope;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.HttpServerRequest;
-import org.wildfly.security.mechanism._private.MechanismUtil;
+import org.wildfly.security.http.Scope;
 import org.wildfly.security.mechanism.AuthenticationMechanismException;
-import org.wildfly.security.ssl.SSLUtils;
+import org.wildfly.security.mechanism._private.MechanismUtil;
 import org.wildfly.security.x500.X500;
 
 /**
@@ -82,7 +83,7 @@ final class ClientCertAuthenticationMechanism implements HttpServerAuthenticatio
     public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
         Function<SecurityDomain, IdentityCache> cacheFunction = createIdentityCacheFunction(request);
 
-        if (cacheFunction!= null && attemptReAuthentication(request, cacheFunction)) {
+        if (cacheFunction != null && attemptReAuthentication(request, cacheFunction)) {
             httpClientCert.trace("Re-authentication succeed");
             return;
         }
@@ -104,7 +105,9 @@ final class ClientCertAuthenticationMechanism implements HttpServerAuthenticatio
         X509Certificate[] x509Certificates = X500.asX509CertificateArray(peerCertificates);
         X509PeerCertificateChainEvidence evidence = new X509PeerCertificateChainEvidence(x509Certificates);
 
-        httpClientCert.tracef("Authenticating using following certificates: [%s]", x509Certificates);
+        if (httpClientCert.isTraceEnabled()) {
+            httpClientCert.tracef("Authenticating using following certificates: [%s]", Arrays.toString(x509Certificates));
+        }
 
         EvidenceVerifyCallback callback = new EvidenceVerifyCallback(evidence);
         try {
@@ -190,23 +193,29 @@ final class ClientCertAuthenticationMechanism implements HttpServerAuthenticatio
     }
 
     private Function<SecurityDomain, IdentityCache> createIdentityCacheFunction(HttpServerRequest request) {
-        SSLSession sslSession = request.getSSLSession();
-        return sslSession == null ? null : securityDomain -> new IdentityCache() {
+        HttpScope scope = request.getScope(Scope.SSL_SESSION);
+        return scope == null ? null : securityDomain -> new IdentityCache() {
 
-            final Map<SecurityDomain, CachedIdentity> identities = SSLUtils.computeIfAbsent(sslSession, "org.wildfly.elytron.identity-cache", key -> new ConcurrentHashMap<>());
+            final Map<SecurityDomain, CachedIdentity> identities = MechanismUtil.computeIfAbsent(scope,
+                    "org.wildfly.elytron.identity-cache", key -> new ConcurrentHashMap<>());
 
             @Override
             public void put(SecurityIdentity identity) {
-                identities.putIfAbsent(securityDomain, new CachedIdentity(getMechanismName(), identity));
+                CachedIdentity cachedIdentity = new CachedIdentity(CLIENT_CERT_NAME, identity);
+                httpClientCert.tracef("storing into cache: %s", cachedIdentity);
+                identities.putIfAbsent(securityDomain, cachedIdentity);
             }
 
             @Override
             public CachedIdentity get() {
-                return identities.get(securityDomain);
+                CachedIdentity cachedIdentity = identities.get(securityDomain);
+                httpClientCert.tracef("loading from cache: %s", cachedIdentity);
+                return cachedIdentity;
             }
 
             @Override
             public CachedIdentity remove() {
+                httpClientCert.tracef("clearing identity cache");
                 return identities.remove(securityDomain);
             }
         };


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1287