### PR TITLE
[ELY-1895] Ignore failure scenario testing as bad UDP host does not trigger the failure in all environments.

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/audit/SyslogAuditEndpointTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/audit/SyslogAuditEndpointTest.java
@@ -30,6 +30,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -113,6 +114,7 @@ public class SyslogAuditEndpointTest {
      * Tests that the server continuously attempts to resend the message for {@link SyslogAuditEndpointTest#RECONNECT_TIMEOUT} milliseconds
      */
     @Test
+    @Ignore("[ELY-1895] Testing of failures is unreliable.")
     public void testFailureInfiniteReconnectAttempts() throws Exception {
         // Windows Server can have an issue echoing back an error, causing the test to fail by not seeing a failure sending
         Assume.assumeFalse("Test does not run on Windows Server", SystemUtils.OS_NAME.contains("Windows Server"));
@@ -152,6 +154,7 @@ public class SyslogAuditEndpointTest {
      * Tests that the server never reattempts to send the message
      */
     @Test
+    @Ignore("[ELY-1895] Testing of failures is unreliable.")
     public void testFailureZeroReconnectAttempts() throws Exception {
         // Windows Server can have an issue echoing back an error, causing the test to fail by not seeing a failure sending
         Assume.assumeFalse("Test does not run on Windows Server", SystemUtils.OS_NAME.contains("Windows Server"));
@@ -168,6 +171,7 @@ public class SyslogAuditEndpointTest {
      * Tests that the server reattempts to send the message {@link SyslogAuditEndpointTest#RECONNECT_NUMBER} times
      */
     @Test
+    @Ignore("[ELY-1895] Testing of failures is unreliable.")
     public void testFailureNumberedReconnectAttempts() throws Exception {
         // Windows Server can have an issue echoing back an error, causing the test to fail by not seeing a failure sending
         Assume.assumeFalse("Test does not run on Windows Server", SystemUtils.OS_NAME.contains("Windows Server"));


### PR DESCRIPTION
In the future we will need to revisit for a more reliable test.  Mocking the SocketFactory allows a switch to TCP however TCP error handling is different making it incompatible with the test.

https://issues.jboss.org/browse/ELY-1895