### PR TITLE
[ELY-1711] Add new modules to japicmp config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1265,6 +1265,11 @@
                                 </dependency>
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron-keystore</artifactId>
+                                    <version>${project.version}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-jaspi</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
@@ -1285,12 +1290,22 @@
                                 </dependency>
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron-mechanism-http</artifactId>
+                                    <version>${project.version}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-mechanism-oauth2</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-mechanism-scram</artifactId>
+                                    <version>${project.version}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron-password-impl</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
                                 <dependency>
@@ -1410,12 +1425,6 @@
                                 </dependency>
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
-                                    <artifactId>wildfly-elytron-tests-common</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>test-jar</type>
-                                </dependency>
-                                <dependency>
-                                    <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-util</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
@@ -1490,6 +1499,7 @@
                                     <include>org.wildfly.security.permission</include>
                                     <include>org.wildfly.security.sasl.util</include>
                                     <include>org.wildfly.security.ssl</include>
+                                    <include>org.wildfly.security.tool</include>
                                     <include>org.wildfly.security.x500</include>
                                     <include>org.wildfly.security.x500.cert</include>
                                 </includes>


### PR DESCRIPTION
I identified the following new modules: 
* wildfly-security-keystore
* wildfly-security-mechanism-http
* wildfly-security-password-impl
* wildfly-security-tool
* wildfly-security-tests-common

The only new public package is **org.wildfly.security.tool**
I removed wildfly-elytron-tests-common from the config I don't think it needs to be there (as it does not contain any non-test sources).