### PR TITLE
[ELY-1876] Log messages are not logged when KeyStoreCredentialStore is initialized with Provider[] in getKeyStoreInstance.

### DIFF
--- a/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -919,9 +919,14 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
 
     private KeyStore getKeyStoreInstance(String type) throws CredentialStoreException {
         if (providers != null) {
+            if (log.isTraceEnabled()) {
+               log.tracef("Obtaining KeyStore instance of type %s, providers: %s", type, Arrays.toString(providers));
+            }
             for (Provider p: providers) {
                 try {
-                    return KeyStore.getInstance(type, p);
+                    KeyStore ks = KeyStore.getInstance(type, p);
+                    log.tracef("Obtained KeyStore instance: %s, provider: %s", ks, p.toString());
+                    return ks;
                 } catch (KeyStoreException e) {
                     // no such keystore type in provider, ignore
                 }


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1876