### PR TITLE
[ELY-1678] Avoid NPE in AcmeClientSpi#checkContentType() when the content type is null and try to fix intermittent failures in AcmeClientSpiTest

### DIFF
--- a/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
+++ b/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
@@ -1109,6 +1109,9 @@ public abstract class AcmeClientSpi {
 
     private static boolean checkContentType(HttpURLConnection connection, String expectedMediaType) throws AcmeException {
         String contentType = connection.getContentType();
+        if (contentType == null) {
+            return false;
+        }
         CodePointIterator cpi = CodePointIterator.ofString(contentType);
         CodePointIterator di = cpi.delimitedBy(CONTENT_TYPE_DELIMS);
         String mediaType = di.drainToString().trim();

--- a/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -452,8 +452,7 @@ public class AcmeClientSpiTest {
         ClientAndServer server;
 
         AcmeMockServerBuilder(ClientAndServer server) {
-            server.reset();
-            this.server = server;
+            this.server = (ClientAndServer) server.reset();
         }
 
         public AcmeMockServerBuilder addDirectoryResponseBody(String directoryResponseBody) {


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1678