### PR TITLE
[ELY-1677] Elytron Bearer Token Authentication - Return a 401 on Invalid Token

### DIFF
--- a/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanism.java
+++ b/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanism.java
@@ -101,16 +101,20 @@ final class BearerTokenAuthenticationMechanism implements HttpServerAuthenticati
                             handleCallback(new IdentityCredentialCallback(new BearerTokenCredential(tokenEvidence.getToken()), true));
                             handleCallback(AuthenticationCompleteCallback.SUCCEEDED);
                             request.authenticationComplete();
-                            return;
+                        } else {
+                            httpBearer.debugf("Token authorization failed.");
+                            request.authenticationFailed(httpBearer.authorizationFailed(), response -> response.setStatusCode(FORBIDDEN));
                         }
+                    } else {
+                        httpBearer.debugf("Token authentication failed.");
+                        request.authenticationFailed(httpBearer.authenticationFailed(), this::unauthorizedResponse);
                     }
-                    httpBearer.debugf("Token authentication failed.");
-                    request.authenticationFailed("Invalid bearer token", response -> response.setStatusCode(FORBIDDEN));
                     return;
                 }
             }
         }
 
+        httpBearer.authenticationFailed();
         request.noAuthenticationInProgress(this::unauthorizedResponse);
     }
 

--- a/mechanism/base/src/main/java/org/wildfly/security/mechanism/_private/ElytronMessages.java
+++ b/mechanism/base/src/main/java/org/wildfly/security/mechanism/_private/ElytronMessages.java
@@ -519,6 +519,9 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 6022, value = "Invalid nonce count %s")
     HttpAuthenticationException invalidNonceCount(int nonceCount);
 
+    @Message(id = 6023, value = "An authorization check failed.")
+    String authorizationFailed();
+
     @Message(id = 7001, value = "Unrecognized encoding algorithm [%s]")
     ASN1Exception asnUnrecognisedAlgorithm(String algorithm);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1677