### PR TITLE
[ELY-1970] Ensure multiple service implementations of the same type are aggregated.

### DIFF
--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -159,22 +159,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>                           
+                <version>3.2.1</version>
                 <executions>
-                  <execution>
-                      <phase>package</phase>
-                      <goals>
-                        <goal>shade</goal>
-                      </goals>
-                      <configuration>
-                          <createSourcesJar>true</createSourcesJar>
-                          <createDependencyReducedPom>false</createDependencyReducedPom>
-                          <artifactSet>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
                                 <excludes>
                                     <exclude>org.wildfly.common:wildfly-common</exclude>
                                 </excludes>
                             </artifactSet>
-                        </configuration>                  
+                            <transformers>
+                                <transformer
+                                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Debugging a different issue I have found our service definitions are not merged in our shaded jar, we end up with a weird first defined wins behaviour.

https://issues.redhat.com/browse/ELY-1970

Attached to ELY-1970 is a text file showing the differences in the results.