### PR TITLE
[ELY-1810] Only check the permission against the current SecurityIdentity if it is a JACC permission.

### DIFF
--- a/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
+++ b/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
@@ -104,12 +104,15 @@ public class JaccDelegatingPolicy extends Policy {
                 if (impliesRolePermission(domain, permission, policyConfiguration)) {
                     return true;
                 }
+
+                // Here we check the permissions mapped to the current identity.
+                // We only perform this check for JACC permissions otherwise we intercept all
+                // SecurityManager checks.
+                if (impliesIdentityPermission(permission)) {
+                    return true;
+                }
             }
 
-            // here we check the permissions mapped to the current identity.
-            if (impliesIdentityPermission(permission)) {
-                return true;
-            }
         } catch (Exception e) {
             log.authzFailedToCheckPermission(domain, permission, e);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1810