### PR TITLE
[ELY-1464] Programatic authentication should be caching the SecurityIdentity not the name of the identity 

### DIFF
--- a/src/main/java/org/wildfly/security/cache/CachedIdentity.java
+++ b/src/main/java/org/wildfly/security/cache/CachedIdentity.java
@@ -18,13 +18,12 @@
 
 package org.wildfly.security.cache;
 
-import org.wildfly.security.auth.server.SecurityIdentity;
+import static org.wildfly.common.Assert.checkNotNullParam;
 
 import java.io.Serializable;
 import java.security.Principal;
-import java.util.function.Supplier;
 
-import static org.wildfly.common.Assert.checkNotNullParam;
+import org.wildfly.security.auth.server.SecurityIdentity;
 
 /**
  * Represents a cached identity, managed by an {@link IdentityCache}.
@@ -48,7 +47,7 @@ public final class CachedIdentity implements Serializable {
      * @param securityIdentity the identity to cache
      */
     public CachedIdentity(String mechanismName, SecurityIdentity securityIdentity) {
-        this(mechanismName, securityIdentity, () -> checkNotNullParam("securityIdentity", securityIdentity).getPrincipal());
+        this(mechanismName, checkNotNullParam("securityIdentity", securityIdentity), securityIdentity.getPrincipal());
     }
 
     /**
@@ -58,12 +57,12 @@ public final class CachedIdentity implements Serializable {
      * @param principal the principal of this cached identity
      */
     public CachedIdentity(String mechanismName, Principal principal) {
-        this(mechanismName, null, () -> principal);
+        this(mechanismName, null, principal);
     }
 
-    private CachedIdentity(String mechanismName, SecurityIdentity securityIdentity, Supplier<Principal> principalSupplier) {
+    private CachedIdentity(String mechanismName, SecurityIdentity securityIdentity, Principal principal) {
         this.mechanismName = checkNotNullParam("mechanismName", mechanismName);
-        this.name = checkNotNullParam("name", checkNotNullParam("principal", principalSupplier.get()).getName());
+        this.name = checkNotNullParam("name", checkNotNullParam("principal", principal).getName());
         this.securityIdentity = securityIdentity;
     }
 

--- a/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -46,6 +46,7 @@ import org.wildfly.security.auth.server.RealmUnavailableException;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.auth.server.ServerAuthenticationContext;
+import org.wildfly.security.cache.CachedIdentity;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.evidence.Evidence;
 import org.wildfly.security.evidence.PasswordGuessEvidence;
@@ -61,7 +62,7 @@ import org.wildfly.security.password.interfaces.ClearPassword;
  */
 public class HttpAuthenticator {
 
-    private static final String AUTHENTICATED_PRINCIPAL_KEY = HttpAuthenticator.class.getName() + ".authenticated-principal";
+    private static final String AUTHENTICATED_IDENTITY_KEY = HttpAuthenticator.class.getName() + ".authenticated-identity";
 
     private final Supplier<List<HttpServerAuthenticationMechanism>> mechanismSupplier;
     private final SecurityDomain securityDomain;
@@ -133,15 +134,18 @@ public class HttpAuthenticator {
             authenticationContext.setAuthenticationName(username);
             if (authenticationContext.verifyEvidence(evidence)) {
                 if (evidence instanceof PasswordGuessEvidence) {
+                    log.tracef("Associating credential for '%s' with identity.", username);
                     authenticationContext.addPrivateCredential(
                             new PasswordCredential(ClearPassword.createRaw(ClearPassword.ALGORITHM_CLEAR, ((PasswordGuessEvidence) evidence).getGuess())));
                 }
                 if (authenticationContext.authorize()) {
                     SecurityIdentity authorizedIdentity = authenticationContext.getAuthorizedIdentity();
                     HttpScope sessionScope = httpExchangeSpi.getScope(Scope.SESSION);
-                    if (sessionScope != null && sessionScope.supportsAttachments()
-                            && (sessionScope.exists() || sessionScope.create())) {
-                        sessionScope.setAttachment(AUTHENTICATED_PRINCIPAL_KEY, username);
+                    if (sessionScope != null && sessionScope.supportsAttachments() && (sessionScope.exists() || sessionScope.create())) {
+                        log.tracef("Caching identity for '%s' against session scope.", username);
+                        sessionScope.setAttachment(AUTHENTICATED_IDENTITY_KEY, new CachedIdentity(mechanismName, authorizedIdentity));
+                    } else {
+                        log.tracef("Unable to cache identity for '%s'.", username);
                     }
                     setupProgramaticLogout(sessionScope);
 
@@ -176,23 +180,45 @@ public class HttpAuthenticator {
 
         HttpScope sessionScope = httpExchangeSpi.getScope(Scope.SESSION);
         if (sessionScope != null && sessionScope.supportsAttachments()) {
-            String principalName = sessionScope.getAttachment(AUTHENTICATED_PRINCIPAL_KEY, String.class);
-            if (principalName != null) {
+            CachedIdentity cachedIdentity = sessionScope.getAttachment(AUTHENTICATED_IDENTITY_KEY, CachedIdentity.class);
+            if (cachedIdentity != null) {
                 ServerAuthenticationContext authenticationContext = securityDomain.createNewAuthenticationContext();
+                SecurityIdentity securityIdentity = cachedIdentity.getSecurityIdentity();
+
                 try {
-                    authenticationContext.setAuthenticationName(principalName);
-                    if (authenticationContext.authorize()) {
-                        SecurityIdentity authorizedIdentity = authenticationContext.getAuthorizedIdentity();
-                        httpExchangeSpi.authenticationComplete(authorizedIdentity, programaticMechanismName);
+                    boolean authorized = securityIdentity != null && authenticationContext.importIdentity(securityIdentity);
+                    boolean cache = false;
+
+                    if (authorized == false) {
+                        log.trace("Unable to use SecurityIdentity from CachedIdentity - attempting to recreate");
+
+                        authenticationContext.setAuthenticationName(cachedIdentity.getName());
+                        authorized = authenticationContext.authorize();
+                        cache = true;
+                    }
+
+                    if (authorized) {
+                        securityIdentity = authenticationContext.getAuthorizedIdentity();
+
+                        httpExchangeSpi.authenticationComplete(securityIdentity, cachedIdentity.getMechanismName());
                         setupProgramaticLogout(sessionScope);
 
+                        if (cache) {
+                            log.tracef("Replacing cached identity for '%s' against session scope.", cachedIdentity.getName());
+                            sessionScope.setAttachment(AUTHENTICATED_IDENTITY_KEY, new CachedIdentity(cachedIdentity.getMechanismName(), securityIdentity));
+                        }
+
                         return true;
-                    } else {
-                        sessionScope.setAttachment(AUTHENTICATED_PRINCIPAL_KEY, null); // Whatever was in there no longer works so just drop it.
                     }
                 } catch (IllegalArgumentException | RealmUnavailableException | IllegalStateException e) {
                     httpExchangeSpi.authenticationFailed(e.getMessage(), programaticMechanismName);
                 }
+
+                log.tracef("Restoring identify '%s' failed, clearing cache from scope.", cachedIdentity.getName());
+                sessionScope.setAttachment(AUTHENTICATED_IDENTITY_KEY, null); // Whatever was in there no longer works so just
+                                                                              // drop it.
+            } else {
+                log.trace("No CachedIdentity to restore.");
             }
         }
 
@@ -201,7 +227,7 @@ public class HttpAuthenticator {
 
     private void setupProgramaticLogout(HttpScope sessionScope) {
         logoutHandlerConsumer.accept(() -> {
-            sessionScope.setAttachment(AUTHENTICATED_PRINCIPAL_KEY, null);
+            sessionScope.setAttachment(AUTHENTICATED_IDENTITY_KEY, null);
         });
     }
 


### PR DESCRIPTION
If we are to include more fixes this one may be good to get in.

https://issues.jboss.org/browse/ELY-1464

PR for 1.6.x is also at https://github.com/wildfly-security/wildfly-elytron/pull/1233