### PR TITLE
[ELY-1867] and [ELY-1868] Update syslog audit endpoint to use current reconnect attempts in infinite case and Fix syslog audit endpoint udp infinite test case

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/audit/SyslogAuditEndpointTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/audit/SyslogAuditEndpointTest.java
@@ -46,7 +46,7 @@ public class SyslogAuditEndpointTest {
     private static final int TCP_PORT = 10857;
     private static final int RECONNECT_NUMBER = 10;
     private static final int BAD_RECONNECT_NUMBER = -2;
-    private static final int RECONNECT_TIMEOUT = 10;
+    private static final int RECONNECT_TIMEOUT = 450;
     private static SocketFactory socketFactory = null;
     private static SimpleSyslogServer udpServer = null;
     private static SimpleSyslogServer tcpServer = null;
@@ -119,7 +119,19 @@ public class SyslogAuditEndpointTest {
         Thread t = new Thread(() -> {
             try {
                 // Since the endpoint gives a message upon creation there is no need to call .accept()
-                AuditEndpoint endpoint = setupEndpointBadUdpReconnectAttempts(-1);
+                SyslogAuditEndpoint endpoint = (SyslogAuditEndpoint) setupEndpointBadUdpReconnectAttempts(-1);
+                int attemptNumber = 1;
+                int currentAttempts = endpoint.getAttempts();
+                while(attemptNumber == currentAttempts || currentAttempts == -1) {
+                    endpoint.accept(EventPriority.INFORMATIONAL, "This is a test message that should fail.");
+                    currentAttempts = endpoint.getAttempts();
+                    if (currentAttempts != -1) {
+                        attemptNumber++;
+                    }
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
+                }
                 if (!Thread.currentThread().isInterrupted()) {
                     this.failString = "No error was thrown while attempting to log to a bad IP with UDP.";
                 }


### PR DESCRIPTION
ELY-1867: https://issues.jboss.org/projects/ELY/issues/ELY-1867
ELY-1868: https://issues.jboss.org/projects/ELY/issues/ELY-1868