### PR TITLE
[1.10.x] [ELY-2045] Update tests to use SHA256withRSA instead of SHA1withRSA.

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/auth/client/MaskedPasswordSSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/client/MaskedPasswordSSLAuthenticationTest.java
@@ -187,7 +187,7 @@ public class MaskedPasswordSSLAuthenticationTest {
         SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(issuerDN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
         X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -203,7 +203,7 @@ public class MaskedPasswordSSLAuthenticationTest {
         X509Certificate ladybirdCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Ladybird"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ladybirdPublicKey)
                 .setSerialNumber(new BigInteger("3"))
@@ -219,7 +219,7 @@ public class MaskedPasswordSSLAuthenticationTest {
         X509Certificate scarabCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Scarab"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(scarabPublicKey)
                 .setSerialNumber(new BigInteger("4"))

--- a/tests/base/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/client/XmlConfigurationTest.java
@@ -112,7 +112,7 @@ public class XmlConfigurationTest {
         SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(issuerDN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
         X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -126,7 +126,7 @@ public class XmlConfigurationTest {
         X509Certificate ladybirdCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(ladybirdDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ladybirdPublicKey)
                 .setSerialNumber(new BigInteger("4"))

--- a/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
@@ -165,7 +165,7 @@ public class JwtSecurityRealmTest extends BaseTestCase {
         SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(new X500Principal("CN=localhost, ST=Elytron, C=UK, EMAILADDRESS=elytron@wildfly.org, O=Root Certificate Authority"))
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
 

--- a/tests/base/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
@@ -94,7 +94,7 @@ public class DirContextFactoryRule implements TestRule {
         SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(issuerDN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
         X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -110,7 +110,7 @@ public class DirContextFactoryRule implements TestRule {
         X509Certificate localhostCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(localhostDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(localhostPublicKey)
                 .setSerialNumber(new BigInteger("3"))
@@ -126,7 +126,7 @@ public class DirContextFactoryRule implements TestRule {
         X509Certificate scarabCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(scarabDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(scarabPublicKey)
                 .setSerialNumber(new BigInteger("4"))

--- a/tests/base/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
@@ -134,7 +134,7 @@ public class EntityTest extends BaseTestCase {
         selfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(CA_DN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(new BasicConstraintsExtension(false, true, -1))
                 .build();
         final X509Certificate caCertificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -145,7 +145,7 @@ public class EntityTest extends BaseTestCase {
         selfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(DN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "SubjectAlternativeName", "DNS:testclient1.example.com")
                 .build();
         certificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -171,7 +171,7 @@ public class EntityTest extends BaseTestCase {
         certificate = new X509CertificateBuilder()
                 .setIssuerDn(CA_DN)
                 .setSubjectDn(subjectDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(caKey)
                 .setPublicKey(publicKey)
                 .build();
@@ -197,7 +197,7 @@ public class EntityTest extends BaseTestCase {
         selfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(DN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "SubjectAlternativeName", "DNS:testserver1.example.com")
                 .build();
         certificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();

--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -237,7 +237,7 @@ public class SSLAuthenticationTest {
         SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(issuerDN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
         X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
@@ -255,7 +255,7 @@ public class SSLAuthenticationTest {
         X509Certificate intermediateIssuerCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(intermediateIssuerDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(intermediateIssuerPublicKey)
                 .setSerialNumber(new BigInteger("6"))
@@ -270,7 +270,7 @@ public class SSLAuthenticationTest {
         X509Certificate ladybirdCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Ladybird"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ladybirdPublicKey)
                 .setSerialNumber(new BigInteger("3"))
@@ -286,7 +286,7 @@ public class SSLAuthenticationTest {
         X509Certificate scarabCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Scarab"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(scarabPublicKey)
                 .setSerialNumber(new BigInteger("4"))
@@ -302,7 +302,7 @@ public class SSLAuthenticationTest {
         X509Certificate dungCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Dung"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(dungPublicKey)
                 .setSerialNumber(new BigInteger("2"))
@@ -318,7 +318,7 @@ public class SSLAuthenticationTest {
         X509Certificate fireflyCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Firefly"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(fireflyPublicKey)
                 .setSerialNumber(new BigInteger("1"))
@@ -350,7 +350,7 @@ public class SSLAuthenticationTest {
         X509Certificate ocspResponderCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=OcspResponder"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ocspResponderPublicKey)
                 .setSerialNumber(new BigInteger("15"))
@@ -370,7 +370,7 @@ public class SSLAuthenticationTest {
         X509Certificate ocspCheckedGoodCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedGood"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ocspCheckedGoodPublicKey)
                 .setSerialNumber(new BigInteger("16"))
@@ -392,7 +392,7 @@ public class SSLAuthenticationTest {
         X509Certificate ocspCheckedRevokedCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedRevoked"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ocspCheckedRevokedPublicKey)
                 .setSerialNumber(new BigInteger("17"))
@@ -414,7 +414,7 @@ public class SSLAuthenticationTest {
         X509Certificate ocspCheckedUnknownCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedUnknown"))
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
                 .setPublicKey(ocspCheckedUnknownPublicKey)
                 .setSerialNumber(new BigInteger("18"))
@@ -457,7 +457,7 @@ public class SSLAuthenticationTest {
                 currentDate
         );
         X509CRLHolder caBlankCrlHolder = caBlankCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA1withRSA")
+                new JcaContentSignerBuilder("SHA256withRSA")
                         .setProvider("BC")
                         .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
         );
@@ -484,7 +484,7 @@ public class SSLAuthenticationTest {
                 CRLReason.unspecified
         );
         X509CRLHolder fireflyRevokedCrlHolder = fireflyRevokedCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA1withRSA")
+                new JcaContentSignerBuilder("SHA256withRSA")
                         .setProvider("BC")
                         .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
         );
@@ -500,7 +500,7 @@ public class SSLAuthenticationTest {
                 CRLReason.unspecified
         );
         X509CRLHolder icaRevokedCrlHolder = icaRevokedCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA1withRSA")
+                new JcaContentSignerBuilder("SHA256withRSA")
                         .setProvider("BC")
                         .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
         );

--- a/tests/base/src/test/java/org/wildfly/security/util/PemTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/util/PemTest.java
@@ -49,7 +49,7 @@ public class PemTest {
         SelfSignedX509CertificateAndSigningKey certificate = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(DN)
                 .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
 
@@ -67,7 +67,7 @@ public class PemTest {
         X509Certificate subjectCertificate = new X509CertificateBuilder()
                 .setIssuerDn(issuerDN)
                 .setSubjectDn(subjectDN)
-                .setSignatureAlgorithmName("SHA1withRSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
                 .setSigningKey(issuerCertificate.getSigningKey())
                 .setPublicKey(publicKey)
                 .build();

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/ocsp-responder.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/ocsp-responder.xml
@@ -21,7 +21,7 @@
             <type>JKS</type>
             <key>password=Elytron,keystore=file:target/test-classes/ca/jks/ocsp-responder.keystore</key>
             <algorithms>
-                <algorithm>SHA1withRSA</algorithm>
+                <algorithm>SHA256withRSA</algorithm>
             </algorithms>
         </signer>
     </signers>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2045