### PR TITLE
[ELY-1711] Restore JavaDoc Generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,46 +248,133 @@
                         <notimestamp>true</notimestamp>
                         <doclint>none</doclint>
                         <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
+                        <sourcepath>
+                            ${project.basedir}/asn1/src/main/java/;
+                            ${project.basedir}/audit/src/main/java/;
+                            ${project.basedir}/auth/base/src/main/java/;
+                            ${project.basedir}/auth/client/src/main/java/;
+                            ${project.basedir}/auth/jaspi/src/main/java/;
+                            ${project.basedir}/auth/realm/base/src/main/java/;
+                            ${project.basedir}/auth/realm/jdbc/src/main/java/;
+                            ${project.basedir}/auth/realm/ldap/src/main/java/;
+                            ${project.basedir}/auth/realm/token/src/main/java/;
+                            ${project.basedir}/auth/server/base/src/main/java/;
+                            ${project.basedir}/auth/server/deprecated/src/main/java/;
+                            ${project.basedir}/auth/server/http/src/main/java/;
+                            ${project.basedir}/auth/server/sasl/src/main/java/;
+                            ${project.basedir}/auth/util/src/main/java/;
+                            ${project.basedir}/base/src/main/java/;
+                            ${project.basedir}/credential/base/src/main/java/;
+                            ${project.basedir}/credential/source/deprecated/src/main/java/;
+                            ${project.basedir}/credential/store/src/main/java/;
+                            ${project.basedir}/digest/src/main/java/;
+                            ${project.basedir}/http/base/src/main/java/;
+                            ${project.basedir}/http/basic/src/main/java/;
+                            ${project.basedir}/http/bearer/src/main/java/;
+                            ${project.basedir}/http/cert/src/main/java/;
+                            ${project.basedir}/http/deprecated/src/main/java/;
+                            ${project.basedir}/http/digest/src/main/java/;
+                            ${project.basedir}/http/form/src/main/java/;
+                            ${project.basedir}/http/spnego/src/main/java/;
+                            ${project.basedir}/http/sso/src/main/java/;
+                            ${project.basedir}/http/util/src/main/java/;
+                            ${project.basedir}/jacc/src/main/java/;
+                            ${project.basedir}/json-util/src/main/java/;
+                            ${project.basedir}/manager/action/src/main/java/;
+                            ${project.basedir}/manager/base/src/main/java9/; <!--java9/ must be before java/-->
+                            ${project.basedir}/manager/base/src/main/java/;
+                            ${project.basedir}/mechanism/base/src/main/java/;
+                            ${project.basedir}/mechanism/digest/src/main/java/;
+                            ${project.basedir}/mechanism/gssapi/src/main/java/;
+                            ${project.basedir}/mechanism/oauth2/src/main/java/;
+                            ${project.basedir}/mechanism/scram/src/main/java/;
+                            ${project.basedir}/permission/src/main/java/;
+                            ${project.basedir}/sasl/anonymous/src/main/java/;
+                            ${project.basedir}/sasl/auth/util/src/main/java/;
+                            ${project.basedir}/sasl/base/src/main/java/;
+                            ${project.basedir}/sasl/deprecated/src/main/java/;
+                            ${project.basedir}/sasl/digest/src/main/java/;
+                            ${project.basedir}/sasl/entity/src/main/java/;
+                            ${project.basedir}/sasl/external/src/main/java/;
+                            ${project.basedir}/sasl/gs2/src/main/java/;
+                            ${project.basedir}/sasl/gssapi/src/main/java/;
+                            ${project.basedir}/sasl/localuser/src/main/java/;
+                            ${project.basedir}/sasl/oauth2/src/main/java/;
+                            ${project.basedir}/sasl/otp/src/main/java/;
+                            ${project.basedir}/sasl/plain/src/main/java/;
+                            ${project.basedir}/sasl/scram/src/main/java/;
+                            ${project.basedir}/ssl/src/main/java/;
+                            ${project.basedir}/tests/base/src/main/java/;
+                            ${project.basedir}/tests/common/src/main/java/;
+                            ${project.basedir}/tool/src/main/java/;
+                            ${project.basedir}/util/src/main/java/;
+                            ${project.basedir}/wildfly-elytron-titan/src/main/java/;
+                            ${project.basedir}/x500/base/src/main/java/;
+                            ${project.basedir}/x500/cert/acme/src/main/java/;
+                            ${project.basedir}/x500/cert/base/src/main/java/;
+                            ${project.basedir}/x500/cert/util/src/main/java/;
+                            ${project.basedir}/x500/deprecated/src/main/java/;
+                            ${project.basedir}/x500/principal/src/main/java/;
+                        </sourcepath>
                         <sourceFileExcludes>
                             <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
                         </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
                     </configuration>
                     <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
+                        <execution><!-- mvn javadoc:aggregate@api-javadoc -->
+                            <id>api-javadoc</id>
+                            <goals>
+                                <goal>aggregate</goal>
+                            </goals>
+                            <configuration>
+                                <destDir>api-javadoc</destDir>
+                                <sourceFileIncludes>
+                                    <include>org/wildfly/security/*.java</include>
+                                    <include>org/wildfly/security/asn1/*.java</include>
+                                    <include>org/wildfly/security/auth/*.java</include>
+                                    <include>org/wildfly/security/auth/callback/*.java</include>
+                                    <include>org/wildfly/security/auth/client/*.java</include>
+                                    <include>org/wildfly/security/auth/jaspi/*.java</include>
+                                    <include>org/wildfly/security/auth/permission/*.java</include>
+                                    <include>org/wildfly/security/auth/principal/*.java</include>
+                                    <include>org/wildfly/security/auth/server/*.java</include>
+                                    <include>org/wildfly/security/auth/server/http/*.java</include>
+                                    <include>org/wildfly/security/auth/server/sasl/*.java</include>
+                                    <include>org/wildfly/security/auth/server/event/*.java</include>
+                                    <include>org/wildfly/security/auth/util/*.java</include>
+                                    <include>org/wildfly/security/authz/*.java</include>
+                                    <include>org/wildfly/security/credential/*.java</include>
+                                    <include>org/wildfly/security/credential/source/*.java</include>
+                                    <include>org/wildfly/security/credential/store/*.java</include>
+                                    <include>org/wildfly/security/evidence/*.java</include>
+                                    <include>org/wildfly/security/http/*.java</include>
+                                    <include>org/wildfly/security/key/*.java</include>
+                                    <include>org/wildfly/security/manager/*.java</include>
+                                    <include>org/wildfly/security/manager/_private/*.java</include>
+                                    <include>org/wildfly/security/manager/action/*.java</include>
+                                    <include>org/wildfly/security/mechanism/*.java</include>
+                                    <include>org/wildfly/security/mechanism/gssapi/*.java</include>
+                                    <include>org/wildfly/security/mechanism/_private/*.java</include>
+                                    <include>org/wildfly/security/password/*.java</include>
+                                    <include>org/wildfly/security/password/interfaces/*.java</include>
+                                    <include>org/wildfly/security/password/spec/*.java</include>
+                                    <include>org/wildfly/security/permission/*.java</include>
+                                    <include>org/wildfly/security/sasl/util/*.java</include>
+                                    <include>org/wildfly/security/sasl/auth/util/*.java</include>
+                                    <include>org/wildfly/security/ssl/*.java</include>
+                                    <include>org/wildfly/security/ssl/_private/*.java</include>
+                                    <include>org/wildfly/security/ssl/*.java</include>
+                                    <include>org/wildfly/security/x500/*.java</include>
+                                    <include>org/wildfly/security/x500/cert/*.java</include>
+                                    <include>org/wildfly/security/x500/principal/*.java</include>
+                                </sourceFileIncludes>
+                            </configuration>
+                        </execution>
+                        <execution><!-- mvn javadoc:aggregate@full-javadoc -->
                             <id>full-javadoc</id>
+                            <goals>
+                                <goal>aggregate</goal>
+                            </goals>
                             <configuration>
                                 <destDir>full-javadoc</destDir>
                                 <show>private</show>

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -256,64 +256,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/wildfly-elytron-titan/pom.xml
+++ b/wildfly-elytron-titan/pom.xml
@@ -216,64 +216,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -191,64 +191,6 @@
                     <version>${version.jar.plugin}</version>
                 </plugin>
 
-                <!-- Javadoc -->
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <configuration>
-                        <notimestamp>true</notimestamp>
-                        <doclint>none</doclint>
-                        <show>protected</show>
-                        <sourcepath>${project.basedir}/src/main/java9;${project.basedir}/src/main/java</sourcepath>
-                        <sourceFileIncludes>
-                            <include>org/wildfly/security/*.java</include>
-                            <include>org/wildfly/security/asn1/*.java</include>
-                            <include>org/wildfly/security/auth/*.java</include>
-                            <include>org/wildfly/security/auth/callback/*.java</include>
-                            <include>org/wildfly/security/auth/client/*.java</include>
-                            <include>org/wildfly/security/auth/jaspi/*.java</include>
-                            <include>org/wildfly/security/auth/permission/*.java</include>
-                            <include>org/wildfly/security/auth/principal/*.java</include>
-                            <include>org/wildfly/security/auth/server/*.java</include>
-                            <include>org/wildfly/security/auth/server/event/*.java</include>
-                            <include>org/wildfly/security/auth/util/*.java</include>
-                            <include>org/wildfly/security/authz/*.java</include>
-                            <include>org/wildfly/security/credential/*.java</include>
-                            <include>org/wildfly/security/credential/source/*.java</include>
-                            <include>org/wildfly/security/credential/store/*.java</include>
-                            <include>org/wildfly/security/evidence/*.java</include>
-                            <include>org/wildfly/security/http/*.java</include>
-                            <include>org/wildfly/security/key/*.java</include>
-                            <include>org/wildfly/security/manager/*.java</include>
-                            <include>org/wildfly/security/manager/action/*.java</include>
-                            <include>org/wildfly/security/mechanism/*.java</include>
-                            <include>org/wildfly/security/password/*.java</include>
-                            <include>org/wildfly/security/password/interfaces/*.java</include>
-                            <include>org/wildfly/security/password/spec/*.java</include>
-                            <include>org/wildfly/security/permission/*.java</include>
-                            <include>org/wildfly/security/sasl/util/*.java</include>
-                            <include>org/wildfly/security/ssl/*.java</include>
-                            <include>org/wildfly/security/x500/*.java</include>
-                            <include>org/wildfly/security/x500/cert/*.java</include>
-                        </sourceFileIncludes>
-                        <sourceFileExcludes>
-                            <exclude>org/wildfly/security/manager/JDKSpecific.java</exclude>
-                        </sourceFileExcludes>
-                        <destDir>api-javadoc</destDir>
-                    </configuration>
-                    <executions>
-                        <execution><!-- mvn javadoc:javadoc@full-javadoc -->
-                            <id>full-javadoc</id>
-                            <configuration>
-                                <destDir>full-javadoc</destDir>
-                                <show>private</show>
-                                <sourceFileIncludes>
-                                    <include>**\/\*.java</include>
-                                </sourceFileIncludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!-- Checkstyle -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
For successfull javadoc generation it was necessary to specify **sourcepath**, because `manager/base/src/main/java9/` must be before `manager/base/src/main/java/` . Not sure why, but it was true before modularization also: https://github.com/wildfly-security/wildfly-elytron/blob/master/pom.xml#L306. The maven-javadoc-plugin does not support wildcards in **sourcepath**,  so all the paths are listed (I did not find nicer solution in the documentation of javadoc tool or javadoc plugin) .

Usage (it is in the comment of pom.xml also ):
` mvn javadoc:aggregate@api-javadoc` for api-javadoc
` mvn javadoc:aggregate@full-javadoc` for full-javadoc