### PR TITLE
[ELY-2056] Add a new GitHub workflow to trigger CI for pull requests.

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,0 +1,29 @@
+name: Pull Request CI
+on:
+  pull_request:
+    branches:
+      - 1.x
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Version Info
+        run: mvn -version
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2056

At the moment this is just a minimal PR to get things going, to test and tweak the PR triggers we really need it set up against a repo that receives PRs to get used to how it behaves so we know what changes it needs.

I haven't added additional items yet for gathering any logs etc.. we can see if we need those but for now all failures I have seen were reproducible locally using a download of the Zulu JDK.

Also for now I have included macOS in the list, we have a concurrency limit of 5 - we may take that one out later but for now contributors may develop on macOS so worth considering.

We already have Elytron Web split out into a separate project and we plan so split Jakarta EE and MicroProfile modules into their own projects so at some point I would like to explore how change in Elytron can be tested against those projects and how PRs against those projects can also build against the latest Elytron so interactions can be tested.  Initially maybe that would be against PRs but if not maybe could be based on push triggers or be scheduled to run nightly.
