### PR TITLE
[ELY-1622] Ensure ConfigurationKeyManager.Builder gets used even when no key-store-ssl-certificate is specified

### DIFF
--- a/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -508,13 +508,13 @@ public final class ElytronXmlParser {
                     if (finalProtocolSelector != null) {
                         sslContextBuilder.setProtocolSelector(finalProtocolSelector);
                     }
+                    final ConfigurationKeyManager.Builder builder = new ConfigurationKeyManager.Builder();
                     if (finalCredentialFactory != null) {
-                        final ConfigurationKeyManager.Builder builder = new ConfigurationKeyManager.Builder();
                         final X509CertificateChainPrivateCredential privateCredential;
                         privateCredential = finalCredentialFactory.get();
                         builder.addCredential(privateCredential);
-                        sslContextBuilder.setKeyManager(builder.build());
                     }
+                    sslContextBuilder.setKeyManager(builder.build());
                     if (initTrustManager) {
                         if (finalTrustStoreSupplier != null) {
                             trustManagerBuilder.setTrustStore(finalTrustStoreSupplier.get());


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1622