### PR TITLE
[ELY-1884] Adding MicroProfile JWT Support

### DIFF
--- a/jwt/pom.xml
+++ b/jwt/pom.xml
@@ -35,7 +35,16 @@
     <description>WildFly Security JWT / SmallRye Integration</description>
 
     <dependencies>
-        
+        <dependency>
+            <artifactId>smallrye-jwt</artifactId>
+            <groupId>io.smallrye</groupId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>

--- a/jwt/pom.xml
+++ b/jwt/pom.xml
@@ -51,6 +51,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <artifactId>smallrye-jwt</artifactId>
             <groupId>io.smallrye</groupId>
             <scope>provided</scope>

--- a/jwt/pom.xml
+++ b/jwt/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2019 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-parent</artifactId>
+        <version>1.11.0.CR4-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wildfly-elytron-jwt</artifactId>
+
+    <name>WildFly Elytron - JWT</name>
+    <description>WildFly Security JWT / SmallRye Integration</description>
+
+    <dependencies>
+        
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>        
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+               
+    </dependencies>
+
+</project>

--- a/jwt/pom.xml
+++ b/jwt/pom.xml
@@ -33,6 +33,21 @@
 
     <name>WildFly Elytron - JWT</name>
     <description>WildFly Security JWT / SmallRye Integration</description>
+    
+    <build>
+        <resources>
+            <resource>
+                <directory>${project.build.sourceDirectory}</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*.Extension</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 
     <dependencies>
         <dependency>

--- a/jwt/src/main/java/org/wildfly/security/mp/jwt/JWTCDIExtension.java
+++ b/jwt/src/main/java/org/wildfly/security/mp/jwt/JWTCDIExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.mp.jwt;
+
+import io.smallrye.jwt.auth.cdi.SmallRyeJWTAuthCDIExtension;
+
+/**
+ * An extension of {@link SmallRyeJWTAuthCDIExtension} to allow overrides.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class JWTCDIExtension extends SmallRyeJWTAuthCDIExtension {
+
+    @Override
+    protected boolean registerOptionalClaimTypeProducer() {
+        return true;
+    }
+
+}

--- a/jwt/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/jwt/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.smallrye.jwt.auth.cdi.SmallRyeJWTAuthCDIExtension

--- a/jwt/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/jwt/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,1 @@
-io.smallrye.jwt.auth.cdi.SmallRyeJWTAuthCDIExtension
+org.wildfly.security.mp.jwt.JWTCDIExtension

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
                             ${project.basedir}/http/util/src/main/java/;
                             ${project.basedir}/jacc/src/main/java/;
                             ${project.basedir}/json-util/src/main/java/;
+                            ${project.basedir}/jwt/src/main/java/;
                             ${project.basedir}/keystore/src/main/java/;
                             ${project.basedir}/manager/action/src/main/java/;
                             ${project.basedir}/manager/base/src/main/java9/; <!--java9/ must be before java/-->
@@ -575,6 +576,12 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-jaspi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-jwt</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -1263,6 +1270,7 @@
         <module>http/util</module>
         <module>jacc</module>
         <module>json-util</module>
+        <module>jwt</module>
         <module>keystore</module>
         <module>manager/base</module>
         <module>manager/action</module>

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,14 @@
     <properties>
         <jdk.min.version>11</jdk.min.version>
         <version.commons-cli>1.4</version.commons-cli>
+        <version.io.smallrye.jwt>2.0.11</version.io.smallrye.jwt>
+        <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.org.apache.commons>3.8.1</version.org.apache.commons>
         <version.org.apache.directory.server>2.0.0-M24</version.org.apache.directory.server>
         <version.org.apache.directory.api>1.0.0</version.org.apache.directory.api>
         <version.org.apache.directory.jdbm>2.0.0-M3</version.org.apache.directory.jdbm>
         <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
+        <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
 
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>
@@ -815,9 +818,21 @@
                  External Modules
             -->
             <dependency>
+                <artifactId>smallrye-jwt</artifactId>
+                <groupId>io.smallrye</groupId>
+                <version>${version.io.smallrye.jwt}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${version.org.apache.commons}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.jwt</groupId>
+                <artifactId>microprofile-jwt-auth-api</artifactId>
+                <version>${version.org.eclipse.microprofile.jwt.api}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -818,6 +818,12 @@
                  External Modules
             -->
             <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.enterprise}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <artifactId>smallrye-jwt</artifactId>
                 <groupId>io.smallrye</groupId>
                 <version>${version.io.smallrye.jwt}</version>

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -343,6 +343,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-keystore</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-1884

This is a relatively small addition to WildFly Elytron at this stage, presently it just adds an extension of the CDI Extension to override some behaviour and the descriptor to make it available using ServiceLoader discovery.

Longer term if any closer Elytron integration becomes necessary this project will be the home to keep the subsystem as slim as possible and should alternative implementations to the CDI implementations be required they will also be added here.

This build will presently fail as it requires changes proposed to SmallRye JWT.