### PR TITLE
[ELY-1678] Avoid NPE in AcmeClientSpi#checkContentType() and [ELY-1699] Intermittently failing AcmeClientSpiTest

### DIFF
--- a/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
+++ b/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
@@ -1109,6 +1109,9 @@ public abstract class AcmeClientSpi {
 
     private static boolean checkContentType(HttpURLConnection connection, String expectedMediaType) throws AcmeException {
         String contentType = connection.getContentType();
+        if (contentType == null) {
+            return false;
+        }
         CodePointIterator cpi = CodePointIterator.ofString(contentType);
         CodePointIterator di = cpi.delimitedBy(CONTENT_TYPE_DELIMS);
         String mediaType = di.drainToString().trim();

--- a/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -452,8 +452,7 @@ public class AcmeClientSpiTest {
         ClientAndServer server;
 
         AcmeMockServerBuilder(ClientAndServer server) {
-            server.reset();
-            this.server = server;
+            this.server = (ClientAndServer) server.reset();
         }
 
         public AcmeMockServerBuilder addDirectoryResponseBody(String directoryResponseBody) {

--- a/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -31,6 +31,7 @@ import static org.wildfly.security.x500.cert.acme.Acme.BASE64_URL;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
@@ -151,6 +152,11 @@ public class AcmeClientSpiTest {
         if (server != null) {
             server.stop();
         }
+    }
+
+    @Before
+    public void resetServerExpectations() {
+        server = (ClientAndServer) server.reset();
     }
 
     @Test
@@ -452,7 +458,7 @@ public class AcmeClientSpiTest {
         ClientAndServer server;
 
         AcmeMockServerBuilder(ClientAndServer server) {
-            this.server = (ClientAndServer) server.reset();
+            this.server = server;
         }
 
         public AcmeMockServerBuilder addDirectoryResponseBody(String directoryResponseBody) {


### PR DESCRIPTION
JBEAP (7.2.z): https://issues.jboss.org/browse/JBEAP-16150

Upstream: https://issues.jboss.org/browse/ELY-1678
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1199

Upstream: https://issues.jboss.org/browse/ELY-1699
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1214