### PR TITLE
[ELY-1519] Make restore of SecurityIdentity on replicated session configurable

### DIFF
--- a/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -78,6 +78,12 @@ public class HttpConstants {
     public static final String CONFIG_CREATE_NAME_GSS_INIT = CONFIG_BASE + ".create-name-gss-init";
 
     /**
+     * In clustered environment Security Identity is restored during failover, load balancer change node (not sticky behavior) and session passivation/activation.
+     * Set to "true" to disable this behavior.
+     */
+    public static final String CONFIG_DISABLE_RESTORE_SECURITY_IDENTITY = CONFIG_BASE + ".disable-restore-security-identity";
+
+    /**
      * A comma separated list of scopes in preferred order the mechanism should attempt to use to persist state including the
      * caching of any previously authenticated identity.
      *

--- a/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
+++ b/src/main/java/org/wildfly/security/http/impl/SpnegoAuthenticationMechanism.java
@@ -30,6 +30,7 @@ import static org.wildfly.security.http.HttpConstants.NEGOTIATE;
 import static org.wildfly.security.http.HttpConstants.SPNEGO_NAME;
 import static org.wildfly.security.http.HttpConstants.UNAUTHORIZED;
 import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
+import static org.wildfly.security.http.HttpConstants.CONFIG_DISABLE_RESTORE_SECURITY_IDENTITY;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -90,6 +91,7 @@ public final class SpnegoAuthenticationMechanism implements HttpServerAuthentica
     private final CallbackHandler callbackHandler;
     private final GSSManager gssManager;
     private final Scope[] storageScopes;
+    private final boolean disableRestoreSecurityIdentity;
 
     SpnegoAuthenticationMechanism(final CallbackHandler callbackHandler, final Map<String, ?> properties) {
         checkNotNullParam("callbackHandler", callbackHandler);
@@ -97,6 +99,7 @@ public final class SpnegoAuthenticationMechanism implements HttpServerAuthentica
 
         this.callbackHandler = callbackHandler;
         this.gssManager = properties.containsKey(CONFIG_GSS_MANAGER) ? (GSSManager) properties.get(CONFIG_GSS_MANAGER) : GSSManager.getInstance();
+        this.disableRestoreSecurityIdentity = properties.containsKey(CONFIG_DISABLE_RESTORE_SECURITY_IDENTITY) && Boolean.parseBoolean((String) properties.get(CONFIG_DISABLE_RESTORE_SECURITY_IDENTITY));
 
         // JDK-8194073 workaround (for Oracle JDK + native Kerberos)
         if (properties.containsKey(CONFIG_CREATE_NAME_GSS_INIT) && Boolean.parseBoolean((String) properties.get(CONFIG_CREATE_NAME_GSS_INIT))) {
@@ -321,7 +324,9 @@ public final class SpnegoAuthenticationMechanism implements HttpServerAuthentica
     }
 
     private IdentityCache createIdentityCache(final IdentityCache existingCache, final HttpScope httpScope, boolean forUpdate) {
-        if (existingCache != null || // If we have a cache continue to use it.
+      if (disableRestoreSecurityIdentity ? existingCache != null && existingCache.get() != null && existingCache.get().getSecurityIdentity() != null
+                : existingCache != null || // disable-restore-security-identity option is "true": Use the cache only if it has SecurityIdentity.
+                                           // disable-restore-security-identity option is "false" (default): If we have a cache continue to use it.
                 httpScope == null || // If we don't have a scope we can't create a cache (existing cache is null so return it)
                 !httpScope.supportsAttachments() || // It is not null but if it doesn't support attachments pointless to wrap in a cache
                 (!httpScope.exists() && (!forUpdate || !httpScope.create())) // Doesn't exist and if update is requested can't be created


### PR DESCRIPTION
JBEAP (7.2.x): https://issues.jboss.org/browse/JBEAP-15807
Upstream: https://issues.jboss.org/browse/ELY-1519
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1216

In clustered environment Security Identity is restored during failover,
load balancer change node (not sticky behavior) and session
passivation/activation. Adding disable-restore-security-identity
configuration option which disables this behavior when set to "true".