### PR TITLE
[ELY-1211] FileAuditEndpoint doesn't allow for file encoding to be overridden

### DIFF
--- a/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -21,13 +21,14 @@ import static org.wildfly.common.Assert.checkNotNullParam;
 import static org.wildfly.security.audit.ElytronMessages.audit;
 
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -44,7 +45,7 @@ import java.util.function.Supplier;
  */
 public class FileAuditEndpoint implements AuditEndpoint {
 
-    private static final byte[] LINE_TERMINATOR = System.lineSeparator().getBytes(StandardCharsets.UTF_8);
+    private static final String LINE_TERMINATOR = System.lineSeparator();
 
     private volatile boolean accepting = true;
 
@@ -54,7 +55,8 @@ public class FileAuditEndpoint implements AuditEndpoint {
 
     private File file;
     private FileDescriptor fileDescriptor;
-    private OutputStream outputStream;
+    private Writer writer;
+    private Charset charset;
     /**  Clock providing access to current time. */
     protected final Clock clock;
 
@@ -63,6 +65,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
         this.syncOnAccept = builder.syncOnAccept;
         this.flushOnAccept = builder.flushOnAccept;
         this.clock = builder.clock;
+        this.charset = builder.charset != null ? builder.charset : StandardCharsets.UTF_8;
         setFile(builder.location.toFile());
     }
 
@@ -70,15 +73,15 @@ public class FileAuditEndpoint implements AuditEndpoint {
         boolean ok = false;
         final FileOutputStream fos = new FileOutputStream(file, true);
         try {
-            final OutputStream bos = new BufferedOutputStream(fos);
+            final Writer writer = new OutputStreamWriter(new BufferedOutputStream(fos), this.charset);
             try {
                 this.fileDescriptor = fos.getFD();
-                this.outputStream = bos;
+                this.writer = writer;
                 this.file = file;
                 ok = true;
             } finally {
                 if (! ok) {
-                    safeClose(bos);
+                    safeClose(writer);
                 }
             }
         } finally {
@@ -101,16 +104,16 @@ public class FileAuditEndpoint implements AuditEndpoint {
     }
 
     /**
-     * Method called to write given byte array to the target local file.
+     * Method called to write given String to the target local file.
      * This method can be overridden by subclasses to modify data written into file (to encrypt them for example),
      * or just for counting amount of written bytes for needs of log rotation and similar.
      *
      * This method can be invoked only in synchronization block surrounding one log message processing.
      *
-     * @param bytes the data to be written into the target local file
+     * @param toWrite the String to be written into the target local file
      */
-    void write(byte[] bytes) throws IOException {
-        outputStream.write(bytes);
+    void write(String toWrite) throws IOException {
+        writer.write(toWrite);
     }
 
     /**
@@ -138,14 +141,14 @@ public class FileAuditEndpoint implements AuditEndpoint {
         if (!accepting) return;
         Instant instant = clock.instant();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        baos.write(dateTimeFormatterSupplier.get().format(instant).getBytes(StandardCharsets.UTF_8));
-        baos.write(',');
-        baos.write(priority.toString().getBytes(StandardCharsets.UTF_8));
-        baos.write(',');
-        baos.write(message.getBytes(StandardCharsets.UTF_8));
-        baos.write(LINE_TERMINATOR);
-        byte[] toWrite = baos.toByteArray();
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(dateTimeFormatterSupplier.get().format(instant));
+        buffer.append(',');
+        buffer.append(priority.toString());
+        buffer.append(',');
+        buffer.append(message);
+        buffer.append(LINE_TERMINATOR);
+        String toWrite = buffer.toString();
 
         synchronized(this) {
             if (!accepting) return; // We may have been waiting to get in here.
@@ -153,7 +156,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
             preWrite(instant);
             write(toWrite);
 
-            if (flushOnAccept) outputStream.flush();
+            if (flushOnAccept) writer.flush();
             if (syncOnAccept) fileDescriptor.sync();
         }
     }
@@ -172,9 +175,9 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * Must be called in synchronized block together with reopening using {@code setFile()}.
      */
     void closeStreams() throws IOException {
-        outputStream.flush();
+        writer.flush();
         fileDescriptor.sync();
-        outputStream.close();
+        writer.close();
     }
 
     /**
@@ -197,6 +200,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
         private boolean syncOnAccept = true;
         private boolean flushOnAccept = true;
         private boolean flushSet = false;
+        private Charset charset;
 
         Builder() {
         }
@@ -264,6 +268,18 @@ public class FileAuditEndpoint implements AuditEndpoint {
          */
         Builder setClock(Clock clock) {
             this.clock = clock;
+
+            return this;
+        }
+
+        /**
+         * Set the file's character set.
+         *
+         * @param charset the character set
+         * @return this builder.
+         */
+        public Builder setCharset(Charset charset) {
+            this.charset = charset;
 
             return this;
         }

--- a/audit/src/main/java/org/wildfly/security/audit/SizeRotatingFileAuditEndpoint.java
+++ b/audit/src/main/java/org/wildfly/security/audit/SizeRotatingFileAuditEndpoint.java
@@ -67,9 +67,9 @@ public class SizeRotatingFileAuditEndpoint extends FileAuditEndpoint {
     }
 
     @Override
-    protected void write(byte[] bytes) throws IOException {
-        super.write(bytes);
-        currentSize += bytes.length;
+    protected void write(String toWrite) throws IOException {
+        super.write(toWrite);
+        currentSize += toWrite.getBytes().length;
     }
 
     @Override

--- a/tests/base/src/test/java/org/wildfly/security/audit/FileAuditEndpointTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/audit/FileAuditEndpointTest.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.audit;
+
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.util.TestClock;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test case to test {@link FileAuditEndpointTest}
+ *
+ * @author <a href="mailto:ivassile@redhat.com">Ilia Vassilev</a>
+ */
+@RunWith(JMockit.class)
+public class FileAuditEndpointTest {
+    static File logDirFile;
+    static Path logFile;
+    static ZoneId UTC = ZoneId.of("UTC");
+    static TestClock clock;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        logDirFile = new File(FileAuditEndpointTest.class.getResource(".").getFile(), "audit");
+        logFile = Paths.get(logDirFile.getPath(), "audit");
+    }
+
+    @Test
+    public void testFileEncoding() throws Exception {
+        Charset charset = StandardCharsets.UTF_16;
+        AuditEndpoint endpoint = FileAuditEndpoint.builder()
+                .setLocation(logFile)
+                .setClock(clock)
+                .setCharset(charset)
+                .build();
+        endpoint.accept(EventPriority.CRITICAL, "testing log message");
+        endpoint.close();
+        assertFiles("audit");
+
+        FileInputStream fis = null;
+        BufferedReader br = null;
+        try {
+            fis = new FileInputStream(logFile.toFile());
+            br = new BufferedReader(new InputStreamReader(fis, charset));
+            Assert.assertTrue(br.readLine().contains("testing log message"));
+        } finally {
+            safeClose(fis);
+            safeClose(br);
+        }
+    }
+
+    @Before
+    public void initDir() {
+        logDirFile.mkdirs();
+        Assert.assertTrue(logDirFile.isDirectory());
+        for (File file : logDirFile.listFiles()) {
+            file.delete();
+        }
+        assertFiles();
+    }
+
+    @Before
+    public void mockTime() {
+        clock = new TestClock(Instant.EPOCH.truncatedTo(ChronoUnit.DAYS));
+        new MockUp<File>() {
+            @Mock
+            public long lastModified() {
+                return clock.millis();
+            }
+        };
+    }
+
+    private void assertFiles(String...files) {
+        Set<String> expected = new HashSet<>(Arrays.asList(files));
+        for (File file : logDirFile.listFiles()) {
+            if (! expected.remove(file.getName())) {
+                Assert.fail("Unexpected file "+file.getName());
+            }
+        }
+        for (String missing : expected) {
+            Assert.fail("Missing file "+missing);
+        }
+    }
+
+    private void safeClose(Closeable c) {
+        if (c != null) {
+            try {
+                c.close();
+            } catch (Throwable ignored) {}
+        }
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-1211