### PR TITLE
[ELY-1761] Add property to skip normalization

### DIFF
--- a/sasl/base/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
+++ b/sasl/base/src/main/java/org/wildfly/security/sasl/WildFlySasl.java
@@ -164,5 +164,12 @@ public final class WildFlySasl {
      * Note: This is a server only property and is not used client side.
      */
     public static final String GSSAPI_CREATE_NAME_GSS_INIT = "wildfly.sasl.gssapi.server.create-name-gss-init";
+    
+    /**
+     * A property used to disable Unicode normalization for passwords.
+     *
+     * Note: This is a client only property and is not used server side.
+     */
+    public static final String SKIP_NORMALIZATION = "org.wildfly.sasl.skip-normalization";
 
 }

--- a/sasl/base/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
+++ b/sasl/base/src/main/java/org/wildfly/security/sasl/util/StringPrep.java
@@ -79,6 +79,10 @@ public final class StringPrep {
     public static final long PROFILE_SASL_STORED = 0
         | PROFILE_SASL_QUERY
         | FORBID_UNASSIGNED;
+    
+    public static final long PROFILE_SASL_STORED_NON_NORMALIZED = (0
+            | PROFILE_SASL_STORED)
+            & ~NORMALIZE_KC;
 
     // StringPrep section 3 - Mapping
 

--- a/sasl/plain/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
+++ b/sasl/plain/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClient.java
@@ -44,11 +44,13 @@ final class PlainSaslClient implements SaslClient, SaslWrapper {
 
     private final String authorizationId;
     private final CallbackHandler cbh;
+    private final long profile;
     private boolean complete = false;
 
-    PlainSaslClient(final String authorizationId, final CallbackHandler cbh) {
+    PlainSaslClient(final String authorizationId, final CallbackHandler cbh, final boolean skipNormalization) {
         this.authorizationId = authorizationId;
         this.cbh = cbh;
+        this.profile = skipNormalization ? StringPrep.PROFILE_SASL_STORED_NON_NORMALIZED : StringPrep.PROFILE_SASL_STORED;
     }
 
     public String getMechanismName() {
@@ -87,12 +89,12 @@ final class PlainSaslClient implements SaslClient, SaslWrapper {
         try {
             final ByteStringBuilder b = new ByteStringBuilder();
             if (authorizationId != null) {
-                StringPrep.encode(authorizationId, b, StringPrep.PROFILE_SASL_STORED);
+                StringPrep.encode(authorizationId, b, this.profile);
             }
             b.append((byte) 0);
-            StringPrep.encode(name, b, StringPrep.PROFILE_SASL_STORED);
+            StringPrep.encode(name, b, this.profile);
             b.append((byte) 0);
-            StringPrep.encode(password, b, StringPrep.PROFILE_SASL_STORED);
+            StringPrep.encode(password, b, this.profile);
             return b.toArray();
         } catch (IllegalArgumentException ex) {
             throw saslPlain.mechMalformedFields(ex).toSaslException();

--- a/sasl/plain/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClientFactory.java
+++ b/sasl/plain/src/main/java/org/wildfly/security/sasl/plain/PlainSaslClientFactory.java
@@ -44,7 +44,13 @@ public final class PlainSaslClientFactory implements SaslClientFactory {
         if (props == null) props = Collections.emptyMap();
         if (PlainSasl.isMatched(props, false)) for (String mechanism : mechanisms) {
             if (SaslMechanismInformation.Names.PLAIN.equals(mechanism)) {
-                return new PlainSaslClient(authorizationId, cbh);
+                boolean skipNormalization;
+                if (props.containsKey(WildFlySasl.SKIP_NORMALIZATION)) {
+                    skipNormalization = Boolean.parseBoolean((String) props.get(WildFlySasl.SKIP_NORMALIZATION));
+                } else {
+                    skipNormalization = false;
+                }
+                return new PlainSaslClient(authorizationId, cbh, skipNormalization);
             }
         }
         return null;


### PR DESCRIPTION
Add the "org.wildfly.sasl.skip-normalization" property to optionally
skip Unicode normalization.