### PR TITLE
[ELY-793] Using @STRENGTH keyword in CipherSuiteSelector.fromString should cause descending sorting

### DIFF
--- a/src/main/java/org/wildfly/security/ssl/CipherSuiteSelector.java
+++ b/src/main/java/org/wildfly/security/ssl/CipherSuiteSelector.java
@@ -356,7 +356,7 @@ public abstract class CipherSuiteSelector {
      *             <li>The special {@code COMPLEMENTOFDEFAULT} keyword, which presently includes any anonymous cipher
      *                  suites (but excludes those without encryption, which must always be enabled manually).</li>
      *             <li>The special {@code @STRENGTH} keyword, which causes all the mechanisms enabled thus far to be
-     *                  automatically sorted by encryption algorithm key length.</li>
+     *                  automatically sorted by encryption algorithm key length in descending order.</li>
      *         </ul>
      *     </li>
      * </ul>
@@ -735,7 +735,7 @@ public abstract class CipherSuiteSelector {
                     final MechanismDatabase database = MechanismDatabase.getInstance();
                     final MechanismDatabase.Entry e1 = database.getCipherSuite(o1);
                     final MechanismDatabase.Entry e2 = database.getCipherSuite(o2);
-                    return Integer.signum(e1.getAlgorithmBits() - e2.getAlgorithmBits());
+                    return Integer.signum(e2.getAlgorithmBits() - e1.getAlgorithmBits());
                 });
                 enabled.clear();
                 enabled.addAll(list);

--- a/src/test/java/org/wildfly/security/ssl/CipherSuiteSelectorTest.java
+++ b/src/test/java/org/wildfly/security/ssl/CipherSuiteSelectorTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -227,7 +226,6 @@ public class CipherSuiteSelectorTest {
     }
 
     @Test
-    @Ignore("ELY-793")
     public void testStrengthForAllAndComplementofall() {
         CipherSuiteSelector selector = CipherSuiteSelector.fromString("ALL COMPLEMENTOFALL @STRENGTH");
         List<String> selectedSuites = Arrays.asList(selector.evaluate(SUPPORTED_SUITES));
@@ -240,7 +238,6 @@ public class CipherSuiteSelectorTest {
     }
 
     @Test
-    @Ignore("ELY-793")
     public void testStrengthForComplementofallAndAll() {
         CipherSuiteSelector selector = CipherSuiteSelector.fromString("COMPLEMENTOFALL ALL @STRENGTH");
         List<String> selectedSuites = Arrays.asList(selector.evaluate(SUPPORTED_SUITES));


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-793