### PR TITLE
[1.10.x] [ELY-2026] Use reflection to pass through the new methods if they are now available on the SSLEngine, SSLParameters, and SSLSocket APIs.

### DIFF
--- a/ssl/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/SSLConfiguratorImpl.java
@@ -133,27 +133,27 @@ final class SSLConfiguratorImpl implements SSLConfigurator {
     }
 
     public void setEnabledCipherSuites(final SSLContext sslContext, final SSLSocket sslSocket, final String[] cipherSuites) {
-        // ignored
+        sslSocket.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
     public void setEnabledCipherSuites(final SSLContext sslContext, final SSLEngine sslEngine, final String[] cipherSuites) {
-        // ignored
+        sslEngine.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
-    public void setEnabledCipherSuites(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] suites) {
-        // ignored
+    public void setEnabledCipherSuites(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] cipherSuites) {
+        sslServerSocket.setEnabledCipherSuites(cipherSuiteSelector.evaluate(cipherSuites));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLSocket sslSocket, final String[] protocols) {
-        // ignored
+        sslSocket.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLEngine sslEngine, final String[] protocols) {
-        // ignored
+        sslEngine.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     public void setEnabledProtocols(final SSLContext sslContext, final SSLServerSocket sslServerSocket, final String[] protocols) {
-        // ignored
+        sslServerSocket.setEnabledProtocols(protocolSelector.evaluate(protocols));
     }
 
     private SSLParameters redefine(SSLParameters original) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2026
https://issues.redhat.com/browse/JBEAP-20313