### PR TITLE
[ELY-2042] ElytronXMLParser is not configuring maximum-cert-path in X509RevocationTrustManager

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -669,6 +669,7 @@ public final class ElytronXmlParser {
                 revocationBuilder.setTrustStore(trustStore);
                 revocationBuilder.setOnlyEndEntity(onlyLeafCert);
                 revocationBuilder.setSoftFail(softFail);
+                revocationBuilder.setMaxCertPath(maxCertPath);
 
                 if (crl && ocsp) {
                     revocationBuilder.setPreferCrls(preferCrls);

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
@@ -51,6 +51,14 @@
             <ssl-context name="one-way-ssl">
                 <trust-store key-store-name="scarab"/>
             </ssl-context>
+            <ssl-context name="one-way-max-cert-path" >
+                <trust-store key-store-name="ca" />
+                <certificate-revocation-list path="target/test-classes/ica/crl/rove-revoked.pem"/>
+            </ssl-context>
+            <ssl-context name="one-way-max-cert-path-failure" >
+                <trust-store key-store-name="ca" />
+                <certificate-revocation-list path="target/test-classes/ica/crl/rove-revoked.pem" maximum-cert-path="1"/>
+            </ssl-context>
             <ssl-context name="one-way-crl-ssl">
                 <trust-store key-store-name="ca"/>
                 <certificate-revocation-list path="target/test-classes/ica/crl/blank-blank.pem"/>
@@ -112,6 +120,12 @@
             </rule>
             <rule use-ssl-context="one-way-ica-revoked-ssl">
                 <match-host name="test-one-way-ica-revoked.org"/>
+            </rule>
+            <rule use-ssl-context="one-way-max-cert-path">
+                <match-host name="test-one-way-max-cert-path.org" />
+            </rule>
+            <rule use-ssl-context="one-way-max-cert-path-failure">
+                <match-host name="test-one-way-max-cert-path-failure.org" />
             </rule>
             <rule use-ssl-context="two-way-ssl">
                 <match-host name="test-two-way.org"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2042