### PR TITLE
[ELY-1691] Add test if all ciphersuites from runtime JDK are known to MechanismDatabase

### DIFF
--- a/src/test/java/org/wildfly/security/ssl/MechanismDatabaseTest.java
+++ b/src/test/java/org/wildfly/security/ssl/MechanismDatabaseTest.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.ssl;
 
+import javax.net.ssl.SSLServerSocketFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -43,4 +45,21 @@ public class MechanismDatabaseTest {
         System.out.println(entry);
     }
 
+    @Test
+    public void testAllJdkCipherSuitesMapping() {
+        final MechanismDatabase mechanismDatabase = MechanismDatabase.getInstance();
+
+        SSLServerSocketFactory ssf = (SSLServerSocketFactory)SSLServerSocketFactory.getDefault();
+        String[] supportedCipherSuites = ssf.getSupportedCipherSuites();
+
+        StringBuffer unknownCipherSuites = new StringBuffer("");
+        for (int i = 0; i < supportedCipherSuites.length; i++) {
+            System.out.println("Trying " + supportedCipherSuites[i]);
+            MechanismDatabase.Entry entry = mechanismDatabase.getCipherSuite(supportedCipherSuites[i]);
+            if (entry == null) {
+                unknownCipherSuites.append(" ").append(supportedCipherSuites[i]);
+            }
+        }
+        Assert.assertTrue("There are JDK cipher suites which are unknown to Elytron MechanismDatabase; " + unknownCipherSuites,unknownCipherSuites.length()==0);
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1691 Add test if Mechansim Database cover cipher suites from JDK

It is up to developers to update MechanismDatabase according to final rfc-s outhere. But this is very hard task and can easily happen Elytron miss some ciphersuite from new release of JDK. This test comes to help point out such ciphersuite when this situation happens.

This has found https://issues.jboss.org/browse/ELY-1690