### PR TITLE
[ELY-2053] key-store-masked-password needs the elytron provider to be manually registered

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -1970,7 +1970,7 @@ public final class ElytronXmlParser {
                         passwordFactory = () -> {
                             try {
                                 Password password = maskedPassword.get();
-                                PasswordFactory factory = PasswordFactory.getInstance(password.getAlgorithm());
+                                PasswordFactory factory = PasswordFactory.getInstance(password.getAlgorithm(), providersSupplier);
                                 ClearPasswordSpec spec = factory.getKeySpec(password, ClearPasswordSpec.class);
                                 return spec.getEncodedPassword();
                             } catch (GeneralSecurityException e) {

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
@@ -26,9 +26,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.PrivateKey;
-import java.security.Provider;
 import java.security.PublicKey;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
@@ -40,7 +38,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.security.SecurityFactory;
-import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.interfaces.ClearPassword;
@@ -55,7 +52,6 @@ public class ElytronXmlParserTest {
     private static File KEYSTORE_DIR = new File("./target/keystore");
     private static final String CLIENT_KEYSTORE_FILENAME = "/client.keystore";
     private static final char[] PASSWORD = "password".toCharArray();
-    private static final Provider provider = new WildFlyElytronProvider();
 
 
     /**
@@ -199,8 +195,6 @@ public class ElytronXmlParserTest {
 
     @BeforeClass
     public static void prepareKeyStores() throws Exception {
-        Security.addProvider(provider);
-
         if (KEYSTORE_DIR.exists() == false) {
             KEYSTORE_DIR.mkdirs();
         }
@@ -219,6 +213,7 @@ public class ElytronXmlParserTest {
 
     @AfterClass
     public static void removeProvider() {
-        Security.removeProvider(provider.getName());
+        Assert.assertTrue("Keystore deleted", new File(KEYSTORE_DIR, CLIENT_KEYSTORE_FILENAME).delete());
+        Assert.assertTrue("Keystore directory deleted", KEYSTORE_DIR.delete());
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2053

The option `key-store-masked-password` needed to manually add the elytron provider when the `wildfly-config.xml` was used in a standalone app. The change just passes the `providersSupplier` parameter as in all the rest of the calls. It also modifies the related test to not include the provider as before.

PR sent to 1.x if if it is needed in more branches just let me now.

Thanks!