### PR TITLE
[ELY-1866] Fixed broken symbolic link to LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,1 +1,1 @@
-src/main/resources/META-INF/LICENSE.txt
+tool/src/main/resources/META-INF/LICENSE.txt


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1866