### PR TITLE
[ELY-1702] Update mockserver-netty to 5.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.org.wildfly.client.config>1.0.0.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
         <version.commons-io.commons-io>2.6</version.commons-io.commons-io>
-        <version.org.mock-server.mockserver-netty>5.3.0</version.org.mock-server.mockserver-netty>
+        <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
@@ -576,12 +576,6 @@
             <artifactId>mockserver-netty</artifactId>
             <version>${version.org.mock-server.mockserver-netty}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -538,7 +538,7 @@ public class AcmeClientSpiTest {
                             .withHeader("Content-Type", "application/jose+json")
                             .withBody(expectedChallengeRequestBody),
                     Times.once())
-                    .callback(request -> {
+                    .respond(request -> {
                         HttpResponse response = response()
                                 .withHeader("Cache-Control", "public, max-age=0, no-cache")
                                 .withHeader("Content-Type", useProblemContentType ? "application/problem+json" : "application/json")


### PR DESCRIPTION
JBEAP (7.2.z): https://issues.jboss.org/browse/JBEAP-16151
Upstream: https://issues.jboss.org/browse/ELY-1702
Upstream PR:  https://github.com/wildfly-security/wildfly-elytron/pull/1214 