### PR TITLE
[ELY-1810] Only check the permission against the current SecurityIdentity if it is a JACC permission.

### DIFF
--- a/jacc/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
+++ b/jacc/src/main/java/org/wildfly/security/authz/jacc/JaccDelegatingPolicy.java
@@ -103,12 +103,15 @@ public class JaccDelegatingPolicy extends Policy {
                 if (impliesRolePermission(domain, permission, policyConfiguration)) {
                     return true;
                 }
+
+                // Here we check the permissions mapped to the current identity.
+                // We only perform this check for JACC permissions otherwise we intercept all
+                // SecurityManager checks.
+                if (impliesIdentityPermission(permission)) {
+                    return true;
+                }
             }
 
-            // here we check the permissions mapped to the current identity.
-            if (impliesIdentityPermission(permission)) {
-                return true;
-            }
         } catch (Exception e) {
             log.authzFailedToCheckPermission(domain, permission, e);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1810


1.9 variant of https://github.com/wildfly-security/wildfly-elytron/pull/1284