### PR TITLE
[ELY-1921] Adding External HTTP authentication mechanism

### DIFF
--- a/base/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/base/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -151,6 +151,7 @@ public class WildFlyElytronProvider extends VersionedProvider {
         putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "DIGEST", "org.wildfly.security.http.digest.DigestMechanismFactory", emptyList, emptyMap, true, true));
         putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "DIGEST-SHA-256", "org.wildfly.security.http.digest.DigestMechanismFactory", emptyList, emptyMap, true, true));
         putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "DIGEST-SHA-512-256", "org.wildfly.security.http.digest.DigestMechanismFactory", emptyList, emptyMap, true, true));
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "EXTERNAL", "org.wildfly.security.http.external.ExternalMechanismFactory", emptyList, emptyMap, true, true));
         putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "FORM", "org.wildfly.security.http.form.FormMechanismFactory", emptyList, emptyMap, true, true));
         putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "SPNEGO", "org.wildfly.security.http.spnego.SpnegoMechanismFactory", emptyList, emptyMap, true, true));
 

--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -379,6 +379,11 @@ public class HttpAuthenticator {
         }
 
         @Override
+        public String getRemoteUser() {
+            return httpExchangeSpi.getRemoteUser();
+        }
+
+        @Override
         public void authenticationInProgress(HttpServerMechanismsResponder responder) {
             authenticationAttempted = true;
             if (responder != null) {

--- a/http/base/src/main/java/org/wildfly/security/http/HttpConstants.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpConstants.java
@@ -141,6 +141,7 @@ public class HttpConstants {
     public static final String DIGEST_NAME = "DIGEST";
     public static final String DIGEST_SHA256_NAME = "DIGEST-SHA-256";
     public static final String DIGEST_SHA512_256_NAME = "DIGEST-SHA-512-256";
+    public static final String EXTERNAL_NAME = "EXTERNAL";
     public static final String FORM_NAME = "FORM";
     public static final String SPNEGO_NAME = "SPNEGO";
     public static final String BEARER_TOKEN = "BEARER_TOKEN";

--- a/http/base/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpExchangeSpi.java
@@ -253,12 +253,21 @@ public interface HttpExchangeSpi extends HttpServerScopes {
          return -1;
      }
 
-     /**
-      * Suspend the current request so that it can be subsequently resumed.
-      *
-      * The server may use any strategy it deems appropriate to suspend the current request and store the state ready for a subsequent request.
-      *
-      * @return {@code true} if suspension is supported, {@code false} otherwise.
+    /**
+     * Returns a remotely authenticated user
+     *
+     * @return the remote user principal or {@code null} if no remote user was authenticated.
+     */
+    default String getRemoteUser() {
+        return null;
+    }
+
+    /**
+     * Suspend the current request so that it can be subsequently resumed.
+     *
+     * The server may use any strategy it deems appropriate to suspend the current request and store the state ready for a subsequent request.
+     *
+     * @return {@code true} if suspension is supported, {@code false} otherwise.
       */
      default boolean suspendRequest() {
          return false;

--- a/http/base/src/main/java/org/wildfly/security/http/HttpServerRequest.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpServerRequest.java
@@ -189,6 +189,15 @@ public interface HttpServerRequest extends HttpServerScopes {
     String getRequestPath();
 
     /**
+     * Returns a remotely authenticated user
+     *
+     * @return the remote user principal or {@code null} if no remote user was authenticated.
+     */
+    default String getRemoteUser() {
+        return null;
+    }
+
+    /**
      * Returns the parameters received in the current request.
      *
      * These parameters will be from both the query string and the form data when available.

--- a/http/deprecated/pom.xml
+++ b/http/deprecated/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-form</artifactId>
         </dependency>
         <dependency>

--- a/http/deprecated/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
+++ b/http/deprecated/src/main/java/org/wildfly/security/http/impl/ServerMechanismFactoryImpl.java
@@ -29,6 +29,7 @@ import org.wildfly.security.http.basic.BasicMechanismFactory;
 import org.wildfly.security.http.bearer.BearerMechanismFactory;
 import org.wildfly.security.http.cert.ClientCertMechanismFactory;
 import org.wildfly.security.http.digest.DigestMechanismFactory;
+import org.wildfly.security.http.external.ExternalMechanismFactory;
 import org.wildfly.security.http.form.FormMechanismFactory;
 import org.wildfly.security.http.spnego.SpnegoMechanismFactory;
 import org.wildfly.security.http.util.AggregateServerMechanismFactory;
@@ -45,8 +46,8 @@ public class ServerMechanismFactoryImpl implements HttpServerAuthenticationMecha
 
     public ServerMechanismFactoryImpl() {
         delegate = new AggregateServerMechanismFactory(new BasicMechanismFactory(), new BearerMechanismFactory(),
-                new ClientCertMechanismFactory(), new DigestMechanismFactory(), new FormMechanismFactory(),
-                new SpnegoMechanismFactory());
+                new ClientCertMechanismFactory(), new DigestMechanismFactory(), new ExternalMechanismFactory(),
+                new FormMechanismFactory(), new SpnegoMechanismFactory());
     }
 
     @Override

--- a/http/external/pom.xml
+++ b/http/external/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron-parent</artifactId>
-        <version>1.13.0.CR4-SNAPSHOT</version>
+        <version>1.13.0.CR5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/http/external/pom.xml
+++ b/http/external/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-parent</artifactId>
+        <version>1.13.0.CR4-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wildfly-elytron-http-external</artifactId>
+
+    <name>WildFly Elytron - HTTP External</name>
+    <description>WildFly Security HTTP External Mechanism Implementation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-auth-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-mechanism-http</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/http/external/src/main/java/org/wildfly/security/http/external/ExternalAuthenticationMechanism.java
+++ b/http/external/src/main/java/org/wildfly/security/http/external/ExternalAuthenticationMechanism.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.external;
+
+import static org.wildfly.security.http.HttpConstants.EXTERNAL_NAME;
+import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
+import static org.wildfly.security.mechanism._private.ElytronMessages.httpExternal;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+
+import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.mechanism.AuthenticationMechanismException;
+import org.wildfly.security.mechanism._private.MechanismUtil;
+
+/**
+ * The EXTERNAL authentication mechanism.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+public class ExternalAuthenticationMechanism implements HttpServerAuthenticationMechanism {
+
+    private final CallbackHandler callbackHandler;
+
+    ExternalAuthenticationMechanism(CallbackHandler callbackHandler) {
+        this.callbackHandler = callbackHandler;
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanism#getMechanismName()
+     */
+    @Override
+    public String getMechanismName() {
+        return EXTERNAL_NAME;
+    }
+
+    @Override
+    public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
+
+        String remoteUser = request.getRemoteUser();
+        if (remoteUser == null) {
+            request.noAuthenticationInProgress();
+            return;
+        }
+
+        if (authorize(remoteUser)) {
+            succeed(request);
+        } else {
+            fail(request);
+        }
+
+    }
+
+    private boolean authorize(String username) throws HttpAuthenticationException {
+        AuthorizeCallback authorizeCallback = new AuthorizeCallback(username, username);
+        try {
+            MechanismUtil.handleCallbacks(httpExternal, callbackHandler, authorizeCallback);
+            return authorizeCallback.isAuthorized();
+        } catch (AuthenticationMechanismException e) {
+            throw e.toHttpAuthenticationException();
+        } catch (UnsupportedCallbackException e) {
+            throw httpExternal.mechCallbackHandlerFailedForUnknownReason(e).toHttpAuthenticationException();
+        }
+    }
+
+    private void succeed(HttpServerRequest request) throws HttpAuthenticationException {
+        try {
+            MechanismUtil.handleCallbacks(httpExternal, callbackHandler, AuthenticationCompleteCallback.SUCCEEDED);
+            request.authenticationComplete();
+        } catch (AuthenticationMechanismException e) {
+            throw e.toHttpAuthenticationException();
+        } catch (UnsupportedCallbackException e) {
+            throw httpExternal.mechCallbackHandlerFailedForUnknownReason(e).toHttpAuthenticationException();
+        }
+    }
+
+    private void fail(HttpServerRequest request) throws HttpAuthenticationException {
+        try {
+            MechanismUtil.handleCallbacks(httpExternal, callbackHandler, AuthenticationCompleteCallback.FAILED);
+            request.authenticationFailed(httpExternal.authenticationFailed(), response -> response.setStatusCode(FORBIDDEN));
+        } catch (AuthenticationMechanismException e) {
+            throw e.toHttpAuthenticationException();
+        } catch (UnsupportedCallbackException e) {
+            throw httpExternal.mechCallbackHandlerFailedForUnknownReason(e).toHttpAuthenticationException();
+        }
+    }
+}

--- a/http/external/src/main/java/org/wildfly/security/http/external/ExternalMechanismFactory.java
+++ b/http/external/src/main/java/org/wildfly/security/http/external/ExternalMechanismFactory.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.external;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security.http.HttpConstants.EXTERNAL_NAME;
+
+import java.security.Provider;
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerAuthenticationMechanismFactory;
+
+/**
+ * A {@link HttpServerAuthenticationMechanismFactory} implementation for the EXTERNAL HTTP authentication mechanism.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+@MetaInfServices(value = HttpServerAuthenticationMechanismFactory.class)
+public class ExternalMechanismFactory implements HttpServerAuthenticationMechanismFactory {
+
+    public ExternalMechanismFactory() {
+    }
+
+    public ExternalMechanismFactory(final Provider provider) {
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanismFactory#getMechanismNames(java.util.Map)
+     */
+    @Override
+    public String[] getMechanismNames(Map<String, ?> properties) {
+        return new String[]{EXTERNAL_NAME};
+    }
+
+    /**
+     * @see org.wildfly.security.http.HttpServerAuthenticationMechanismFactory#createAuthenticationMechanism(java.lang.String,
+     * java.util.Map, javax.security.auth.callback.CallbackHandler)
+     */
+    @Override
+    public HttpServerAuthenticationMechanism createAuthenticationMechanism(String mechanismName, Map<String, ?> properties, CallbackHandler callbackHandler) throws HttpAuthenticationException {
+        checkNotNullParam("mechanismName", mechanismName);
+        checkNotNullParam("properties", properties);
+        checkNotNullParam("callbackHandler", callbackHandler);
+
+        if (EXTERNAL_NAME.equals(mechanismName)) {
+            return new ExternalAuthenticationMechanism(callbackHandler);
+        }
+
+        return null;
+    }
+
+}

--- a/http/external/src/main/java/org/wildfly/security/http/external/WildFlyElytronHttpExternalProvider.java
+++ b/http/external/src/main/java/org/wildfly/security/http/external/WildFlyElytronHttpExternalProvider.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.external;
+
+import java.security.Provider;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.security.WildFlyElytronBaseProvider;
+
+/**
+ * Provider for the HTTP External authentication mechanism.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+@MetaInfServices(Provider.class)
+public class WildFlyElytronHttpExternalProvider extends WildFlyElytronBaseProvider {
+
+    private static final long serialVersionUID = 6923305263952210174L;
+    private static WildFlyElytronHttpExternalProvider INSTANCE = new WildFlyElytronHttpExternalProvider();
+
+    /**
+     * Construct a new instance.
+     */
+    public WildFlyElytronHttpExternalProvider() {
+        super("WildFlyElytronHttpExternalProvider", "1.0", "WildFly Elytron HTTP External Provider");
+        putService(new ProviderService(this, HTTP_SERVER_FACTORY_TYPE, "EXTERNAL", "org.wildfly.security.http.external.ExternalMechanismFactory", emptyList, emptyMap, true, true));
+    }
+
+    /**
+     * Get the HTTP External authentication mechanism provider instance.
+     *
+     * @return the HTTP External authentication mechanism provider instance
+     */
+    public static WildFlyElytronHttpExternalProvider getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/mechanism/base/src/main/java/org/wildfly/security/mechanism/_private/ElytronMessages.java
+++ b/mechanism/base/src/main/java/org/wildfly/security/mechanism/_private/ElytronMessages.java
@@ -66,6 +66,7 @@ public interface ElytronMessages extends BasicLogger {
     ElytronMessages httpSpnego = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.spnego");
     ElytronMessages httpClientCert = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.cert");
     ElytronMessages httpDigest = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.digest");
+    ElytronMessages httpExternal = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.external");
     ElytronMessages httpUserPass = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.password");
     ElytronMessages httpForm = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.form");
     ElytronMessages httpBearer = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security.http.bearer");

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
                             ${project.basedir}/http/cert/src/main/java/;
                             ${project.basedir}/http/deprecated/src/main/java/;
                             ${project.basedir}/http/digest/src/main/java/;
+                            ${project.basedir}/http/external/src/main/java/;
                             ${project.basedir}/http/form/src/main/java/;
                             ${project.basedir}/http/spnego/src/main/java/;
                             ${project.basedir}/http/sso/src/main/java/;
@@ -545,6 +546,11 @@
             <dependency>
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-http-digest</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-http-external</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -1298,6 +1304,7 @@
         <module>http/cert</module>
         <module>http/deprecated</module>
         <module>http/digest</module>
+        <module>http/external</module>
         <module>http/form</module>
         <module>http/spnego</module>
         <module>http/sso</module>

--- a/provider/util/src/main/java/org/wildfly/security/provider/util/ProviderFactory.java
+++ b/provider/util/src/main/java/org/wildfly/security/provider/util/ProviderFactory.java
@@ -43,6 +43,7 @@ public class ProviderFactory {
             "org.wildfly.security.http.bearer.WildFlyElytronHttpBearerProvider",
             "org.wildfly.security.http.cert.WildFlyElytronHttpClientCertProvider",
             "org.wildfly.security.http.digest.WildFlyElytronHttpDigestProvider",
+            "org.wildfly.security.http.external.WildFlyElytronHttpExternalProvider",
             "org.wildfly.security.http.form.WildFlyElytronHttpFormProvider",
             "org.wildfly.security.http.spnego.WildFlyElytronHttpSpnegoProvider",
             "org.wildfly.security.key.WildFlyElytronKeyProvider",

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -373,6 +373,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-form</artifactId>
         </dependency>
         <dependency>

--- a/tests/base/src/test/java/org/wildfly/security/http/external/ExternalAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/external/ExternalAuthenticationMechanismTest.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.external;
+
+import static org.wildfly.security.http.HttpConstants.EXTERNAL_NAME;
+import static org.wildfly.security.http.HttpConstants.FORBIDDEN;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.Collections;
+
+import mockit.integration.junit4.JMockit;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+
+/**
+ * Test of server side of the External HTTP mechanism.
+ *
+ * @author <a href="mailto:aabdelsa@redhat.com">Ashley Abdel-Sayed</a>
+ */
+@RunWith(JMockit.class)
+public class ExternalAuthenticationMechanismTest extends AbstractBaseHttpTest {
+
+    private static final Provider provider = WildFlyElytronHttpExternalProvider.getInstance();
+
+    @BeforeClass
+    public static void registerProvider() {
+        Security.insertProviderAt(provider, 1);
+    }
+
+    @AfterClass
+    public static void removeProvider() {
+        Security.removeProvider(provider.getName());
+    }
+
+    @Test
+    public void testExternalAuthenticationMechanism() throws Exception {
+        HttpServerAuthenticationMechanism mechanism = externalFactory.createAuthenticationMechanism(EXTERNAL_NAME, Collections.emptyMap(), getCallbackHandler("remoteUser", "testrealm@host.com", null));
+
+        //Test no authentication in progress (no remote user passed in externally)
+        TestingHttpServerRequest request1 = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request1);
+        Assert.assertEquals(Status.NO_AUTH, request1.getResult());
+
+        //Test unsuccessful authentication
+        TestingHttpServerRequest request2 = new TestingHttpServerRequest(null);
+        request2.setRemoteUser("wrongUser");
+        mechanism.evaluateRequest(request2);
+        Assert.assertEquals(Status.FAILED, request2.getResult());
+        Assert.assertEquals(FORBIDDEN, request2.getResponse().getStatusCode());
+
+        //Test successful authentication
+        TestingHttpServerRequest request3 = new TestingHttpServerRequest(null);
+        request3.setRemoteUser("remoteUser");
+        mechanism.evaluateRequest(request3);
+        Assert.assertEquals(Status.COMPLETE, request3.getResult());
+    }
+}

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -319,6 +319,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-external</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-form</artifactId>
         </dependency>
         <dependency>
@@ -650,6 +654,11 @@
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-http-digest</artifactId>
+                                    <version>${project.version}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron-http-external</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
                                 <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-1921

Supersedes https://github.com/wildfly-security/wildfly-elytron/pull/1386. This PR just combines Ashley's PR with a commit that updates the version in `http/external/pom.xml` to `1.13.0.CR5-SNAPSHOT`.