### PR TITLE
[ELY-2026] Use reflection to pass through the new methods if they are now available on the SSLEngine, SSLParameters, and SSLSocket APIs.

### DIFF
--- a/ssl/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
@@ -133,27 +133,27 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
     }
 
     public void setEnabledCipherSuites(final SSLContext sslContext, final SSLSocket sslSocket, final String[] cipherSuites) {
-        // ignored
+        sslSocket.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
     public void setEnabledCipherSuites(final SSLContext sslContext, final SSLEngine sslEngine, final String[] cipherSuites) {
-        // ignored
+        sslEngine.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
-    public void setEnabledCipherSuites(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] suites) {
-        // ignored
+    public void setEnabledCipherSuites(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] cipherSuites) {
+        sslServerSocket.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLSocket sslSocket, final String[] protocols) {
-        // ignored
+        sslSocket.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLEngine sslEngine, final String[] protocols) {
-        // ignored
+        sslEngine.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] protocols) {
-        // ignored
+        sslServerSocket.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     private SSLParameters redefine(SSLParameters original) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2026

Under ELY-1979 we did attempt a number of different approaches to implement these methods directly and avoid the use of reflection, unfortunately as the project is built using Java 11 but targeting Java 8 the Java 11 compiler does not agree that these methods are present in Java 8.

We could consider a more complex build that compiles using two different JDKs but that seems overly complex, another option could be to split out an "accessor" class into another project which is built using the latest Java 8 (and has no plans to move to Java 11 soon) but that seems over complex.

Users of Java 9 or later will automatically get the JDKSpecific implementation that uses direct access.