### PR TITLE
[JBEAP-19998] ELY-2013 - Upgrade JBoss Threads in Elytron to 2.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
         <version.org.jboss.spec.jboss-json-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.jboss-json-api_1.0_spec>
-        <version.org.jboss.threads>2.3.3.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services.metainf-services>1.7</version.org.kohsuke.metainf-services.metainf-services>
         <version.junit.junit>4.12</version.junit.junit>
         <version.jmockit>1.33</version.jmockit>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-19998
Upstream issue: https://issues.redhat.com/browse/ELY-2013
Upstream PR (1.x): https://github.com/wildfly-security/wildfly-elytron/pull/1429