### PR TITLE
[ELY-1677] Elytron Bearer Token Authentication - Return a 401 on Invalid Token

### DIFF
--- a/src/main/java/org/wildfly/security/http/impl/BearerTokenAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/BearerTokenAuthenticationMechanism.java
@@ -101,11 +101,14 @@ final class BearerTokenAuthenticationMechanism implements HttpServerAuthenticati
                             handleCallback(new IdentityCredentialCallback(new BearerTokenCredential(tokenEvidence.getToken()), true));
                             handleCallback(AuthenticationCompleteCallback.SUCCEEDED);
                             request.authenticationComplete();
-                            return;
+                        } else {
+                            httpBearer.debugf("Token authorization failed.");
+                            request.authenticationFailed("Authorization failed.", response -> response.setStatusCode(FORBIDDEN));
                         }
+                    } else {
+                        httpBearer.debugf("Token authentication failed.");
+                        request.authenticationFailed(httpBearer.authenticationFailed(), this::unauthorizedResponse);
                     }
-                    httpBearer.debugf("Token authentication failed.");
-                    request.authenticationFailed("Invalid bearer token", response -> response.setStatusCode(FORBIDDEN));
                     return;
                 }
             }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1677