### PR TITLE
[ELY-1595] Reenabling source compatibility check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -614,7 +614,7 @@
                     <plugin>
                         <groupId>com.github.siom79.japicmp</groupId>
                         <artifactId>japicmp-maven-plugin</artifactId>
-                        <version>0.12.0</version>
+                        <version>0.13.0</version>
                         <configuration>
                             <oldVersion>
                                 <dependency>
@@ -631,7 +631,7 @@
                             </newVersion>
                             <parameter>
                                 <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
-                                <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
+                                <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                                 <overrideCompatibilityChangeParameters>
                                     <overrideCompatibilityChangeParameter><!-- allowing new method in interface if default impl provided -->
                                         <compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1595

Reenabled source compatibility check which was disabled because of japicmp bug.