### PR TITLE
Blog posts for WildFly 21

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -19,6 +19,9 @@ jucook:
 hkalina:
   name: Honza Kalina
   bio: "https://github.com/hkalina"
+mmazanek:
+  name: Martin Mazanek
+  bio: "https://github.com/nekdozjam"
 stuartwdouglas:
   name: Stuart Douglas
   bio: "https://github.com/stuartwdouglas"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 - name: Home
   link: /
 - name: Docs
-  link: https://docs.wildfly.org/20/WildFly_Elytron_Security.html
+  link: https://docs.wildfly.org/21/WildFly_Elytron_Security.html
 - name: Community
   link: /community/
 - name: Blog

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -8,7 +8,7 @@ layout: default
   <div class="grid__item width-4-12 width-12-12-m community-block">
     <img src="{{site.baseurl}}/assets/images/community/icon-documentation.png"/>
     <h3>Documentation</strong></h3>
-    <p>Be sure to check out our <a href="{{site.baseurl}}/getting-started-for-developers">getting started guide for developers</a> and our <a href="https://docs.wildfly.org/20/WildFly_Elytron_Security.html" target="_blank">documentation</a>. For more information on our APIs and SPIs, check out our <a href="{{site.baseurl}}/javadoc">Javadoc</a>.</p>
+    <p>Be sure to check out our <a href="{{site.baseurl}}/getting-started-for-developers">getting started guide for developers</a> and our <a href="https://docs.wildfly.org/21/WildFly_Elytron_Security.html" target="_blank">documentation</a>. For more information on our APIs and SPIs, check out our <a href="{{site.baseurl}}/javadoc">Javadoc</a>.</p>
   </div>
   <div class="grid__item width-4-12 width-12-12-m community-block">
     <img src="{{site.baseurl}}/assets/images/community/icon-github.png"/>

--- a/_posts/2018-08-31-obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli.adoc
+++ b/_posts/2018-08-31-obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli.adoc
@@ -5,5 +5,328 @@ date: 2018-08-31
 tags: ssl wildfly elytron LetsEncrypt
 synopsis: An overview on how to obtain and manage certificates from the Let’s Encrypt certificate authority using the WildFly CLI.
 author: fjuma
-link: https://developer.jboss.org/people/fjuma/blog/2018/08/31/obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli
 ---
+
+:toc: macro
+:toc-title:
+
+It is possible to obtain and manage certificates from the Let's Encrypt certificate authority using the WildFly CLI.
+In particular, it is possible to get a certificate from Let's Encrypt, revoke it if necessary, and check if it’s due for renewal.
+This blog post is going to give an overview of these new operations.
+
+toc::[]
+
+== Obtaining a certificate from Let's Encrypt
+
+First, make sure your WildFly server instance is publicly accessible using the domain name(s) you will be obtaining
+a certificate for from Let's Encrypt. For example, if you are requesting a certificate for the domain name
+"www.example.org", then "www.example.org" needs to be publicly accessible. This is because Let's Encrypt will attempt
+to access this URL when attempting to validate that you really do own this domain name. WildFly itself will handle
+proving that you really do own this domain name.
+
+There are a couple ways to obtain a certificate from Let's Encrypt using WildFly CLI commands.
+
+=== Using the `security` command
+
+The simplest way to obtain and make use of a certificate from Let's Encrypt is by using one of the `security`
+https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc#security-commands[wrapper commands] as follows:
+
+[source,shell]
+----
+security enable-ssl-http-server --interactive --lets-encrypt
+security enable-ssl-management --interactive --lets-encrypt
+----
+
+These commands allow you to easily enable either one-way or two-way SSL for applications or management
+interfaces, respectively, using a certificate that will be obtained automatically from Let's Encrypt.
+
+Let's take a look at the `security enable-ssl-http-server --interactive --lets-encrypt` command:
+
+[source,shell]
+----
+[standalone@localhost:9990 /] security enable-ssl-http-server --interactive --lets-encrypt
+Please provide required pieces of information to enable SSL:
+
+Let's Encrypt account key-store:
+File name (default accounts.keystore.jks):
+Password (blank generated):
+
+Let's Encrypt certificate authority account:
+Account name (default CertAuthorityAccount):
+Contact email(s) [admin@example.com,info@example.com]:
+Password (blank generated):
+Alias (blank generated):
+Certificate authority URL (default https://acme-v02.api.letsencrypt.org/directory):
+
+Let's Encrypt TOS (https://community.letsencrypt.org/tos)
+Do you agree to Let's Encrypt terms of service? y/n:y
+
+Certificate info:
+Key-store file name (default default-server.keystore):
+Password (blank generated):
+Your domain name(s) (must be accessible by the Let's Encrypt server at 80 & 443 ports) [example.com,second.example.com]: www.example.org
+Alias (blank generated):
+Enable SSL Mutual Authentication y/n (blank n):
+
+Let's Encrypt options:
+account key store name: account-key-store-b1f62709-d679-4e19-acf4-f5d286d481b8
+password: OAaMa6aI
+account keystore file accounts.keystore.jks will be generated in server configuration directory.
+Let's Encrypt certificate authority account name: CertAuthorityAccount
+contact urls: []
+password: lSgY0ZoS
+alias: account-key-store-alias-b1f62709-d679-4e19-acf4-f5d286d481b8
+certificate authority URL: https://acme-v02.api.letsencrypt.org/directory
+You provided agreement to Let's Encrypt terms of service.
+
+
+SSL options:
+key store file: default-server.keystore
+domain name: [www.mydomainname.com]
+password: iuApeaDH
+validity: 90
+alias: alias-b1f62709-d679-4e19-acf4-f5d286d481b8
+Certificate will be obtained from Let's Encrypt server and will be valid for 90 days.
+Server keystore file will be generated in server configuration directory.
+
+Do you confirm y/n :y
+----
+
+As we can see from the output, this command will first prompt you to specify the information needed
+to configure your Let's Encrypt account. It will then ask for information related to the certificate
+that you would like to obtain from Let's Encrypt. This command will then automatically create your Let's
+Encrypt account (if it doesn't already exist), it will obtain a certificate from Let's Encrypt
+using the domain name that you specified, and it will configure one-way SSL using this certificate.
+
+=== Using Elytron subsystem commands
+
+It is also possible to obtain a certificate from Let's Encrypt using Elytron subsystem commands
+directly.
+
+==== Prerequisite configuration
+
+First, configure a `key-store` in the Elytron subsystem that will be used to hold your server certificates.
+Note that the path to the keystore file doesn't need to exist yet.
+
+[source,shell]
+----
+/subsystem=elytron/key-store=serverKS:add(path=server.keystore.jks, relative-to=jboss.server.config.dir, credential-reference={clear-text=secret}, type=JKS)
+----
+
+==== Show me the commands first
+
+Obtaining certificates from Let's Encrypt using Elytron subsystem commands requires a couple one-time
+configuration steps. These commands are shown below. We're going to go through each of these commands in more detail in the following sections.
+
+[source,shell]
+----
+### One-time configuration
+
+# Configure a Let’s Encrypt account
+/subsystem=elytron/key-store=accountsKS:add(path=accounts.keystore.jks,relative-to=jboss.server.config.dir,credential-reference={clear-text=secret},type=JKS)
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:add(alias=letsEncrypt,key-store=accountsKS,contact-urls=[mailto:admin@admin.org])
+
+### Now you’re ready to start obtaining and managing certificates
+
+# Obtain a certificate from Let’s Encrypt
+/subsystem=elytron/key-store=serverKS:obtain-certificate(alias=server,domain-names=[www.example.org],certificate-authority-account=myLetsEncryptAccount,agree-to-terms-of-service)
+
+# Revoke a certificate that was issued by Let’s Encrypt
+/subsystem=elytron/key-store=serverKS:revoke-certificate(alias=server,reason=keyCompromise,certificate-authority-account=myLetsEncryptAccount)
+
+# Check if a certificate is due for renewal in less than 30 days
+/subsystem=elytron/key-store=serverKS:should-renew-certificate(alias=server)
+----
+
+==== Configuring a Let’s Encrypt account
+
+Before obtaining your first certificate from Let's Encrypt, a Let's Encrypt account needs to be configured.
+
+First, configure a `key-store` in the Elytron subsystem that will be used to hold your Let's Encrypt account key.
+The path to the keystore file doesn’t need to exist yet.
+
+[source,shell]
+----
+/subsystem=elytron/key-store=accountsKS:add(path=accounts.keystore.jks,relative-to=jboss.server.config.dir,credential-reference={clear-text=secret},type=JKS)
+----
+
+Now we can configure a Let's Encrypt account that we will reference when obtaining certificates:
+
+[source,shell]
+----
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:add(alias=letsEncrypt,key-store=accountsKS,contact-urls=[mailto:admin@admin.org])
+----
+
+The above command results in the following configuration in the Elytron subsystem:
+
+[source,xml]
+----
+<subsystem xmlns="urn:wildfly:elytron:4.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+...
+    <tls>
+    ...
+        <certificate-authority-accounts>
+            <certificate-authority-account name="myLetsEncryptAccount" contact-urls="mailto:admin@admin.org">
+                <account-key key-store="accountsKS" alias="letsEncrypt"/>
+            </certificate-authority-account>
+        </certificate-authority-accounts>
+    ...
+    </tls>
+...
+</subsystem>
+----
+
+Notice that a `certificate-authority-account` has the following attributes and element:
+
+* `name` - The name of the certificate authority account.
+* `contact-urls` - An optional list of contact URLs that Let's Encrypt can use to notify you about any issues with your account.
+* `account-key` - Information about the account key that will be used when communicating with Let's Encrypt.
+* `key-store` - A reference to the Elytron `key-store` that will hold your Let's Encrypt account key.
+* `alias` - The alias in the referenced `key-store` that will contain your Let's Encrypt account key.
+
+==== Obtaining a certificate from Let's Encrypt
+
+To obtain a certificate from Let's Encrypt, the `key-store` `obtain-certificate` command can be used. Its syntax is as follows:
+
+`obtain-certificate --alias= --domain-names= --certificate-authority-account= [--agree-to-terms-of-service=<true,false>] [--staging=<true,false>] [--algorithm=] [--key-size=] [--credential-reference=]`
+
+Let's take a closer look at the `obtain-certificate` operation's parameters:
+
+* `alias` - The alias in the key-store that will be used to store the certificate obtained from Let's Encrypt.
+* `domain-names` - The list of domain names to request a certificate for.
+* `certificate-authority-account` - A reference to the certificate authority account information that should be used to obtain the certificate.
+* `agree-to-terms-of-service` - Whether or not you agree to Let's Encrypt's terms of service (this only needs to be specified the first time you obtain a certificate from Let's Encrypt with your `certificate-authority-account`).
+* `staging` - Optional. Indicates whether or not Let's Encrypt's staging environment should be used to obtain the certificate. The default value is false. This should only be set to true for testing purposes. This should never be set to true in a production environment.
+* `algorithm` - Optional. Indicates the key algorithm that should be used (RSA or EC). The default value is RSA.
+* `key-size` - Optional. Indicates the key size that should be used. The default value is 2048.
+* `credential-reference` - Optional. The `credential-reference` that should be used to protect the generated private key. The default value is the `key-store` password.
+
+The `obtain-certificate` command will use the referenced `certificate-authority-account` to create an account with
+Let's Encrypt if one does not already exist. It will then request a certificate from Let's Encrypt for the specified `domain-names`.
+In particular, the `obtain-certificate` operation will prove ownership of the requested domain names, generate a key pair,
+generate a certificate signing request (CSR) using the generated key pair and the requested domain names, and submit this
+CSR to Let's Encrypt. If successful, the `obtain-certificate` operation will retrieve the resulting
+certificate chain from Let's Encrypt and store it along with the generated PrivateKey under the given alias in the `key-store`.
+These changes will also be persisted to the file that backs the `key-store`.
+
+For example, to request a certificate from Let's Encrypt for the domain name "www.example.org" using the "myLetsEncryptAccount"
+`certificate-authority-account`, the following command could be used. The resulting certificate will be stored in the file that backs
+the "serverKS" `key-store` under the alias "server".
+
+[source,shell]
+----
+/subsystem=elytron/key-store=serverKS:obtain-certificate(alias=server,domain-names=[www.example.org],certificate-authority-account=myLetsEncryptAccount,agree-to-terms-of-service)
+----
+
+You can now check the alias names in the `key-store` and confirm the new alias, "server", is listed:
+
+[source,shell]
+----
+/subsystem=elytron/key-store=serverKS:read-aliases()
+{
+    "outcome" => "success",
+    "result" => ["server"]
+}
+----
+
+To make use of this server certificate that's been issued by Let's Encrypt for one-way or two-way SSL, this server `key-store`
+can be used to create a `key-manager` in the Elytron subsystem and an `ssl-context` that references this `key-manager` can
+then be created. More details about setting up one-way and two-way SSL can be found in the Elytron https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc[documentation].
+
+Now that we've seen the two main ways that certificates can be obtained from Let's Encrypt using WildFly CLI commands, the
+next sections will describe how to manage these certificates.
+
+== Revoking a certificate from Let's Encrypt
+
+If you need to revoke a certificate that was issued by Let's Encrypt, the `revoke-certificate` command can be used:
+
+[source,shell]
+----
+/subsystem=elytron/key-store=serverKS:revoke-certificate(alias=server,reason=keyCompromise,certificate-authority-account=myLetsEncryptAccount)
+----
+
+In the above example, alias identifies the certificate that should be revoked. The `certificate-authority-account` is a
+reference to the certificate authority account information that should be used to revoke the certificate. The reason is
+optional and indicates the reason for revocation. If provided, it must be a valid revocation string.
+
+Once the certificate has been successfully revoked, it will be deleted from the `key-store`. This change will also be
+persisted to the file that backs the `key-store`.
+
+== Checking if a certificate is due for renewal
+
+The `should-renew-certificate` command can be used to check if a certificate is due for renewal. It returns true if the
+certificate expires in less than the given number of days and false otherwise. Its output also indicates the number of
+days to expiry. In the following example, should-renew-certificate checks if the certificate stored under the alias
+"server" expires in less than 15 days.
+
+[source,shell]
+----
+/subsystem=elytron/key-store=serverKS:should-renew-certificate(alias=server,expiration=15)
+{
+    "outcome" => "success",
+    "result" => {
+        "should-renew-certificate" => false,
+        "days-to-expiry" => 89L
+    }
+}
+----
+
+If the expiration parameter is not provided, it will default to 30 days, i.e., `should-renew-certificate` will return
+true if the certificate expires in less than 30 days and false otherwise.
+
+== Using a CLI script to automate certificate renewal
+
+Certificates issued by Let's Encrypt are valid for 90 days. Let's Encrypt recommends renewing certificates every 60 days.
+You can automate renewal by first creating a CLI script that checks if a certificate is due for renewal and if so, uses
+the obtain-certificate command to renew it. You could then create a cron job that runs say, twice daily, and executes
+the CLI script. A simple example of such a CLI script can be found below:
+
+[source,shell]
+----
+if (result.should-renew-certificate == true) of /subsystem=elytron/key-store=serverKS:should-renew-certificate(alias=server)
+
+    # certificate is due for renewal in less than 30 days, obtain a new certificate to replace the existing one in the key-store
+    /subsystem=elytron/key-store=serverKS:obtain-certificate(alias=server,domain-names=[www.example.org],certificate-authority-account=myLetsEncryptAccount,agree-to-terms-of-service)
+
+    # re-initialize your key-manager to ensure your new certificate will be used without needing to restart the server
+    /subsystem=elytron/key-manager=httpsKM:init()
+
+end-if
+----
+
+Notice that in the above script, after renewing the certificate, we can simply execute the key-manager init command in
+order to ensure that the new certificate will be used by the key-manager from now on without needing to restart WildFly.
+
+== Updating the contact URLs associated with your Let's Encrypt account
+
+To update the contact URLs that are associated with your Let's Encrypt, the following commands can be used:
+
+[source,shell]
+----
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:write-attribute(name=contact-urls,value=[mailto:newadmin@admin.org])
+reload
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:update-account()
+----
+
+== Changing your Let's Encrypt account key
+
+If you ever want to change the key that is associated with your Let's Encrypt account (e.g., in the event of a key
+compromise), the `change-account-key` command can be used:
+
+[source,shell]
+----
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:change-account-key()
+----
+
+== Deactivating your Let's Encrypt account
+
+If you ever need to deactivate your Let's Encrypt account, the `deactivate-account` command can be used:
+
+[source,shell]
+----
+/subsystem=elytron/certificate-authority-account=myLetsEncryptAccount:deactivate-account()
+----
+
+== Summary
+
+This blog post has given an overview on how to obtain and manage certificates from the Let's Encrypt certificate authority using the WildFly CLI.

--- a/_posts/2020-10-14-distributed-and-failover-realms.adoc
+++ b/_posts/2020-10-14-distributed-and-failover-realms.adoc
@@ -1,0 +1,75 @@
+---
+layout: post
+title: 'An overview of new security realm implementations'
+date: 2020-10-14
+tags: elytron wildfly21 securityrealm realm identity distributed database
+synopsis: An overview of the new realm implementations in WildFly Elytron and WildFly 21.
+author: mmazanek
+---
+
+We have added a new functionality to WildFly Elytron
+
+It is now possible to configure security realms that delegate authentication and authorization to multiple realms.
+
+== Distributed realm
+
+First added realm is the `distributed-realm`, which can be used to join multiple realms into one, for example if you
+have user data on two databases. Unlike `aggregate-realm`, which uses one realm for authentication and multiple realms
+or authorization, `distributed-realm` uses multiple realms for both authentication and authorization.
+
+
+Lets say we have two realms called `realm1` and `realm2`, which we want to use as one. We can do so in CLI using following command:
+
+[source]
+----
+/subsystem=elytron/distributed-realm=newrealm:add(realms=[realm1, realm2])
+----
+
+which results in following configuration:
+
+[source,xml]
+----
+<security-realms>
+...
+    <distributed-realm name="newrealm" realms="realm1 realm2"/>
+...
+</security-realms>
+----
+
+The new distributed-realm `newrealm` will use both `realm1` and `realm2` for authentication and authorization.
+
+
+== Failover realm
+
+The other added realm is the `failover-realm`, which enables you to configure a backup realm in case another realm is
+unavailable. For example, we can have a file based as a backup for database realm,
+so we can still access the deployed application using backup identity stored in the file based realm,
+even if we lose network connection to the `jdbc-realm` database.
+
+Lets say we have user data in jdbc-realm called `realm1` and we want to use filesystem-realm called `realm2` as a backup.
+We can do this in CLI using following command:
+
+[source]
+----
+/subsystem=elytron/failover-realm=newrealm:add(delegate-realm=realm1, failover-realm=realm2)
+----
+
+which results in following configuration:
+
+[source,xml]
+----
+<security-realms>
+...
+    <failover-realm name="newrealm" delegate-realm="realm1" failover-realm="realm2"/>
+...
+</security-realms>
+----
+
+The new failover-realm `newrealm` will use `realm1` as a primary realm for authentication and authorization, but if the
+realm becomes unavailable, it will switch to using `realm2`. The failover happens per authentication, so if the `realm1` becomes
+unavailable for a short time, you will be able to authenticate using it as soon as it comes back up without any reloads.
+
+
+== Summary
+
+This blog post has given an overview of WildFly Elytron distributed-realm and failover-realm.

--- a/_posts/2020-10-14-http-external-mechanism.adoc
+++ b/_posts/2020-10-14-http-external-mechanism.adoc
@@ -1,0 +1,22 @@
+---
+layout: post
+title: HTTP External Mechanism
+date: 2020-10-14
+tags: elytron http external
+synopsis: Overview of Elytron support for the HTTP External Mechanism
+author: aabdelsa
+---
+
+WildFly Elytron now supports authenticating users with the External HTTP mechanism. The External mechanism allows users to
+be authenticated with credentials established outside the server via the AJP protocol. This means if you have users authenticated
+by an Apache httpd server, these users can be forwarded to WildFly. This can be done by setting up
+Elytron to secure a WildFly deployment and specifying for the External HTTP mechanism to be used. This is done by specifying
+the `EXTERNAL` mechanism as one of the mechanism configurations to be used by the `http-authentication-factory`:
+[source, shell]
+----
+/subsystem=elytron/http-authentication-factory=web-tests:add(security-domain=example-domain, http-server-mechanism-factory=example-factory,
+mechanism-configurations=[{mechanism-name=EXTERNAL}])
+----
+If your application is secured using this `http-authentication-factory` and a remote server forwards an authenticated
+user using the `REMOTE_USER` attribute via the AJP protocol, Elytron will accept the externally authenticated user and
+use the specified security domain to perform role mapping to complete authorization.

--- a/_posts/2020-10-14-new-security-features-in-wildfly-21.adoc
+++ b/_posts/2020-10-14-new-security-features-in-wildfly-21.adoc
@@ -1,0 +1,57 @@
+---
+layout: post
+title: 'New Security Features in WildFly 21'
+date: 2020-10-14
+tags: elytron release wildfly21
+synopsis: An overview of the new security features in WildFly 21.
+author: fjuma
+---
+
+This blog post highlights the new security features that are in WildFly 21.
+
+== Security Realm Enhancements
+
+If a security realm becomes unavailable for some reason, it is now possible to fail over to an alternate security
+realm.
+
+WildFly 21 also adds support for distributed security realms, where identities can be stored in multiple security
+realms. When retrieving an identity from a distributed security realm, each of the configired realms is invoked
+sequentially until a realm containing the identity is found.
+
+For an overview of these two new realm implementations, check out this https://wildfly-security.github.io/wildfly-elytron/blog/distributed-and-failover-realms/[blog post].
+
+== Client Integration
+
+It's now possible for RESTEasy clients to make use of authentication information like credentials and SSL configuration
+from an Elytron client configuration file. Check out this https://wildfly-security.github.io/wildfly-elytron/blog/resteasy-elytron-client-integration/[blog post]
+to see an example of how to make use of this new feature.
+
+== Additional Authentication Mechanisms
+
+When using a remote Git repository to manage your WildFly configuration file history, it's now possible to
+connect to your Git repository using SSH authentication. For details on how to specify the SSH
+credentials that are needed to connect to your Git repository, take a look at this
+https://wildfly-security.github.io/wildfly-elytron/blog/ssh-auth-for-git-persistence/[blog post].
+
+Support for the HTTP External authentication mechanism has now been added to WildFly. This means that
+it is now possible for WildFly to authenticate a user based on credentials established externally.
+More details can be found in this https://wildfly-security.github.io/wildfly-elytron/blog/http-external-mechanism/[blog post].
+
+== TLS 1.3 Support with OpenSSL
+
+A little while ago, we added support for TLS 1.3 for WildFly when using the JSSE TLS provider. WildFly 21 now
+adds support for TLS 1.3 when using the OpenSSL TLS provider. As with the JSSE TLS provider, there is an important
+caveat to be aware of when using the OpenSSL TLS provider with TLS 1.3. If JDK 11 is in use and if there is a very
+large number of TLS 1.3 requests being made, it is possible that a drop in performance (throughput and response time)
+will occur compared to when using TLS 1.2 with WildFly. It is recommended to test for performance degradation prior
+to enabling TLS 1.3 in a production environment. Take a look at this
+https://wildfly-security.github.io/wildfly-elytron/blog/tls-13-with-wildfly-openssl/[blog post]
+to learn how to enable TLS 1.3 when using the OpenSSL TLS provider.
+
+== Where to Find More Information
+
+Be sure to check out our https://wildfly-security.github.io/wildfly-elytron/blog/[blog posts] page, where we have all our
+blog posts on Elytron features. If there is an Elytron topic you’d like to see a blog post on, feel free to let us know
+on WildFly’s https://groups.google.com/forum/#!forum/wildfly[user forums].
+
+To learn more about Elytron, check out our https://wildfly-security.github.io/wildfly-elytron/[site].

--- a/_posts/2020-10-14-ssh-auth-for-git-persistence.adoc
+++ b/_posts/2020-10-14-ssh-auth-for-git-persistence.adoc
@@ -1,0 +1,207 @@
+---
+layout: post
+title: 'SSH Authentication with Git Persistence'
+date: 2020-10-14
+tags: elytron wildfly client ssh git-persistence
+synopsis: An overview on how to use SSH credentials with the Elytron client to connect to a git repository that manages the WildFly server configuration file history.
+author: aabdelsa
+---
+
+:toc: macro
+:toc-title:
+
+When using a standalone WildFly server, it is currently possible to manage your configuration file history using a git
+repository. While previously it was only possible to connect to HTTP git servers, it is now possible to establish a connection
+with SSH servers as well.
+
+In order to connect to the SSH git repository, you will have to use an Elytron configuration file to set up SSH credentials.
+This blog will describe how to generate SSH keys and add them as credentials in a `wildfly-config.xml` file and how to
+start the standalone server with an SSH git repository to manage your configuration file history.
+
+toc::[]
+
+== Generating SSH keys using the Elytron Tool
+Elytron offers a way to generate and store private keys securely in a credential store. We can use the Elytron tool scripts
+found in your JBOSS home to do so. For this example, we will be creating a new credential store and generating an RSA key.
+
+First, we must create the credential store:
+
+[source,shell]
+----
+[$JBOSS_HOME]$ ./bin/elytron-tool.sh credential-store --create --location=cs_example.cs --password Elytron
+----
+This command creates a credential store in the file `cs_example.cs` and secures the credential store with the password
+`Elytron`. Note the file `cs_example.cs` does not need to exist before running this command to create the credential store.
+
+Next, we generate a key pair to store in the credential store:
+[source,shell]
+----
+[$JBOSS_HOME]$ ./bin/elytron-tool.sh credential-store --location=cs_example.cs --password Elytron --generate-key-pair example --algorithm RSA --size 3072
+----
+This command generates an RSA key pair credential of size 3072 bytes and stores it under the alias `example` in the credential
+store we created.
+
+Finally, we can print our public key with the following command:
+[source,shell]
+----
+[JBOSS_HOME]$ ./bin/elytron-tool.sh credential-store --location=cs_example.cs --password Elytron --export-key-pair-public-key example
+ssh-rsa
+AAAAB3NzaC1yc2EAAAADAQABAAABgwo8etzxo2JiERvv07/Cvkb6eIqodZrdWWAI11cp0VYgnEvd5dGoYGSHmDWO5EqXdOLROifr+CmOGUEWRIwSy+W13QywZbnrmDPJbx4e/KckVvhpEtq3AZc2w7Zunob+yxGlX9PyeYI4HEsKmwOi+brqeBD7fo923U9FUyqs47pu088tpuoYo2kcxX7BJP+uxfEIkZECWkQcolL8qMl4PkUvzWnTv+KjRzUXYAHEefdqpMa+th58KmB7W8An8weJ85/nerbOkVxN6dAbDO82at77LvaRRDh+65ur1JfTWf1iS+fH2TwTv5e/RGNOnV4sdpNcKVfZ3AWVKp5kmt+x0EQsCalFiDwGyciIjQ1jA8NRr83/LQgdzHsDZ7Amudc25IEwRdXS9BYxTqAMeBLoxHqDKAZ6uiZoPH4QfaVYSXeF3GrYUC2Fzg5P1VKa1OJQOb3itztXsor2vFVtQeUjQ3lv63FN8YE6HnS2PRhbqn9Ep0oh/QqbhlK4vtY+WtY5UWBf7Q==
+----
+
+If you already have an SSH key pair, it is possible to import the key into a credential store. See the
+https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Credential_Store.adoc[Credential Store Documentation]
+for more information
+
+=== The `wildfly-config.xml` configuration
+
+Once we have our key pair credential in a credential store, we can reference it from our `wildfly-config.xml` file as follows:
+[source,xml]
+----
+<configuration>
+  <authentication-client xmlns="urn:elytron:client:1.6">
+
+     <credential-stores>
+        <credential-store name="store1">
+           <protection-parameter-credentials>
+              <clear-password password="Elytron"/>
+           </protection-parameter-credentials>
+           <attributes>
+              <attribute name="keyStoreType" value="JCEKS"/>
+                <attribute name="location" value="cs_example.cs"/>
+           </attributes>
+        </credential-store>
+     </credential-stores>
+
+     <authentication-rules>
+        <rule use-configuration="example-config"/>
+     </authentication-rules>
+
+     <authentication-configurations>
+        <configuration name="example-config">
+           <credentials>
+              <credential-store-reference store="store1" alias="example" clear-text="Elytron"/>
+           </credentials>
+        </configuration>
+     </authentication-configurations>
+
+  </authentication-client>
+</configuration>
+----
+
+This configuration defines a new credential store from the file we created. It then references the alias `example` (which
+stores the RSA key pair we generated) to be used as credentials.
+
+== Generating SSH keys using the OpenSSH command line tool
+Alternatively, one may use the OpenSSH command line tool to generate their SSH keys. The algorithms supported by Elytron
+are: RSA, DSA, and ECDSA. For example, we can generate an ECDSA key of size 256 and encrypted with the passphrase “secret”
+as follows:
+[source,shell]
+----
+[~/.ssh]$ ssh-keygen -t ecdsa -b 256
+Generating public/private ecdsa key pair.
+Enter file in which to save the key (/home/user/.ssh/id_ecdsa):
+Enter passphrase (empty for no passphrase): secret
+Enter same passphrase again: secret
+Your identification has been saved in /home/user/.ssh/id_ecdsa.
+Your public key has been saved in /home/user/.ssh/id_ecdsa.pub.
+----
+For more information on how to generate OpenSSH keys see: https://man.openbsd.org/ssh-keygen[OpenSSH Documentation]
+
+=== The `wildfly-config.xml` configuration
+If you already have SSH keys generated, you can add them as credentials a couple of ways:
+
+==== Key Pair Credential
+One way is to specify your keys directly in the `wildfly-config.xml` using a `key-pair` credential as follows:
+[source,xml]
+----
+<configuration>
+  <authentication-client xmlns="urn:elytron:client:1.6">
+
+     <authentication-rules>
+        <rule use-configuration="example"/>
+     </authentication-rules>
+
+     <authentication-configurations>
+        <configuration name="example">
+           <credentials>
+              <key-pair>
+                 <openssh-private-key pem="-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDaZzGpGV
+922xmrL+bMHioPAAAAEAAAAAEAAABoAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlz
+dHAyNTYAAABBBIMTU1m6pmpnSTZ2k/cbKnxXkRpXUmWwqN1SSNLpRswGsUhmLG2H21br1Z
+lEHRiRn6zQmA4YCtCw2hLuz8M8WVoAAADAQk+bMNWFfaI4Ej1AQdlLl6v4RDa2HGjDS3V4
+39h0pOx4Ix7YZKydTN4SPkYRt78CNK0AhhtKsWo2lVNwyfh8/6SeqowhgCG9MJYW8yRR1R
+3DX/eQTx6MV/gSSRLDTpcVWUY0jrBGpMaEvylKoNcabiEo44flkIYlG6E/YtFXsmXsoBsj
+nFcjvmfE7Lzyin5Fowwpbqj9f0XOARu9wsUzeyJVAwT7+YCU3mWJ3dnO1bOxK4TuLsxD6j
+RB7bJemsfr
+-----END OPENSSH PRIVATE KEY-----">
+                    <clear-password password="secret"/>
+                 </openssh-private-key>
+              </key-pair>
+           </credentials>
+        </configuration>
+     </authentication-configurations>
+  </authentication-client>
+</configuration>
+----
+This configuration shows how to specify keys which are in OpenSSH format. In this example, we specify the passphrase `secret`
+that is required to decrypt the key as a `clear-password` type, but we could have also used a `masked-password` or a
+`credential-store-reference`.
+
+Elytron also supports keys in PKCS8 format, but they must not be encrypted with a passphrase.
+
+==== SSH credential
+The other way to add existing keys as credentials is to specify the location and file name containing your private keys
+using a `ssh-credential` as follows:
+
+[source,xml]
+----
+<configuration>
+  <authentication-client xmlns="urn:elytron:client:1.6">
+
+     <authentication-rules>
+        <rule use-configuration="example"/>
+     </authentication-rules>
+
+     <authentication-configurations>
+        <configuration name="example">
+           <credentials>
+              <ssh-credential ssh-directory="/user/home/example/.ssh" private-key-file="id_test_ecdsa" known-hosts-file="known_hosts_test">
+                 <clear-password password="secret"/>
+              </ssh-credential>
+           </credentials>
+        </configuration>
+     </authentication-configurations>
+  </authentication-client>
+</configuration>
+----
+* The `ssh-directory` attribute specifies the location of the key and the known hosts file.
+* The `private-key-file` attribute specifies the name of the file containing your private key.
+* The `known-hosts-file` attribute specifies the name of the file containing the known SSH hosts.
+
+This key was encrypted with the passphrase `secret` and so we specify a `clear-password` to be able to decrypt it, but
+again we could have also used a `masked-password` or a `credential-store-reference`.
+
+It is also possible to specify both a `key-pair` credential and `ssh-credential` at the same time if you would
+like to specify your private key using a `key-pair` but your `known_hosts` file is not in the default `[user.home]/.ssh` location and you need
+to use the `ssh-credential` to specify its location.
+
+For more information on the `key-pair` credential and `ssh-credential` check out the
+https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_client-guide/authentication-client.adoc[Elytron Authentication Client Documentation]
+
+== Connecting to a git repo
+
+Once we have added our credentials in a `wildfly-config.xml` file, we can connect to the remote SSH git repo.
+To connect, we use the SSH url of this repo and specify the following options when starting the standalone WildFly server:
+[source,xml]
+----
+[JBOSS_HOME]$ ./bin/standalone.sh --git-repo=ssh:giturl.com/repo --git-auth=file:///path/to/wildfly-config.xml
+----
+* The `--git-repo` option specifies the uri of the git repo we would like to connect to.
+* The `--git-auth` option specifies the location of the `wildfly-config` file containing your credentials.
+
+And all done! We should be able to successfully start up our standalone server and your configuration file history will be
+managed by the repository we connected to. For more information on git persistence, check out:
+
+https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc[Git Configuration file history]

--- a/_posts/2020-10-14-tls-13-with-wildfly-openssl.adoc
+++ b/_posts/2020-10-14-tls-13-with-wildfly-openssl.adoc
@@ -1,0 +1,160 @@
+---
+layout: post
+title: 'TLS 1.3 support for WildFly with OpenSSL'
+date: 2020-10-14
+tags: elytron wildfly21 tls13 ssl openssl
+synopsis: An overview of the new TLS 1.3 support included in WildFly 21.
+author: fjuma
+---
+
+WildFly 21 adds the ability to use TLS 1.3 with WildFly when using the OpenSSL TLS provider.
+This blog post will give an introduction to this new feature.
+
+== Disabled by Default
+
+The use of TLS 1.3 is currently disabled by default when using the OpenSSL TLS provider. This is because if
+JDK 11 is in use and if there is a very large number of TLS 1.3 requests coming in, it is possible that a drop
+in performance (i.e., throughput and response time) will occur compared to when using TLS 1.2 with the OpenSSL
+TLS provider. It is recommended to test for performance degradation prior to enabling TLS 1.3 in a production
+environment.
+
+== Enabling TLS 1.3 on the Server Side
+
+TLS 1.3 can be enabled by configuring the `cipher-suite-names` attribute in the SSL Context resource definition
+in the Elytron subsystem. Let's take a look at a complete example.
+
+=== Pre-requisite Configuration
+
+As a first step, we're going to enable one-way SSL for applications deployed to WildFly using the
+`security enable-ssl-http-server` CLI command:
+
+==== Enabling one-way SSL
+
+[source,shell]
+----
+security enable-ssl-http-server --interactive
+Please provide required pieces of information to enable SSL:
+
+Certificate info:
+Key-store file name (default default-server.keystore): server.keystore
+Password (blank generated): secret
+What is your first and last name? [Unknown]: localhost
+What is the name of your organizational unit? [Unknown]:
+What is the name of your organization? [Unknown]:
+What is the name of your City or Locality? [Unknown]:
+What is the name of your State or Province? [Unknown]:
+What is the two-letter country code for this unit? [Unknown]:
+Is CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct y/n [y]?y
+Validity (in days, blank default): 30
+Alias (blank generated): localhost
+Enable SSL Mutual Authentication y/n (blank n):n
+
+SSL options:
+key store file: server.keystore
+distinguished name: CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown,
+C=Unknown
+password: secret
+validity: 30
+alias: localhost
+Server keystore file server.keystore, certificate file server.pem and server.csr
+ file will be generated in server configuration directory.
+
+Do you confirm y/n :y
+Server reloaded.
+SSL enabled for default-server
+ssl-context is ssl-context-b0110cb7-595b-4de9-942b-e616690bb350
+key-manager is key-manager-b0110cb7-595b-4de9-942b-e616690bb350
+key-store   is key-store-b0110cb7-595b-4de9-942b-e616690bb350
+----
+
+As we can see from the output, the above command automatically generated a self-signed server certificate, added it to a
+newly created keystore, and added a new `ssl-context` resource, `ssl-context-b0110cb7-595b-4de9-942b-e616690bb350`, to
+the Elytron subsystem in order to enable one-way SSL for applications deployed to WildFly.
+
+==== Configuring WildFly to use the OpenSSL TLS provider
+
+There are two ways to configure WildFly to make use of the OpenSSL TLS provider.
+
+===== Using the OpenSSL TLS provider by default
+
+To configure the Elytron subsystem so that the OpenSSL TLS provider is used by default, the following commands can be used:
+
+[source,shell]
+----
+/subsystem=elytron:write-attribute(name=initial-providers, value=combined-providers)
+/subsystem=elytron:undefine-attribute(name=final-providers)
+reload
+----
+
+===== Configuring an SSL context to use the OpenSSL TLS provider
+
+Instead of configuring the Elytron subsystem to use the OpenSSL TLS provider by default, it is also possible
+to specify that the OpenSSL TLS provider should be used for a specific SSL context by configuring the `providers`
+attribute for a `server-ssl-context`. Let's update our `server-ssl-context` to specify that we want to use the
+OpenSSL TLS provider:
+
+[source,shell]
+----
+/subsystem=elytron/server-ssl-context=ssl-context-b0110cb7-595b-4de9-942b-e616690bb350:write-attribute(name=providers,value=openssl)
+reload
+----
+
+Now, let's try to access the WildFly landing page using `curl`:
+
+[source,shell]
+----
+curl -v -k https://localhost:8443
+* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
+* ALPN, server accepted to use h2
+* Server certificate:
+*  subject: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=localhost
+*  start date: Oct  6 14:58:16 2020 GMT
+*  expire date: Nov  5 15:58:16 2020 GMT
+*  issuer: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=localhost
+*  SSL certificate verify result: self signed certificate (18), continuing anyway.
+----
+
+Since the `security enable-ssl-http-server` command simply generated a self-signed server certificate for
+testing purposes, this server certificate won't be trusted by `curl`. This is why we specified the `-k` option
+in the `curl` command.
+
+Notice that in the above output, we can see that the TLS 1.2 protocol was used for the connection
+and that the `ECDHE-RSA-AES256-GCM-SHA384` cipher suite was used.
+
+=== Switching to TLS 1.3
+
+To enable TLS 1.3, we just need to update our `ssl-context` configuration in the Elytron subsystem to specify the
+`cipher-suite-names` attribute. The format of this attribute is colon separated list of the TLS 1.3 cipher suites
+that you would like to enable. We're going to set this attribute to `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`:
+
+[source,shell]
+----
+# This is only needed when the ssl-context is configured to use specific protocol version(s) other
+# than TLS 1.3. In general, this is not needed when the protocols attribute is simply undefined.
+/subsystem=elytron/server-ssl-context=ssl-context-b0110cb7-595b-4de9-942b-e616690bb350:write-attribute(name=protocols,value=[TLSv1.3])
+
+/subsystem=elytron/server-ssl-context=ssl-context-b0110cb7-595b-4de9-942b-e616690bb350:write-attribute(name=cipher-suite-names,value=TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256)
+reload
+----
+
+Now, let's try to access the WildFly landing page using `curl` again:
+
+[source,shell]
+----
+* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
+* ALPN, server accepted to use h2
+* Server certificate:
+*  subject: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=localhost
+*  start date: Oct  6 14:58:16 2020 GMT
+*  expire date: Nov  5 15:58:16 2020 GMT
+*  issuer: C=Unknown; ST=Unknown; L=Unknown; O=Unknown; OU=Unknown; CN=localhost
+*  SSL certificate verify result: self signed certificate (18), continuing anyway.
+----
+
+Notice that this time, we can see that the TLS 1.3 protocol was used for the connection and that the TLS 1.3
+`TLS_AES_256_GCM_SHA384` cipher suite was used.
+
+== Summary
+
+This blog post has given an overview on how TLS 1.3 can be used with WildFly with the OpenSSL TLS provider.
+For more details, take a look at the https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/OpenSSL.adoc[documentation].


### PR DESCRIPTION
* Added a blog post on TLS 1.3 with OpenSSL
* Added a blog post that gives an overview of the new security features in WildFly 21
* Migrated my blog post on Let's Encrypt over to our website and added a section on how to use the security wrapper commands to obtain a certificate from Let's Encrypt, as suggested by Diana

Will adjust the dates in the posts once WildFly 21 is released.