### PR TITLE
[JBEAP-20656] [ELY-1976] Elytron provider not being used with credential store and SASL authentication on the client side

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/CredentialStoreFactory.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/CredentialStoreFactory.java
@@ -81,10 +81,11 @@ final class CredentialStoreFactory implements ExceptionSupplier<CredentialStore,
         try {
             if (providers != null) {
                 credentialStore = providerName != null ? CredentialStore.getInstance(type, providerName, providers) : CredentialStore.getInstance(type, providers);
+                credentialStore.initialize(attributes, credentialSource == null ? null : new CredentialStore.CredentialSourceProtectionParameter(credentialSource.get()), providers.get());
             } else {
                 credentialStore = providerName != null ? CredentialStore.getInstance(type, providerName) : CredentialStore.getInstance(type);
+                credentialStore.initialize(attributes, credentialSource == null ? null : new CredentialStore.CredentialSourceProtectionParameter(credentialSource.get()));
             }
-            credentialStore.initialize(attributes, credentialSource == null ? null : new CredentialStore.CredentialSourceProtectionParameter(credentialSource.get()));
         } catch (GeneralSecurityException e) {
             throw xmlLog.xmlFailedToCreateCredentialStore(location, e);
         }

--- a/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -283,7 +283,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 final Password password = credential.castAndApply(PasswordCredential.class, PasswordCredential::getPassword);
                 final String algorithm = password.getAlgorithm();
                 final DEREncoder encoder = new DEREncoder();
-                final PasswordFactory passwordFactory = PasswordFactory.getInstance(algorithm);
+                final PasswordFactory passwordFactory = providers != null ? PasswordFactory.getInstance(algorithm, () -> providers) : PasswordFactory.getInstance(algorithm);
                 switch (algorithm) {
                     case BCryptPassword.ALGORITHM_BCRYPT:
                     case BSDUnixDESCryptPassword.ALGORITHM_BSD_CRYPT_DES:
@@ -676,7 +676,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                         }
                     }
                 }
-                PasswordFactory passwordFactory = PasswordFactory.getInstance(matchedAlgorithm);
+                PasswordFactory passwordFactory = providers != null ? PasswordFactory.getInstance(matchedAlgorithm, () -> providers) : PasswordFactory.getInstance(matchedAlgorithm);
                 final Password password = passwordFactory.generatePassword(passwordSpec);
                 return credentialType.cast(new PasswordCredential(password));
             } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {

--- a/tests/base/src/test/java/org/wildfly/security/auth/client/CredentialStoreSaslAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/client/CredentialStoreSaslAuthenticationTest.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.credential.store.CredentialStoreBuilder;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.sasl.plain.PlainSaslServerFactory;
+import org.wildfly.security.sasl.plain.WildFlyElytronSaslPlainProvider;
+import org.wildfly.security.sasl.test.SaslServerBuilder;
+
+/**
+ * Tests a successful SASL authentication with a credential store reference in xml configuration
+ *
+ * @author <a href="mailto:szaldana@redhat.com">Sonia Zaldana</a>
+ */
+
+public class CredentialStoreSaslAuthenticationTest {
+
+    private static final String PLAIN = "PLAIN";
+    private static final String USERNAME = "Guest";
+    private static final String PASSWORD = "gpwd";
+    private static final String CREDENTIAL_CONFIG_FILE = "wildfly-credential-sasl-config.xml";
+    private static String BASE_STORE_DIRECTORY = "target/ks-cred-stores";
+
+    private static final Provider[] providers = new Provider[] {
+            WildFlyElytronSaslPlainProvider.getInstance(),
+            WildFlyElytronPasswordProvider.getInstance()
+    };
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        System.setProperty("wildfly.config.url", CredentialStoreSaslAuthenticationTest.class.getResource(CREDENTIAL_CONFIG_FILE).toExternalForm());
+
+        // Enable Elytron Password provider manually to configure credential store
+        Security.insertProviderAt(providers[1], 1);
+
+        CredentialStoreBuilder.get().setKeyStoreFile(BASE_STORE_DIRECTORY + "/mycredstore.cs")
+                .setKeyStoreType("JCEKS")
+                .setKeyStorePassword("StorePassword")
+                .addPassword(USERNAME, PASSWORD)
+                .build();
+
+        // disable Elytron provider before client and server exchange messages
+        Security.removeProvider(providers[1].getName());
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        cleanCredentialStore();
+    }
+
+    private static void cleanCredentialStore() {
+        File file = new File(BASE_STORE_DIRECTORY + "/mycredstore.cs");
+        file.delete();
+    }
+
+    @Test
+    public void testSuccessfulSaslAuthenticationWithCredentialStore() throws Exception {
+
+            SaslServer server = new SaslServerBuilder(PlainSaslServerFactory.class, PLAIN)
+                    .setProviderSupplier(() -> providers)
+                    .setUserName(USERNAME)
+                    .setPassword(PASSWORD.toCharArray())
+                    .build();
+
+            // Create SASL client from XML configuration file
+            AuthenticationContext context = AuthenticationContext.getContextManager().get();
+
+            AuthenticationContextConfigurationClient contextConfigurationClient = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+            SaslClient client = contextConfigurationClient.createSaslClient(new URI(CREDENTIAL_CONFIG_FILE), context.authRules.getConfiguration(), Arrays.asList(new String[]{PLAIN}));
+
+            assertTrue(client.hasInitialResponse());
+            byte[] message = client.evaluateChallenge(new byte[0]);
+            assertEquals("\0"+USERNAME+"\0"+PASSWORD,new String(message, StandardCharsets.UTF_8));
+
+            server.evaluateResponse(message);
+            assertTrue(server.isComplete());
+            assertTrue(client.isComplete());
+            assertEquals(USERNAME, server.getAuthorizationID());
+
+    }
+
+}

--- a/tests/base/src/test/resources/org/wildfly/security/auth/client/wildfly-credential-sasl-config.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/auth/client/wildfly-credential-sasl-config.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2020, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.4">
+        <credential-stores>
+            <credential-store name="mycredstore">
+                <attributes>
+                    <attribute name="keyStoreType" value="JCEKS"/>
+                    <attribute name="location" value="target/ks-cred-stores/mycredstore.cs"></attribute>
+                </attributes>
+                <protection-parameter-credentials>
+                    <clear-password password="StorePassword"/>
+                </protection-parameter-credentials>
+            </credential-store>
+        </credential-stores>
+
+        <authentication-rules>
+            <rule use-configuration="default-config"/>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="default-config">
+                <set-user-name name="Guest"/>
+                <credentials>
+                    <credential-store-reference store="mycredstore" alias="Guest"/>
+                </credentials>
+                <sasl-mechanism-selector selector="PLAIN"/>
+                <providers>
+                    <use-service-loader />
+                </providers>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-20656
Upstream Issue: https://issues.redhat.com/browse/ELY-1976
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1405

Backport of ELY-1976 to 1.10.x branch, needed for JBEAP-20656. Plain cherry-pick changing the version of the test configuration file `wildfly-credential-sasl-config.xml` to `urn:elytron:client:1.4` (in upstream was 1.5 that did not work).