### PR TITLE
ELY-1851 set ThreadLocalSSLSocketFactory around LdapContext search.

### DIFF
--- a/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
+++ b/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/DelegatingLdapContext.java
@@ -306,42 +306,82 @@ class DelegatingLdapContext implements LdapContext {
 
     @Override
     public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
-        return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes, String[] attributesToReturn) throws NamingException {
-        return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, matchingAttributes, attributesToReturn));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(Name name, Attributes matchingAttributes) throws NamingException {
-        return wrap(delegating.search(name, matchingAttributes));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, matchingAttributes));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(String name, Attributes matchingAttributes) throws NamingException {
-        return wrap(delegating.search(name, matchingAttributes));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, matchingAttributes));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(Name name, String filter, SearchControls cons) throws NamingException {
-        return wrap(delegating.search(name, filter, cons));
+        ClassLoader previous = setSocketFactory();
+        try{
+            return wrap(delegating.search(name, filter, cons));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(String name, String filter, SearchControls cons) throws NamingException {
-        return wrap(delegating.search(name, filter, cons));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, filter, cons));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(Name name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
-        return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override
     public NamingEnumeration<SearchResult> search(String name, String filterExpr, Object[] filterArgs, SearchControls cons) throws NamingException {
-        return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+        ClassLoader previous = setSocketFactory();
+        try {
+            return wrap(delegating.search(name, filterExpr, filterArgs, cons));
+        } finally {
+            unsetSocketFactory(previous);
+        }
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/ELY-1851 Elytron ldaps realm fails if a referral is returned inside a search