### PR TITLE
[ELY-1596] javadoc: required permissions for enabled security manager

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
+++ b/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
@@ -64,7 +64,7 @@ public final class AuthenticationContextConfigurationClient {
     public static final PrivilegedAction<AuthenticationContextConfigurationClient> ACTION = AuthenticationContextConfigurationClient::new;
 
     /**
-     * Construct a new instance.
+     * Construct a new instance.  Requires the {@code createAuthenticationContextConfigurationClient} {@link ElytronPermission}.
      *
      * @throws SecurityException if the caller does not have permission to instantiate this class
      */

--- a/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -123,6 +123,8 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
     /**
      * Construct a new instance.
      *
+     * Construction with enabled security manager requires {@code createSecurityRealm} {@link ElytronPermission}.
+     *
      * @param root the root path of the identity store
      * @param nameRewriter the name rewriter to apply to looked up names
      * @param levels the number of levels of directory hashing to apply

--- a/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityDomain.java
@@ -131,6 +131,8 @@ public final class SecurityDomain {
     /**
      * Register this {@link SecurityDomain} with the specified {@link ClassLoader}.
      *
+     * Registration with enabled security manager requires {@code registerSecurityDomain} {@link ElytronPermission}.
+     *
      * @throws IllegalStateException If a {@link SecurityDomain} is already associated with the specified {@link ClassLoader}.
      * @param classLoader the non {@code null} {@link ClassLoader} to associate this {@link SecurityDomain} with.
      */
@@ -150,6 +152,8 @@ public final class SecurityDomain {
     /**
      * Get the {@link SecurityDomain} associated with the context class loader of the calling Thread or {@code null} if one is
      * not associated.
+     *
+     * Obtaining security domain with enabled security manager requires {@code getSecurityDomain} {@link ElytronPermission}.
      *
      * @return the {@link SecurityDomain} associated with the context class loader of the calling Thread or {@code null} if one
      *         is not associated.
@@ -174,6 +178,8 @@ public final class SecurityDomain {
     /**
      * Get the security domain associated with the given identity.
      *
+     * Obtaining security domain with enabled security manager requires {@code getSecurityDomain} {@link ElytronPermission}.
+     *
      * @param identity the security identity (must not be {@code null})
      * @return the identity's security domain (not {@code null})
      */
@@ -188,6 +194,8 @@ public final class SecurityDomain {
 
     /**
      * Unregister any {@link SecurityDomain} associated with the specified {@link ClassLoader}.
+     *
+     * Unregistration with enabled security manager requires {@code unregisterSecurityDomain} {@link ElytronPermission}.
      *
      * @param classLoader the non {@code null} {@link ClassLoader} to clear any {@link SecurityDomain} association.
      */
@@ -214,6 +222,8 @@ public final class SecurityDomain {
      * Create a new authentication context for this security domain which can be used to carry out a single authentication
      * operation.
      *
+     * Calling with enabled security manager requires {@code createServerAuthenticationContext} {@link ElytronPermission}.
+     *
      * @return the new authentication context
      */
     public ServerAuthenticationContext createNewAuthenticationContext() {
@@ -227,6 +237,8 @@ public final class SecurityDomain {
     /**
      * Create a new authentication context for this security domain which can be used to carry out a single authentication
      * operation.
+     *
+     * Calling with enabled security manager requires {@code createServerAuthenticationContext} {@link ElytronPermission}.
      *
      * @param mechanismConfigurationSelector the selector to use to obtain the mechanism configuration
      * @return the new authentication context
@@ -277,6 +289,8 @@ public final class SecurityDomain {
      * Perform an authentication based on {@link Evidence} for the specified identity {@link Principal}.
      *
      * Note:  It is the caller's responsibility to destroy any evidence passed into this method.
+     *
+     * Calling with enabled security manager requires {@code authenticate} {@link ElytronPermission}.
      *
      * @param principal the principal of the identity to authenticate or {@code null} if the identity is to be derived from the evidence.
      * @param evidence the {@link Evidence} to use for authentication.
@@ -334,6 +348,8 @@ public final class SecurityDomain {
      * Look up a {@link RealmIdentity} by principal.
      * The returned identity must be {@linkplain RealmIdentity#dispose() disposed}.
      *
+     * Calling with enabled security manager requires {@code getIdentity} {@link ElytronPermission}.
+     *
      * @param principal the principal to map (must not be {@code null})
      * @return the identity for the name (not {@code null}, may be non-existent)
      * @throws IllegalArgumentException if the principal could not be successfully decoded to a name
@@ -351,6 +367,8 @@ public final class SecurityDomain {
     /**
      * Look up a {@link ModifiableRealmIdentity} by principal.
      * The returned identity must be {@linkplain RealmIdentity#dispose() disposed}.
+     *
+     * Calling with enabled security manager requires {@code getIdentityForUpdate} {@link ElytronPermission}.
      *
      * @param principal the principal to map (must not be {@code null})
      * @return the identity for the name (not {@code null}, may be non-existent)
@@ -370,6 +388,8 @@ public final class SecurityDomain {
      * Get a function which can be used to look up principals without a security manager permission check.
      * All returned identities must be {@linkplain RealmIdentity#dispose() disposed}.
      *
+     * Calling with enabled security manager requires {@code getIdentity} {@link ElytronPermission}.
+     *
      * @return the lookup function (not {@code null})
      * @throws SecurityException if the caller is not authorized to perform the operation
      */
@@ -384,6 +404,7 @@ public final class SecurityDomain {
     /**
      * Get a function which can be used to look up principals for update without a security manager permission check.
      * All returned identities must be {@linkplain RealmIdentity#dispose() disposed}.
+     * Calling with enabled security manager requires {@code getIdentityForUpdate} {@link ElytronPermission}.
      *
      * @return the lookup function (not {@code null})
      * @throws SecurityException if the caller is not authorized to perform the operation
@@ -632,6 +653,8 @@ public final class SecurityDomain {
     /**
      * Create an empty ad-hoc identity.  The identity will have no authorization information and no credentials associated
      * with it.
+     *
+     * Calling with enabled security manager requires {@code createAdHocIdentity} {@link ElytronPermission}.
      *
      * @param principal the identity principal (must not be {@code null})
      * @return the ad-hoc identity
@@ -986,6 +1009,8 @@ public final class SecurityDomain {
 
         /**
          * Construct this security domain.
+         *
+         * Construction requires {@code createSecurityDomain} {@link ElytronPermission}.
          *
          * @return the new security domain
          */

--- a/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
+++ b/src/main/java/org/wildfly/security/auth/server/SecurityIdentity.java
@@ -46,6 +46,7 @@ import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.security.ParametricPrivilegedAction;
 import org.wildfly.security.ParametricPrivilegedExceptionAction;
 import org.wildfly.security.auth.permission.ChangeRoleMapperPermission;
+import org.wildfly.security.auth.permission.RunAsPrincipalPermission;
 import org.wildfly.security.auth.principal.AnonymousPrincipal;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.server.event.SecurityPermissionCheckFailedEvent;
@@ -192,7 +193,7 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
         return authorizationIdentity;
     }
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private Supplier<SecurityIdentity>[] establishIdentities() {
         SecurityIdentity[] withIdentities = this.withIdentities != null ? this.withIdentities : withSuppliedIdentities != null ? withSuppliedIdentities.get() : NO_IDENTITIES;
         if (withIdentities.length == 0) {
@@ -208,8 +209,7 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
         return oldIdentities;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private void restoreIdentities(Supplier[] securityIdentities) {
+    private void restoreIdentities(Supplier<SecurityIdentity>[] securityIdentities) {
         for (Supplier<SecurityIdentity> currentIdentity : securityIdentities) {
             currentIdentity.get().securityDomain.setCurrentSecurityIdentity(currentIdentity);
         }
@@ -438,6 +438,7 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
      * @return the action result (may be {@code null})
      * @throws PrivilegedActionException if the action fails
      */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static <T> T runAsAll(PrivilegedExceptionAction<T> action, SecurityIdentity... identities) throws PrivilegedActionException {
         if (action == null) return null;
         int length = identities.length;
@@ -590,6 +591,9 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
      * Attempt to create a new identity that can be used to run as a user with the given name. If the
      * current identity is not authorized to run as a user with the given name, an exception is thrown.
      *
+     * Calling with enabled security manager requires {@code setRunAsPrincipal} {@link ElytronPermission}.
+     * Regardless security manager is enabled, {@link RunAsPrincipalPermission} for given name is required.
+     *
      * @param name the name to attempt to run as
      * @return the new security identity
      * @throws SecurityException if the operation authorization failed for any reason
@@ -601,10 +605,11 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
     /**
      * Attempt to create a new identity that can be used to run as a user with the given name.
      *
+     * Calling with enabled security manager requires {@code setRunAsPrincipal} {@link ElytronPermission}.
+     *
      * @param name the name to attempt to run as
-     * @param authorize {@code true} to check the current identity is authorized to run as a user
-     *        with the given name, {@code false} to just check if the caller has the
-     *        {@code setRunAsPermission} {@link RuntimePermission}
+     * @param authorize whether to check the current identity is authorized to run as a user
+     *        with the given principal (has {@link RunAsPrincipalPermission})
      * @return the new security identity
      * @throws SecurityException if the caller does not have the {@code setRunAsPrincipal}
      *         {@link ElytronPermission} or if the operation authorization failed for any other reason
@@ -617,37 +622,39 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
     /**
      * Attempt to create a new identity that can be used to run as a user with the given principal.
      *
+     * Calling with enabled security manager requires {@code setRunAsPrincipal} {@link ElytronPermission}.
+     *
      * @param principal the principal to attempt to run as
-     * @param authorize {@code true} to check the current identity is authorized to run as a user
-     *        with the given principal, {@code false} to just check if the caller has the
-     *        {@code setRunAsPermission} {@link RuntimePermission}
+     * @param authorize whether to check the current identity is authorized to run as a user
+     *        with the given principal (has {@link RunAsPrincipalPermission})
      * @return the new security identity
      * @throws SecurityException if the caller does not have the {@code setRunAsPrincipal}
      *         {@link ElytronPermission} or if the operation authorization failed for any other reason
      */
     public SecurityIdentity createRunAsIdentity(Principal principal, boolean authorize) throws SecurityException {
         Assert.checkNotNullParam("principal", principal);
-        // rewrite principal
+
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(SET_RUN_AS_PERMISSION);
         }
 
-        SecurityIdentity identity = null;
         try (final ServerAuthenticationContext context = securityDomain.createNewAuthenticationContext(this, MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY))) {
             if (! (context.importIdentity(this) && context.authorize(principal, authorize))) {
                 throw log.runAsAuthorizationFailed(this.principal, principal, null);
             }
-            identity = context.getAuthorizedIdentity();
+            return context.getAuthorizedIdentity();
         } catch (RealmUnavailableException e) {
             throw log.runAsAuthorizationFailed(this.principal, principal, e);
         }
-        return identity;
     }
 
     /**
      * Attempt to create a new identity that can be used to run as an anonymous user. If the
      * current identity is not authorized to run as an anonymous user, an exception is thrown.
+     *
+     * Calling with enabled security manager requires {@code setRunAsPrincipal} {@link ElytronPermission}.
+     * {@link org.wildfly.security.auth.permission.LoginPermission} granted to the anonymous identity will be required.
      *
      * @return the new security identity
      * @throws SecurityException if the operation authorization failed for any reason
@@ -659,9 +666,10 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
     /**
      * Attempt to create a new identity that can be used to run as an anonymous user
      *
-     * @param authorize {@code true} to check the current identity is authorized to run as a user
-     *        with the given name, {@code false} to just check if the caller has the
-     *        {@code setRunAsPermission} {@link RuntimePermission}
+     * Calling with enabled security manager requires {@code setRunAsPrincipal} {@link ElytronPermission}.
+     *
+     * @param authorize whether to check the anonymous identity is authorized to log in
+     *                  (has {@link org.wildfly.security.auth.permission.LoginPermission})
      * @return the new security identity
      * @throws SecurityException if the caller does not have the {@code setRunAsPrincipal}
      *         {@link ElytronPermission} or if the operation authorization failed for any other reason
@@ -672,14 +680,12 @@ public final class SecurityIdentity implements PermissionVerifier, PermissionMap
             sm.checkPermission(SET_RUN_AS_PERMISSION);
         }
 
-        SecurityIdentity identity = null;
         try (final ServerAuthenticationContext context = securityDomain.createNewAuthenticationContext(this, MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY))) {
             if (! context.authorizeAnonymous(authorize)) {
                 throw log.runAsAuthorizationFailed(principal, AnonymousPrincipal.getInstance(), null);
             }
-            identity = context.getAuthorizedIdentity();
+            return context.getAuthorizedIdentity();
         }
-        return identity;
     }
 
     /**

--- a/src/main/java/org/wildfly/security/manager/StackInspector.java
+++ b/src/main/java/org/wildfly/security/manager/StackInspector.java
@@ -39,6 +39,7 @@ public final class StackInspector {
     /**
      * Get the singleton {@code StackInspector} instance.  The caller must have the {@code getStackInspector}
      * {@link RuntimePermission}.
+     * If the security manager is enabled, requires {@code getStackInspector} {@link WildFlySecurityManagerPermission}.
      *
      * @return the singleton {@code StackInspector} instance
      */

--- a/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
+++ b/src/test/java/org/wildfly/security/sasl/test/StringPrepTest.java
@@ -25,8 +25,8 @@ import java.text.Normalizer;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.wildfly.common.bytes.ByteStringBuilder;
 import org.wildfly.security.sasl.util.StringPrep;
-import org.wildfly.security.util.ByteStringBuilder;
 
 /**
  * Tests of org.wildfly.security.sasl.util.StringPrep by RFC 3454

--- a/src/test/java/org/wildfly/security/util/Base32Test.java
+++ b/src/test/java/org/wildfly/security/util/Base32Test.java
@@ -29,6 +29,7 @@ import org.wildfly.security.util.Alphabet.Base32Alphabet;
  *
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
+@Deprecated
 public class Base32Test {
 
     @Test

--- a/src/test/java/org/wildfly/security/util/Base64Test.java
+++ b/src/test/java/org/wildfly/security/util/Base64Test.java
@@ -35,6 +35,7 @@ import org.wildfly.security.util.Alphabet.Base64Alphabet;
  *
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
+@Deprecated
 public class Base64Test {
 
     /*


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1596

* improved javadoc to inform about required permissions
* few minor code improvements (to remove built warnings)