### PR TITLE
[ELY-1954] If there is no request path and the application has a context root, redirect to ensure a trailing slash is on the URL.

### DIFF
--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -289,6 +289,11 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
     }
 
     private void sendLogin(HttpServerRequest request, HttpServerResponse response) throws HttpAuthenticationException {
+        if (request.getRequestPath().isEmpty() && !contextPath.isEmpty()) {
+            sendRedirect(response, getCompleteRedirectLocation(request, "/"));
+            return;
+        }
+
         // Save the current request.
         URI requestURI = request.getRequestURI();
         HttpScope session = getSessionScope(request, true);
@@ -345,6 +350,10 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             }
         }
 
+        sendRedirect(response, getCompleteRedirectLocation(request, page));
+    }
+
+    private String getCompleteRedirectLocation(HttpServerRequest request, String location) {
         URI requestURI = request.getRequestURI();
         StringBuilder sb = new StringBuilder();
         String scheme = requestURI.getScheme();
@@ -356,8 +365,9 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             sb.append(':').append(port);
         }
         sb.append(contextPath);
-        sb.append(page);
-        sendRedirect(response, sb.toString());
+        sb.append(location);
+
+        return sb.toString();
     }
 
     private void sendRedirect(HttpServerResponse response, String location) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-1954