### PR TITLE
[ELY-2023] Elytron ClientCertAuthenticationMechanism does not work when using a web proxy

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/auth/callback/PrincipalAuthorizeCallback.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/callback/PrincipalAuthorizeCallback.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.callback;
+
+import java.security.Principal;
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+/**
+ * <p>An authorization callback similar to javase {@link javax.security.sasl.AuthorizeCallback}
+ * but using a generic principal.</p>
+ *
+ * @author rmartinc
+ */
+public class PrincipalAuthorizeCallback implements ExtendedCallback {
+
+    private final Principal principal;
+    private boolean authorized;
+
+    /**
+     * Creates a new instance to authorize the associated <code>name</code>.
+     * It will be transformed in a {@link NamePrincipal}.
+     *
+     * @param name the name to authorize
+     */
+    public PrincipalAuthorizeCallback(String name) {
+        Assert.checkNotNullParam("name", name);
+        this.principal = new NamePrincipal(name);
+    }
+
+    /**
+     * Creates a new instance to authorize the associated <code>principal</code>.
+     *
+     * @param principal the principal to authorize
+     */
+    public PrincipalAuthorizeCallback(Principal principal) {
+        Assert.checkNotNullParam("principal", principal);
+        this.principal = principal;
+    }
+
+    /**
+     * Indicates if the principal was successfully authorized.
+     *
+     * @return true if the principal was successfully authorized. Otherwise, false
+     */
+    public boolean isAuthorized() {
+        return authorized;
+    }
+
+    /**
+     * Sets whether the authorization is allowed for the principal.
+     *
+     * @param authorized authorization result
+     */
+    public void setAuthorized(boolean authorized) {
+        this.authorized = authorized;
+    }
+
+    /**
+     * Returns the {@link Principal}.
+     *
+     * @return the principal (not {@code null})
+     */
+    public Principal getPrincipal() {
+        return this.principal;
+    }
+}

--- a/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -56,6 +56,7 @@ import org.wildfly.security.auth.callback.EvidenceDecodePrincipalCallback;
 import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
 import org.wildfly.security.auth.callback.ExclusiveNameCallback;
 import org.wildfly.security.auth.callback.FastUnsupportedCallbackException;
+import org.wildfly.security.auth.callback.PrincipalAuthorizeCallback;
 import org.wildfly.security.auth.callback.MechanismInformationCallback;
 import org.wildfly.security.auth.callback.IdentityCredentialCallback;
 import org.wildfly.security.auth.callback.PeerPrincipalCallback;
@@ -1114,6 +1115,15 @@ public final class ServerAuthenticationContext implements AutoCloseable {
                     } else {
                         addPublicCredential(credential);
                     }
+                    handleOne(callbacks, idx + 1);
+                } else if (callback instanceof PrincipalAuthorizeCallback) {
+                    PrincipalAuthorizeCallback authorizeCallback = (PrincipalAuthorizeCallback) callback;
+                    Principal principal = authorizeCallback.getPrincipal();
+                    // always re-set the principal to ensure it hasn't changed.
+                    setAuthenticationPrincipal(principal);
+                    boolean authorized = authorize();
+                    log.tracef("Handling PrincipalAuthorizeCallback: principal = %s  authorized = %b", principal, authorized);
+                    authorizeCallback.setAuthorized(authorized);
                     handleOne(callbacks, idx + 1);
                 } else {
                     CallbackUtil.unsupported(callback);

--- a/http/cert/src/main/java/org/wildfly/security/http/cert/ClientCertAuthenticationMechanism.java
+++ b/http/cert/src/main/java/org/wildfly/security/http/cert/ClientCertAuthenticationMechanism.java
@@ -31,12 +31,12 @@ import java.util.function.Function;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.sasl.AuthorizeCallback;
 
 import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.auth.callback.CachedIdentityAuthorizeCallback;
 import org.wildfly.security.auth.callback.EvidenceDecodePrincipalCallback;
 import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
+import org.wildfly.security.auth.callback.PrincipalAuthorizeCallback;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.cache.CachedIdentity;
@@ -141,10 +141,9 @@ final class ClientCertAuthenticationMechanism implements HttpServerAuthenticatio
                 authorizedFunction = cacheCallback::isAuthorized;
                 authorizeCallBack = cacheCallback;
             } else {
-                String name = evidence.getDecodedPrincipal().getName();
-                AuthorizeCallback plainCallback = new AuthorizeCallback(name, name);
-                authorizedFunction = plainCallback::isAuthorized;
-                authorizeCallBack = plainCallback;
+                PrincipalAuthorizeCallback principalCallback = new PrincipalAuthorizeCallback(evidence.getDecodedPrincipal());
+                authorizedFunction = principalCallback::isAuthorized;
+                authorizeCallBack = principalCallback;
             }
 
             try {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2023

When the certificate mechanism is used behind a web proxy that injects the certificate and SSL info using headers (no cache available), the mechanism uses a `AuthorizeCallback` that fails (because it creates a `NamePrincipal` which is different to the original `X500Principal`). I decided to create a new callback for authorization but using a principal. Let me know if you see something better.

I'm sending the PR against EAP 1.10.x, if you need it against 1.x or other branch please just tell me to do that.

I'm preparing a test PR for wildfly that checks a certificate login using key-store realm.

Wildfly Test PR: https://github.com/wildfly/wildfly/pull/13573