### PR TITLE
[ELY-1618] Avoid NPE in Protocol.forName() when the protocol name is null

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/Protocol.java
+++ b/src/main/java/org/wildfly/security/ssl/Protocol.java
@@ -80,7 +80,7 @@ public enum Protocol {
      * @return an enum item
      */
     public static Protocol forName(final String name) {
-        return map.get(name.toUpperCase(Locale.ENGLISH));
+        return name == null ? null : map.get(name.toUpperCase(Locale.ENGLISH));
     }
 
     /**


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1618