### PR TITLE
[ELY-2060] Move Certificate Authority set up to re-usable tool.

### DIFF
--- a/sasl/external/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
+++ b/sasl/external/src/test/java/org/wildfly/security/sasl/external/ExternalSaslClientTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Provider;
@@ -42,7 +43,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 
 /**
  * Tests for the SASL Client for EXTERNAL mechanism (
@@ -50,7 +50,7 @@ import org.wildfly.security.sasl.test.BaseTestCase;
  *
  * @author Josef Cacek
  */
-public class ExternalSaslClientTest extends BaseTestCase {
+public class ExternalSaslClientTest {
 
     private static final byte[] BYTES_EMPTY = new byte[0];
     private static final String ADMIN = "admin";

--- a/sasl/external/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
+++ b/sasl/external/src/test/java/org/wildfly/security/sasl/external/ExternalSaslServerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Provider;
@@ -46,7 +47,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 
 /**
@@ -55,7 +55,7 @@ import org.wildfly.security.sasl.util.AbstractSaslParticipant;
  *
  * @author Josef Cacek
  */
-public class ExternalSaslServerTest extends BaseTestCase {
+public class ExternalSaslServerTest {
 
     private static final String ADMIN = "admin";
     private static final String EXTERNAL = "EXTERNAL";

--- a/sasl/gssapi/src/test/java/org/wildfly/security/sasl/gssapi/MechanismSelectionTestCase.java
+++ b/sasl/gssapi/src/test/java/org/wildfly/security/sasl/gssapi/MechanismSelectionTestCase.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wildfly.security.sasl.gssapi;
 
 import static org.junit.Assert.assertNotNull;
@@ -7,9 +25,8 @@ import java.security.Provider;
 import java.security.Security;
 
 import org.junit.Test;
-import org.wildfly.security.sasl.test.BaseTestCase;
 
-public class MechanismSelectionTestCase extends BaseTestCase {
+public class MechanismSelectionTestCase {
 
     @Test
     public void testGetJdkOnlyGSSAPI() throws Exception {

--- a/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
@@ -80,7 +80,6 @@ import org.wildfly.security.authz.Attributes;
 import org.wildfly.security.evidence.BearerTokenEvidence;
 import org.wildfly.security.evidence.Evidence;
 import org.wildfly.security.pem.Pem;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.ssl.SSLContextBuilder;
 import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
 
@@ -94,7 +93,7 @@ import static org.junit.Assert.assertTrue;
  */
 // dependent on wildfly-security-ssl
 @RunWith(JMockit.class)
-public class JwtSecurityRealmTest extends BaseTestCase {
+public class JwtSecurityRealmTest {
 
     private static final MockWebServer server = new MockWebServer();
     private static final MockWebServer nonTlsServer = new MockWebServer();

--- a/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -18,8 +18,33 @@
 
 package org.wildfly.security.http.impl;
 
-import mockit.Mock;
-import mockit.MockUp;
+import static org.wildfly.security.http.HttpConstants.AUTHENTICATION_INFO;
+import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
+import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.SSLSession;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
+
 import org.junit.Assert;
 import org.wildfly.security.auth.callback.AuthenticationCompleteCallback;
 import org.wildfly.security.auth.callback.AvailableRealmsCallback;
@@ -38,44 +63,20 @@ import org.wildfly.security.http.HttpServerMechanismsResponder;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.http.Scope;
+import org.wildfly.security.http.basic.BasicMechanismFactory;
+import org.wildfly.security.http.digest.DigestMechanismFactory;
+import org.wildfly.security.http.digest.NonceManager;
 import org.wildfly.security.http.external.ExternalMechanismFactory;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
-import org.wildfly.security.sasl.test.BaseTestCase;
-import org.wildfly.security.http.basic.BasicMechanismFactory;
-import org.wildfly.security.http.digest.DigestMechanismFactory;
-import org.wildfly.security.http.digest.NonceManager;
 
-import javax.net.ssl.SSLSession;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.sasl.AuthorizeCallback;
-import javax.security.sasl.RealmCallback;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.Certificate;
-import java.security.spec.InvalidKeySpecException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.wildfly.security.http.HttpConstants.AUTHENTICATION_INFO;
-import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
-import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
+import mockit.Mock;
+import mockit.MockUp;
 
 // has dependency on wildfly-elytron-sasl, wildfly-elytron-http-basic and wildfly-elytron-digest
-public class AbstractBaseHttpTest extends BaseTestCase {
+public class AbstractBaseHttpTest {
 
     protected HttpServerAuthenticationMechanismFactory basicFactory = new BasicMechanismFactory();
     protected HttpServerAuthenticationMechanismFactory digestFactory = new DigestMechanismFactory();

--- a/tests/base/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/digest/CompatibilityClientTest.java
@@ -56,7 +56,6 @@ import org.wildfly.security.credential.store.CredentialStoreBuilder;
 import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.sasl.SaslMechanismSelector;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
 import mockit.Mock;
@@ -71,7 +70,7 @@ import mockit.integration.junit4.JMockit;
  */
 // has dependency on wildfly-elytron-client, wildfly-elytron-credential
 @RunWith(JMockit.class)
-public class CompatibilityClientTest extends BaseTestCase {
+public class CompatibilityClientTest {
 
     /** mechanism name */
     protected static final String DIGEST = "DIGEST-MD5";

--- a/tests/base/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/digest/CompatibilityServerTest.java
@@ -41,7 +41,6 @@ import org.wildfly.common.iteration.ByteIterator;
 import org.wildfly.common.iteration.CodePointIterator;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
@@ -56,7 +55,7 @@ import mockit.integration.junit4.JMockit;
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 @RunWith(JMockit.class)
-public class CompatibilityServerTest extends BaseTestCase {
+public class CompatibilityServerTest {
 
     protected static final String REALM_PROPERTY = "com.sun.security.sasl.digest.realm";
     protected static final String QOP_PROPERTY = "javax.security.sasl.qop";

--- a/tests/base/src/test/java/org/wildfly/security/sasl/digest/DigestTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/digest/DigestTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.wildfly.security.sasl.digest.DigestCallbackHandlerUtils.createClearPwdClientCallbackHandler;
 import static org.wildfly.security.sasl.digest.DigestCallbackHandlerUtils.createDigestPwdClientCallbackHandler;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,7 +55,6 @@ import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.password.interfaces.DigestPassword;
 import org.wildfly.security.password.spec.DigestPasswordSpec;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
@@ -64,7 +64,7 @@ import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class DigestTest extends BaseTestCase {
+public class DigestTest {
 
     private static Logger log = Logger.getLogger(DigestTest.class);
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/entity/EntityTest.java
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertMechanisms;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.Closeable;
 import java.io.File;
@@ -76,7 +79,6 @@ import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.KeyStoreBackedSecurityRealm;
 import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.sasl.SaslMechanismSelector;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 import org.wildfly.security.x500.cert.BasicConstraintsExtension;
@@ -94,7 +96,7 @@ import mockit.integration.junit4.JMockit;
  */
 //has dependency on x500-cert
 @RunWith(JMockit.class)
-public class EntityTest extends BaseTestCase {
+public class EntityTest {
 
     private static final String CLIENT_KEYSTORE_ALIAS = "testclient1";
     private static final String KEYSTORE_TYPE = "JKS";

--- a/tests/base/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/gs2/Gs2SuiteChild.java
@@ -31,6 +31,9 @@ import static org.wildfly.security.sasl.gs2.Gs2.SPNEGO_PLUS;
 import static org.wildfly.security.sasl.gssapi.JaasUtil.loginClient;
 import static org.wildfly.security.sasl.gssapi.JaasUtil.loginServer;
 import static org.wildfly.security.sasl.gssapi.TestKDC.LDAP_PORT;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertMechanisms;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -80,7 +83,6 @@ import org.wildfly.security.mechanism.gssapi.GSSCredentialSecurityFactory;
 import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.gssapi.GssapiTestSuite;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.ChannelBindingSaslClientFactory;
 import org.wildfly.security.sasl.util.PropertiesSaslClientFactory;
@@ -93,7 +95,7 @@ import org.wildfly.security.sasl.util.ServerNameSaslClientFactory;
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
 // has dependency on wildfly-elytron-client, wildfly-elytron-realm
-public class Gs2SuiteChild extends BaseTestCase {
+public class Gs2SuiteChild {
 
     private static final String TEST_SERVER_1 = "test_server_1";
     private static Subject clientSubject;

--- a/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientV10Test.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientV10Test.java
@@ -61,7 +61,6 @@ import org.wildfly.security.auth.realm.token.validator.JwtValidator;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.credential.source.OAuth2CredentialSource;
 import org.wildfly.security.sasl.SaslMechanismSelector;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
@@ -71,7 +70,7 @@ import org.wildfly.security.sasl.util.SaslMechanismInformation;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 // has dependency on wildfly-elytron-client
-public class OAuth2SaslClientV10Test extends BaseTestCase {
+public class OAuth2SaslClientV10Test {
 
     private static final MockWebServer server = new MockWebServer();
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientV11Test.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslClientV11Test.java
@@ -67,7 +67,6 @@ import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.credential.source.OAuth2CredentialSource;
 import org.wildfly.security.credential.store.CredentialStoreBuilder;
 import org.wildfly.security.sasl.SaslMechanismSelector;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
@@ -77,7 +76,7 @@ import org.wildfly.security.sasl.util.SaslMechanismInformation;
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
 // has dependency on wildfly-elytron-client
-public class OAuth2SaslClientV11Test extends BaseTestCase {
+public class OAuth2SaslClientV11Test {
 
     private static final MockWebServer server = new MockWebServer();
     private static final Provider[] providers = new Provider[] {

--- a/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/oauth2/OAuth2SaslTest.java
@@ -18,6 +18,9 @@
 
 package org.wildfly.security.sasl.oauth2;
 
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
+
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.integration.junit4.JMockit;
@@ -40,7 +43,6 @@ import org.wildfly.security.auth.util.RegexNameRewriter;
 import org.wildfly.security.authz.MapAttributes;
 import org.wildfly.security.credential.BearerTokenCredential;
 import org.wildfly.security.mechanism.oauth2.OAuth2Server;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
@@ -89,7 +91,7 @@ import static org.junit.Assert.fail;
  */
 // has dependency on wildfly-elytron-realm-auth-token
 @RunWith(JMockit.class)
-public class OAuth2SaslTest extends BaseTestCase {
+public class OAuth2SaslTest {
 
     private static final Provider provider = WildFlyElytronSaslOAuth2Provider.getInstance();
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/otp/OTPTest.java
@@ -37,6 +37,8 @@ import static org.wildfly.security.sasl.otp.OTP.MATCH_RESPONSE_CHOICE;
 import static org.wildfly.security.sasl.otp.OTP.PASS_PHRASE;
 import static org.wildfly.security.sasl.otp.OTP.WORD_RESPONSE;
 import static org.wildfly.security.sasl.otp.OTP.getOTPParameterSpec;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -88,7 +90,6 @@ import org.wildfly.security.password.spec.OneTimePasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.OneTimePasswordSpec;
 import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.test.SaslServerBuilder.BuilderReference;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
@@ -105,7 +106,7 @@ import mockit.integration.junit4.JMockit;
  */
 // has dependency on wildfly-elytron-client
 @RunWith(JMockit.class)
-public class OTPTest extends BaseTestCase {
+public class OTPTest {
 
     private long timeout;
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/plain/PlainTest.java
@@ -24,6 +24,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertNoMechanisms;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertSingleMechanism;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -43,14 +46,13 @@ import javax.security.sasl.SaslServerFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
 import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
 import org.wildfly.security.sasl.SaslMechanismSelector;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 
 /**
@@ -62,7 +64,7 @@ import org.wildfly.security.sasl.test.SaslServerBuilder;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 // has dependency on wildfly-elytron-client
-public class PlainTest extends BaseTestCase {
+public class PlainTest {
 
     private static final String PLAIN = "PLAIN";
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/BasicScramSelfTest.java
@@ -21,6 +21,7 @@ package org.wildfly.security.sasl.scram;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.password.interfaces.ScramDigestPassword.ALGORITHM_SCRAM_SHA_1;
 import static org.wildfly.security.sasl.scram.ScramCallbackHandlerUtils.createClientCallbackHandler;
 
 import java.security.AccessController;
@@ -47,19 +48,17 @@ import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.IteratedSaltedHashPasswordSpec;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
+import org.wildfly.security.sasl.test.SaslTestUtil;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.ChannelBindingSaslClientFactory;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
-
-import static org.wildfly.security.password.interfaces.ScramDigestPassword.ALGORITHM_SCRAM_SHA_1;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
-public class BasicScramSelfTest extends BaseTestCase {
+public class BasicScramSelfTest {
 
     private static final Provider[] providers = new Provider[] {
             WildFlyElytronSaslScramProvider.getInstance(),
@@ -291,7 +290,7 @@ public class BasicScramSelfTest extends BaseTestCase {
     }
 
     private SaslClientFactory obtainSaslClientFactory() {
-        final SaslClientFactory clientFactory = obtainSaslClientFactory(ScramSaslClientFactory.class);
+        final SaslClientFactory clientFactory = SaslTestUtil.obtainSaslClientFactory(ScramSaslClientFactory.class);
         Assert.assertTrue(clientFactory instanceof ScramSaslClientFactory);
         return clientFactory;
     }

--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.wildfly.security.sasl.scram.ScramCallbackHandlerUtils.createClientCallbackHandler;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Provider;
@@ -44,7 +45,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.mechanism.scram.ScramClient;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.util.AbstractSaslParticipant;
 import org.wildfly.security.sasl.util.ChannelBindingSaslClientFactory;
 
@@ -61,7 +61,7 @@ import org.wildfly.security.sasl.util.SaslMechanismInformation;
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 @RunWith(JMockit.class)
-public class ScramClientCompatibilityTest extends BaseTestCase {
+public class ScramClientCompatibilityTest {
 
     private static final Provider provider = WildFlyElytronSaslScramProvider.getInstance();
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
@@ -52,7 +53,6 @@ import org.wildfly.security.password.interfaces.ScramDigestPassword;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
 import org.wildfly.security.sasl.WildFlySasl;
-import org.wildfly.security.sasl.test.BaseTestCase;
 import org.wildfly.security.sasl.test.SaslServerBuilder;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
@@ -67,7 +67,7 @@ import mockit.integration.junit4.JMockit;
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
 @RunWith(JMockit.class)
-public class ScramServerCompatibilityTest extends BaseTestCase {
+public class ScramServerCompatibilityTest {
 
     private static final Provider provider = WildFlyElytronSaslScramProvider.getInstance();
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/AnonymousTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/AnonymousTest.java
@@ -22,6 +22,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertNoMechanisms;
+import static org.wildfly.security.sasl.test.SaslTestUtil.assertSingleMechanism;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslClientFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.net.URI;
 import java.security.Provider;
@@ -40,7 +44,6 @@ import javax.security.sasl.SaslServerFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.wildfly.security.sasl.anonymous.WildFlyElytronSaslAnonymousProvider;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.ClientUtils;
@@ -49,6 +52,7 @@ import org.wildfly.security.sasl.anonymous.AnonymousClientFactory;
 import org.wildfly.security.sasl.anonymous.AnonymousSaslClient;
 import org.wildfly.security.sasl.anonymous.AnonymousSaslServer;
 import org.wildfly.security.sasl.anonymous.AnonymousServerFactory;
+import org.wildfly.security.sasl.anonymous.WildFlyElytronSaslAnonymousProvider;
 
 /**
  * Test for the Anonymous SASL mechanism, this will test both the client and server side.
@@ -56,7 +60,7 @@ import org.wildfly.security.sasl.anonymous.AnonymousServerFactory;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 // has dependency on wildfly-elytron-client
-public class AnonymousTest extends BaseTestCase {
+public class AnonymousTest {
 
     private static final String ANONYMOUS = "ANONYMOUS";
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/LocalUserTest.java
@@ -59,7 +59,7 @@ import org.wildfly.security.sasl.localuser.LocalUserServerFactory;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 // has dependency on wildfly-elytron-client
-public class LocalUserTest extends BaseTestCase {
+public class LocalUserTest {
 
     private static final String LOCAL_USER = "JBOSS-LOCAL-USER";
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslFactoriesApiTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslFactoriesApiTest.java
@@ -48,7 +48,7 @@ import org.junit.Test;
  * @author Josef Cacek
  */
 // dependency on wildfly-tests-common
-public class SaslFactoriesApiTest extends BaseTestCase {
+public class SaslFactoriesApiTest {
 
     private static final String REGEX_MECHANISM_NAME = "^[A-Z0-9-_]{1,20}$";
 

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -17,7 +17,7 @@
  */
 package org.wildfly.security.sasl.test;
 
-import static org.wildfly.security.sasl.test.BaseTestCase.obtainSaslServerFactory;
+import static org.wildfly.security.sasl.test.SaslTestUtil.obtainSaslServerFactory;
 
 import java.io.Closeable;
 import java.io.File;

--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.wildfly.security.ssl.test.util.CAGenerationTool.SIGNATURE_ALGORTHM;
 import static org.wildfly.security.x500.X500.OID_AD_OCSP;
 import static org.wildfly.security.x500.X500.OID_KP_OCSP_SIGNING;
 
@@ -32,16 +33,11 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.URI;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.Principal;
-import java.security.PublicKey;
-import java.security.PrivateKey;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.AccessController;
@@ -89,15 +85,13 @@ import org.wildfly.security.auth.realm.KeyStoreBackedSecurityRealm;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.permission.PermissionVerifier;
-
+import org.wildfly.security.ssl.test.util.CAGenerationTool;
+import org.wildfly.security.ssl.test.util.CAGenerationTool.Identity;
 import org.wildfly.security.x500.GeneralName;
 import org.wildfly.security.x500.principal.X500AttributePrincipalDecoder;
 import org.wildfly.security.x500.cert.AccessDescription;
 import org.wildfly.security.x500.cert.AuthorityInformationAccessExtension;
-import org.wildfly.security.x500.cert.BasicConstraintsExtension;
 import org.wildfly.security.x500.cert.ExtendedKeyUsageExtension;
-import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
-import org.wildfly.security.x500.cert.X509CertificateBuilder;
 
 /**
  * Simple test case to test authentication occurring during the establishment of an {@link SSLSession}.
@@ -111,32 +105,20 @@ public class SSLAuthenticationTest {
     private static final int OCSP_PORT = 4854;
     private final int TESTING_PORT = 18201;
     private static final char[] PASSWORD = "Elytron".toCharArray();
-    private static final String CA_JKS_LOCATION = "./target/test-classes/ca/jks";
-    private static final String ICA_JKS_LOCATION = "./target/test-classes/ica/jks";
+
+    private static final String JKS_LOCATION = "./target/test-classes/jks";
     private static final String CA_CRL_LOCATION = "./target/test-classes/ca/crl";
     private static final String ICA_CRL_LOCATION = "./target/test-classes/ica/crl";
-    private static final File WORKING_DIR_CA = new File(CA_JKS_LOCATION);
-    private static final File WORKING_DIR_ICA =  new File(ICA_JKS_LOCATION);
     private static final File WORKING_DIR_CACRL = new File(CA_CRL_LOCATION);
     private static final File WORKING_DIR_ICACRL = new File(ICA_CRL_LOCATION);
-    private static final File LADYBIRD_FILE = new File(WORKING_DIR_CA,"ladybird.keystore");
-    private static final File SCARAB_FILE = new File(WORKING_DIR_CA,"scarab.keystore");
-    private static final File DUNG_FILE = new File(WORKING_DIR_CA,"dung.keystore");
-    private static final File FIREFLY_FILE = new File(WORKING_DIR_CA,"firefly.keystore");
-    private static final File OCSP_RESPONDER_FILE = new File(WORKING_DIR_CA,"ocsp-responder.keystore");
-    private static final File OCSP_CHECKED_GOOD_FILE = new File(WORKING_DIR_CA,"ocsp-checked-good.keystore");
-    private static final File OCSP_CHECKED_REVOKED_FILE = new File(WORKING_DIR_CA,"ocsp-checked-revoked.keystore");
-    private static final File OCSP_CHECKED_UNKNOWN_FILE = new File(WORKING_DIR_CA,"ocsp-checked-unknown.keystore");
-    private static final File BEETLES_FILE = new File(WORKING_DIR_CA,"beetles.keystore");
-    private static final File TRUST_FILE = new File(WORKING_DIR_CA,"ca.truststore");
-    private static final File SHORTWINGED_FILE = new File(WORKING_DIR_ICA, "shortwinged.keystore");
-    private static final File ROVE_FILE = new File(WORKING_DIR_ICA, "rove.keystore");
+    private static final File SHORTWINGED_FILE = new File(JKS_LOCATION, "shortwinged.keystore");
     private static final File CA_BLANK_PEM_CRL = new File(WORKING_DIR_CACRL, "blank.pem");
     private static final File ICA_BLANK_PEM_CRL = new File(WORKING_DIR_ICACRL, "blank.pem");
     private static final File BLANK_BLANK_PEM_CRL = new File(WORKING_DIR_ICACRL, "blank-blank.pem");
     private static final File FIREFLY_REVOKED_PEM_CRL = new File(WORKING_DIR_CACRL, "firefly-revoked.pem");
     private static final File ICA_REVOKED_PEM_CRL = new File(WORKING_DIR_CACRL, "ica-revoked.pem");
     private static final File ROVE_REVOKED_PEM_CRL = new File(WORKING_DIR_ICACRL, "rove-revoked.pem");
+    private static CAGenerationTool caGenerationTool = null;
     private static TestingOcspServer ocspServer = null;
     private static X509Certificate ocspResponderCertificate;
 
@@ -171,7 +153,7 @@ public class SSLAuthenticationTest {
      */
     private static X509TrustManager getCATrustManager() throws Exception {
         TrustManagerFactory trustManagerFactory = getTrustManagerFactory();
-        trustManagerFactory.init(createKeyStore("/ca/jks/ca.truststore"));
+        trustManagerFactory.init(createKeyStore("/jks/ca.truststore"));
 
         for (TrustManager current : trustManagerFactory.getTrustManagers()) {
             if (current instanceof X509TrustManager) {
@@ -221,238 +203,53 @@ public class SSLAuthenticationTest {
 
     @BeforeClass
     public static void beforeTest() throws Exception {
-        WORKING_DIR_CA.mkdirs();
         WORKING_DIR_CACRL.mkdirs();
-        WORKING_DIR_ICA.mkdirs();
         WORKING_DIR_ICACRL.mkdirs();
 
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        caGenerationTool = CAGenerationTool.builder()
+                .setBaseDir(JKS_LOCATION)
+                .setRequestIdentities(Identity.values()) // Create all identities.
+                .build();
+
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
-        X500Principal issuerDN = new X500Principal("CN=Elytron CA, ST=Elytron, C=UK, EMAILADDRESS=elytron@wildfly.org, O=Root Certificate Authority");
-        X500Principal intermediateIssuerDN = new X500Principal("CN=Elytron ICA, ST=Elytron, C=UK, O=Intermediate Certificate Authority");
-
-        KeyStore ladybirdKeyStore = createKeyStore();
-        KeyStore scarabKeyStore = createKeyStore();
-        KeyStore dungKeyStore = createKeyStore();
-        KeyStore fireflyKeyStore = createKeyStore();
-        KeyStore beetlesKeyStore = createKeyStore();
-        KeyStore trustStore = createKeyStore();
-        KeyStore shortwingedKeyStore = createKeyStore();
-        KeyStore roveKeyStore = createKeyStore();
-
-        // Generates the issuer certificate and adds it to the keystores
-        SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
-                .setDn(issuerDN)
-                .setKeyAlgorithmName("RSA")
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
-                .build();
-        X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
-        ladybirdKeyStore.setCertificateEntry("ca", issuerCertificate);
-        scarabKeyStore.setCertificateEntry("ca", issuerCertificate);
-        dungKeyStore.setCertificateEntry("ca", issuerCertificate);
-        fireflyKeyStore.setCertificateEntry("ca", issuerCertificate);
-        trustStore.setCertificateEntry("mykey",issuerCertificate);
-
-        // Generates the intermediate issuer certificate
-        KeyPair intermediateIssuerKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey intermediateIssuerSigningKey = intermediateIssuerKeys.getPrivate();
-        PublicKey intermediateIssuerPublicKey = intermediateIssuerKeys.getPublic();
-
-        X509Certificate intermediateIssuerCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(intermediateIssuerDN)
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(intermediateIssuerPublicKey)
-                .setSerialNumber(new BigInteger("6"))
-                .addExtension(new BasicConstraintsExtension(false, true, -1))
-                .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
-                        new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
-                )))
-                .build();
-
-        // Generates certificate and keystore for Ladybird
-        KeyPair ladybirdKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey ladybirdSigningKey = ladybirdKeys.getPrivate();
-        PublicKey ladybirdPublicKey = ladybirdKeys.getPublic();
-
-        X509Certificate ladybirdCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Ladybird"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(ladybirdPublicKey)
-                .setSerialNumber(new BigInteger("3"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .build();
-        ladybirdKeyStore.setKeyEntry("ladybird", ladybirdSigningKey, PASSWORD, new X509Certificate[]{ladybirdCertificate,issuerCertificate});
-
-        // Generates certificate and keystore for Scarab
-        KeyPair scarabKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey scarabSigningKey = scarabKeys.getPrivate();
-        PublicKey scarabPublicKey = scarabKeys.getPublic();
-
-        X509Certificate scarabCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Scarab"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(scarabPublicKey)
-                .setSerialNumber(new BigInteger("4"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .build();
-        scarabKeyStore.setKeyEntry("scarab", scarabSigningKey, PASSWORD, new X509Certificate[]{scarabCertificate,issuerCertificate});
-
-        // Generates certificate and keystore for Dung
-        KeyPair dungKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey dungSigningKey = dungKeys.getPrivate();
-        PublicKey dungPublicKey = dungKeys.getPublic();
-
-        X509Certificate dungCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Dung"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(dungPublicKey)
-                .setSerialNumber(new BigInteger("2"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .build();
-        dungKeyStore.setKeyEntry("dung", dungSigningKey, PASSWORD, new X509Certificate[]{dungCertificate,issuerCertificate});
-
-        // Generates certificate and keystore for Firefly
-        KeyPair fireflyKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey fireflySigningKey = fireflyKeys.getPrivate();
-        PublicKey fireflyPublicKey = fireflyKeys.getPublic();
-
-        X509Certificate fireflyCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Firefly"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(fireflyPublicKey)
-                .setSerialNumber(new BigInteger("1"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .build();
-        fireflyKeyStore.setKeyEntry("firefly", fireflySigningKey, PASSWORD, new X509Certificate[]{fireflyCertificate,issuerCertificate});
-
-        // Generates certificate and keystore for Rove
-        KeyPair roveKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey roveSigningKey = roveKeys.getPrivate();
-        PublicKey rovePublicKey = roveKeys.getPublic();
-
-        X509Certificate roveCertificate = new X509CertificateBuilder()
-                .setIssuerDn(intermediateIssuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Rove"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(intermediateIssuerSigningKey)
-                .setPublicKey(rovePublicKey)
-                .setSerialNumber(new BigInteger("100"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .build();
-        roveKeyStore.setKeyEntry("rove", roveSigningKey, PASSWORD, new X509Certificate[]{roveCertificate,intermediateIssuerCertificate,issuerCertificate});
-
         // Generates certificate and keystore for OCSP responder
-        KeyPair ocspResponderKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey ocspResponderSigningKey = ocspResponderKeys.getPrivate();
-        PublicKey ocspResponderPublicKey = ocspResponderKeys.getPublic();
-
-        ocspResponderCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=OcspResponder"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(ocspResponderPublicKey)
-                .setSerialNumber(new BigInteger("15"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .addExtension(new ExtendedKeyUsageExtension(false, Collections.singletonList(OID_KP_OCSP_SIGNING)))
-                .build();
-        KeyStore ocspResponderKeyStore = createKeyStore();
-        ocspResponderKeyStore.setCertificateEntry("ca", issuerCertificate);
-        ocspResponderKeyStore.setKeyEntry("ocspResponder", ocspResponderSigningKey, PASSWORD, new X509Certificate[]{ocspResponderCertificate, issuerCertificate});
-        createTemporaryKeyStoreFile(ocspResponderKeyStore, OCSP_RESPONDER_FILE, PASSWORD);
+        ocspResponderCertificate = caGenerationTool.createIdentity("ocspResponder",
+                new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=OcspResponder"),
+                "ocsp-responder.keystore", Identity.CA, new ExtendedKeyUsageExtension(false, Collections.singletonList(OID_KP_OCSP_SIGNING)));
 
         // Generates GOOD certificate referencing the OCSP responder
-        KeyPair ocspCheckedGoodKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey ocspCheckedGoodSigningKey = ocspCheckedGoodKeys.getPrivate();
-        PublicKey ocspCheckedGoodPublicKey = ocspCheckedGoodKeys.getPublic();
-
-        X509Certificate ocspCheckedGoodCertificate = new X509CertificateBuilder()
-                .setIssuerDn(intermediateIssuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedGood"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(intermediateIssuerSigningKey)
-                .setPublicKey(ocspCheckedGoodPublicKey)
-                .setSerialNumber(new BigInteger("20"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
+        X509Certificate ocspCheckedGoodCertificate = caGenerationTool.createIdentity("checked",
+                new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedGood"),
+                "ocsp-checked-good.keystore", Identity.INTERMEDIATE, new AuthorityInformationAccessExtension(Collections.singletonList(
                         new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
-                )))
-                .build();
-        KeyStore ocspCheckedGoodKeyStore = createKeyStore();
-        ocspCheckedGoodKeyStore.setCertificateEntry("ca", issuerCertificate);
-        ocspCheckedGoodKeyStore.setCertificateEntry("ca2", intermediateIssuerCertificate);
-        ocspCheckedGoodKeyStore.setKeyEntry("checked", ocspCheckedGoodSigningKey, PASSWORD, new X509Certificate[]{ocspCheckedGoodCertificate, intermediateIssuerCertificate, issuerCertificate});
-        createTemporaryKeyStoreFile(ocspCheckedGoodKeyStore, OCSP_CHECKED_GOOD_FILE, PASSWORD);
+                )));
 
         // Generates REVOKED certificate referencing the OCSP responder
-        KeyPair ocspCheckedRevokedKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey ocspCheckedRevokedSigningKey = ocspCheckedRevokedKeys.getPrivate();
-        PublicKey ocspCheckedRevokedPublicKey = ocspCheckedRevokedKeys.getPublic();
-
-        X509Certificate ocspCheckedRevokedCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedRevoked"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(ocspCheckedRevokedPublicKey)
-                .setSerialNumber(new BigInteger("17"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
+        X509Certificate ocspCheckedRevokedCertificate = caGenerationTool.createIdentity("checked",
+                new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedRevoked"),
+                "ocsp-checked-revoked.keystore", Identity.CA, (new AuthorityInformationAccessExtension(Collections.singletonList(
                         new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
-                )))
-                .build();
-        KeyStore ocspCheckedRevokedKeyStore = createKeyStore();
-        ocspCheckedRevokedKeyStore.setCertificateEntry("ca", issuerCertificate);
-        ocspCheckedRevokedKeyStore.setKeyEntry("checked", ocspCheckedRevokedSigningKey, PASSWORD, new X509Certificate[]{ocspCheckedRevokedCertificate,issuerCertificate});
-        createTemporaryKeyStoreFile(ocspCheckedRevokedKeyStore, OCSP_CHECKED_REVOKED_FILE, PASSWORD);
+                ))));
 
         // Generates UNKNOWN certificate referencing the OCSP responder
-        KeyPair ocspCheckedUnknownKeys = keyPairGenerator.generateKeyPair();
-        PrivateKey ocspCheckedUnknownSigningKey = ocspCheckedUnknownKeys.getPrivate();
-        PublicKey ocspCheckedUnknownPublicKey = ocspCheckedUnknownKeys.getPublic();
-
-        X509Certificate ocspCheckedUnknownCertificate = new X509CertificateBuilder()
-                .setIssuerDn(issuerDN)
-                .setSubjectDn(new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedUnknown"))
-                .setSignatureAlgorithmName("SHA256withRSA")
-                .setSigningKey(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
-                .setPublicKey(ocspCheckedUnknownPublicKey)
-                .setSerialNumber(new BigInteger("18"))
-                .addExtension(new BasicConstraintsExtension(false, false, -1))
-                .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
+        X509Certificate ocspCheckedUnknownCertificate = caGenerationTool.createIdentity("checked",
+                new X500Principal("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=ocspCheckedUnknown"),
+                "ocsp-checked-unknown.keystore", Identity.CA, new AuthorityInformationAccessExtension(Collections.singletonList(
                         new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
-                )))
-                .build();
-        KeyStore ocspCheckedUnknownKeyStore = createKeyStore();
-        ocspCheckedUnknownKeyStore.setCertificateEntry("ca", issuerCertificate);
-        ocspCheckedUnknownKeyStore.setKeyEntry("checked", ocspCheckedUnknownSigningKey, PASSWORD, new X509Certificate[]{ocspCheckedUnknownCertificate,issuerCertificate});
-        createTemporaryKeyStoreFile(ocspCheckedUnknownKeyStore, OCSP_CHECKED_UNKNOWN_FILE, PASSWORD);
+                )));
 
-
-        // Adds trusted certs for beetles
-        beetlesKeyStore.setCertificateEntry("ladybird", ladybirdCertificate);
-        beetlesKeyStore.setCertificateEntry("scarab", scarabCertificate);
-        beetlesKeyStore.setCertificateEntry("dung", dungCertificate);
-        beetlesKeyStore.setCertificateEntry("firefly", fireflyCertificate);
+        KeyStore beetlesKeyStore = createKeyStore("/jks/beetles.keystore");
         beetlesKeyStore.setCertificateEntry("ocspResponder", ocspResponderCertificate);
         beetlesKeyStore.setCertificateEntry("ocspCheckedGood", ocspCheckedGoodCertificate);
         beetlesKeyStore.setCertificateEntry("ocspCheckedRevoked", ocspCheckedRevokedCertificate);
         beetlesKeyStore.setCertificateEntry("ocspCheckedUnknown", ocspCheckedUnknownCertificate);
+        createTemporaryKeyStoreFile(beetlesKeyStore, new File(JKS_LOCATION, "beetles.keystore"), PASSWORD);
 
         // Adds trusted cert for shortwinged
-        shortwingedKeyStore.setCertificateEntry("rove", roveCertificate);
+        KeyStore shortwingedKeyStore = createKeyStore();
+        shortwingedKeyStore.setCertificateEntry("rove", caGenerationTool.getCertificate(Identity.ROVE));
+        createTemporaryKeyStoreFile(shortwingedKeyStore, SHORTWINGED_FILE, PASSWORD);
 
         // Used for all CRLs
         Calendar calendar = Calendar.getInstance();
@@ -465,79 +262,70 @@ public class SSLAuthenticationTest {
 
         // Creates the CRL for ca/crl/blank.pem
         X509v2CRLBuilder caBlankCrlBuilder = new X509v2CRLBuilder(
-                convertSunStyleToBCStyle(intermediateIssuerCertificate.getIssuerDN()),
+                convertSunStyleToBCStyle(caGenerationTool.getCertificate(Identity.CA).getSubjectDN()),
                 currentDate
         );
         X509CRLHolder caBlankCrlHolder = caBlankCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA256withRSA")
+                new JcaContentSignerBuilder(SIGNATURE_ALGORTHM)
                         .setProvider("BC")
-                        .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
+                        .build(caGenerationTool.getPrivateKey(Identity.CA))
         );
 
         // Creates the CRL for ica/crl/blank.pem
         X509v2CRLBuilder icaBlankCrlBuilder = new X509v2CRLBuilder(
-                convertSunStyleToBCStyle(intermediateIssuerDN),
+                convertSunStyleToBCStyle(caGenerationTool.getCertificate(Identity.INTERMEDIATE).getSubjectDN()),
                 currentDate
         );
         X509CRLHolder icaBlankCrlHolder = icaBlankCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA256withRSA")
+                new JcaContentSignerBuilder(SIGNATURE_ALGORTHM)
                         .setProvider("BC")
-                        .build(intermediateIssuerSigningKey)
+                        .build(caGenerationTool.getPrivateKey(Identity.INTERMEDIATE))
         );
 
         // Creates the CRL for firefly-revoked.pem
         X509v2CRLBuilder fireflyRevokedCrlBuilder = new X509v2CRLBuilder(
-                convertSunStyleToBCStyle(issuerCertificate.getSubjectDN()),
+                convertSunStyleToBCStyle(caGenerationTool.getCertificate(Identity.CA).getSubjectDN()),
                 currentDate
         );
+
         fireflyRevokedCrlBuilder.addCRLEntry(
-                new BigInteger("1"),
+                caGenerationTool.getCertificate(Identity.FIREFLY).getSerialNumber(),
                 revokeDate,
                 CRLReason.unspecified
         );
         X509CRLHolder fireflyRevokedCrlHolder = fireflyRevokedCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA256withRSA")
+                new JcaContentSignerBuilder(SIGNATURE_ALGORTHM)
                         .setProvider("BC")
-                        .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
+                        .build(caGenerationTool.getPrivateKey(Identity.CA))
         );
 
         // Creates the CRL for ica-revoked.pem
         X509v2CRLBuilder icaRevokedCrlBuilder = new X509v2CRLBuilder(
-                convertSunStyleToBCStyle(issuerCertificate.getSubjectDN()),
+                convertSunStyleToBCStyle(caGenerationTool.getCertificate(Identity.CA).getSubjectDN()),
                 currentDate
         );
         icaRevokedCrlBuilder.addCRLEntry(
-                new BigInteger("6"),
+                caGenerationTool.getCertificate(Identity.INTERMEDIATE).getSerialNumber(),
                 revokeDate,
                 CRLReason.unspecified
         );
         X509CRLHolder icaRevokedCrlHolder = icaRevokedCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA256withRSA")
+                new JcaContentSignerBuilder(SIGNATURE_ALGORTHM)
                         .setProvider("BC")
-                        .build(issuerSelfSignedX509CertificateAndSigningKey.getSigningKey())
+                        .build(caGenerationTool.getPrivateKey(Identity.CA))
         );
 
         // Creates the CRL for rove-revoked.pem
         X509v2CRLBuilder roveRevokedCrlBuilder = new X509v2CRLBuilder(
-                convertSunStyleToBCStyle(intermediateIssuerCertificate.getSubjectDN()),
+                convertSunStyleToBCStyle(caGenerationTool.getCertificate(Identity.INTERMEDIATE).getSubjectDN()),
                 currentDate
         );
 
         X509CRLHolder roveRevokedCrlHolder = roveRevokedCrlBuilder.setNextUpdate(nextYear).build(
-                new JcaContentSignerBuilder("SHA256withRSA")
+                new JcaContentSignerBuilder(SIGNATURE_ALGORTHM)
                 .setProvider("BC")
-                .build(intermediateIssuerSigningKey)
+                .build(caGenerationTool.getPrivateKey(Identity.INTERMEDIATE))
         );
-
-        // Create the temporary files
-        createTemporaryKeyStoreFile(ladybirdKeyStore, LADYBIRD_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(scarabKeyStore, SCARAB_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(dungKeyStore, DUNG_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(fireflyKeyStore, FIREFLY_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(beetlesKeyStore, BEETLES_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(trustStore, TRUST_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(shortwingedKeyStore, SHORTWINGED_FILE, PASSWORD);
-        createTemporaryKeyStoreFile(roveKeyStore, ROVE_FILE, PASSWORD);
 
         PemWriter caBlankCrlOutput = new PemWriter(new OutputStreamWriter(new FileOutputStream(CA_BLANK_PEM_CRL)));
         PemWriter icaBlankCrlOutput = new PemWriter(new OutputStreamWriter(new FileOutputStream(ICA_BLANK_PEM_CRL)));
@@ -564,9 +352,9 @@ public class SSLAuthenticationTest {
         roveRevokedCrlOutput.close();
 
         ocspServer = new TestingOcspServer(OCSP_PORT);
-        ocspServer.createIssuer(1, issuerCertificate);
-        ocspServer.createIssuer(2, intermediateIssuerCertificate);
-        ocspServer.createCertificate(1, 1, intermediateIssuerCertificate);
+        ocspServer.createIssuer(1, caGenerationTool.getCertificate(Identity.CA));
+        ocspServer.createIssuer(2, caGenerationTool.getCertificate(Identity.INTERMEDIATE));
+        ocspServer.createCertificate(1, 1, caGenerationTool.getCertificate(Identity.INTERMEDIATE));
         ocspServer.createCertificate(2, 2, ocspCheckedGoodCertificate);
         ocspServer.createCertificate(3, 1, ocspCheckedRevokedCertificate);
         ocspServer.revokeCertificate(3, 4);
@@ -593,34 +381,24 @@ public class SSLAuthenticationTest {
         if (ocspServer != null) {
             ocspServer.stop();
         }
-        LADYBIRD_FILE.delete();
-        SCARAB_FILE.delete();
-        DUNG_FILE.delete();
-        FIREFLY_FILE.delete();
-        OCSP_RESPONDER_FILE.delete();
-        OCSP_CHECKED_GOOD_FILE.delete();
-        OCSP_CHECKED_REVOKED_FILE.delete();
-        OCSP_CHECKED_UNKNOWN_FILE.delete();
-        BEETLES_FILE.delete();
-        TRUST_FILE.delete();
+
         SHORTWINGED_FILE.delete();
-        ROVE_FILE.delete();
         CA_BLANK_PEM_CRL.delete();
         ICA_BLANK_PEM_CRL.delete();
         BLANK_BLANK_PEM_CRL.delete();
         FIREFLY_REVOKED_PEM_CRL.delete();
         ICA_REVOKED_PEM_CRL.delete();
         ROVE_REVOKED_PEM_CRL.delete();
-        WORKING_DIR_CA.delete();
-        WORKING_DIR_ICA.delete();
         WORKING_DIR_CACRL.delete();
         WORKING_DIR_ICACRL.delete();
+
+        caGenerationTool.close();
     }
 
     @Test
     public void testOneWay() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ca/jks/firefly.keystore"))
+                .setKeyManager(getKeyManager("/jks/firefly.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way.org", true, "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly", null, true);
@@ -629,7 +407,7 @@ public class SSLAuthenticationTest {
     @Test
     public void testCrlBlank() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ca/jks/firefly.keystore"))
+                .setKeyManager(getKeyManager("/jks/firefly.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way-crl.org", true, "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Firefly", null, true);
@@ -638,7 +416,7 @@ public class SSLAuthenticationTest {
     @Test
     public void testServerRevoked() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ca/jks/firefly.keystore"))
+                .setKeyManager(getKeyManager("/jks/firefly.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way-firefly-revoked.org", false, null, null, true);
@@ -647,7 +425,7 @@ public class SSLAuthenticationTest {
     @Test
     public void testServerIcaRevoked() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ica/jks/rove.keystore"))
+                .setKeyManager(getKeyManager("/jks/rove.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way-ica-revoked.org", false, null, null, true);
@@ -660,7 +438,7 @@ public class SSLAuthenticationTest {
     @Test
     public void testCRLMaxCertPathSucceeds() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ica/jks/rove.keystore"))
+                .setKeyManager(getKeyManager("/jks/rove.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way-max-cert-path.org", true, "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Rove", null, true);
@@ -674,7 +452,7 @@ public class SSLAuthenticationTest {
     @Test
     public void testCRLMaxCertPathFails() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ica/jks/rove.keystore"))
+                .setKeyManager(getKeyManager("/jks/rove.keystore"))
                 .build().create();
 
         performConnectionTest(serverContext, "protocol://test-one-way-max-cert-path-failure.org", false, null, null, true);
@@ -683,8 +461,8 @@ public class SSLAuthenticationTest {
     @Test
     public void testTwoWay() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/ca/jks/beetles.keystore"))
-                .setKeyManager(getKeyManager("/ca/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
+                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .setTrustManager(getCATrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
@@ -696,8 +474,8 @@ public class SSLAuthenticationTest {
     @Test
     public void testTwoWayIca() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/ica/jks/shortwinged.keystore"))
-                .setKeyManager(getKeyManager("/ca/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/shortwinged.keystore"))
+                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .setTrustManager(getCATrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
@@ -716,7 +494,7 @@ public class SSLAuthenticationTest {
 
         X509RevocationTrustManager trustManager = X509RevocationTrustManager.builder()
                 .setTrustManagerFactory(getTrustManagerFactory())
-                .setTrustStore(createKeyStore("/ca/jks/ca.truststore"))
+                .setTrustStore(createKeyStore("/jks/ca.truststore"))
                 .setCrlStream(crl)
                 .setPreferCrls(true)
                 .setNoFallback(true)
@@ -728,11 +506,11 @@ public class SSLAuthenticationTest {
     @Test
     public void testOcspGood() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/ca/jks/beetles.keystore"))
-                .setKeyManager(getKeyManager("/ca/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
+                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .setTrustManager(X509RevocationTrustManager.builder()
                         .setTrustManagerFactory(getTrustManagerFactory())
-                        .setTrustStore(createKeyStore("/ca/jks/ca.truststore"))
+                        .setTrustStore(createKeyStore("/jks/ca.truststore"))
                         .setOcspResponderCert(ocspResponderCertificate)
                         .build())
                 .setNeedClientAuth(true)
@@ -764,11 +542,11 @@ public class SSLAuthenticationTest {
 
     private void ocspMaxCertPathCommon(int maxCertPath, boolean expectValid) throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/ca/jks/beetles.keystore"))
-                .setKeyManager(getKeyManager("/ca/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
+                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .setTrustManager(X509RevocationTrustManager.builder()
                         .setTrustManagerFactory(getTrustManagerFactory())
-                        .setTrustStore(createKeyStore("/ca/jks/ca.truststore"))
+                        .setTrustStore(createKeyStore("/jks/ca.truststore"))
                         .setOcspResponderCert(ocspResponderCertificate)
                         .setMaxCertPath(maxCertPath)
                         .build())
@@ -781,17 +559,17 @@ public class SSLAuthenticationTest {
     @Test
     public void testClientSideOcsp() throws Throwable {
         SSLContext serverContextGood = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ca/jks/ocsp-checked-good.keystore"))
+                .setKeyManager(getKeyManager("/jks/ocsp-checked-good.keystore"))
                 .build().create();
 
         SSLContext serverContextRevoked = new SSLContextBuilder()
-                .setKeyManager(getKeyManager("/ca/jks/ocsp-checked-revoked.keystore"))
+                .setKeyManager(getKeyManager("/jks/ocsp-checked-revoked.keystore"))
                 .build().create();
 
         SSLContext clientContext = new SSLContextBuilder()
                 .setTrustManager(X509RevocationTrustManager.builder()
                         .setTrustManagerFactory(getTrustManagerFactory())
-                        .setTrustStore(createKeyStore("/ca/jks/ca.truststore"))
+                        .setTrustStore(createKeyStore("/jks/ca.truststore"))
                         .setOcspResponderCert(ocspResponderCertificate)
                         .build())
                 .setClientMode(true)

--- a/tests/base/src/test/resources/org/wildfly/security/auth/client/wildfly-masked-password-ssl-config-v1_4.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/auth/client/wildfly-masked-password-ssl-config-v1_4.xml
@@ -22,10 +22,10 @@
     <authentication-client xmlns="urn:elytron:client:1.4">
         <key-stores>
             <key-store name="scarab" type="JKS">
-                <file name="target/test-classes/ca/jks/scarab.keystore"/>
+                <file name="target/test-classes/jks/scarab.keystore"/>
             </key-store>
             <key-store name="ladybird" type="JKS">
-                <file name="target/test-classes/ca/jks/ladybird.keystore"/>
+                <file name="target/test-classes/jks/ladybird.keystore"/>
                 <key-store-masked-password iteration-count="100" salt="12345678" masked-password="4J8OSOEqjB0="/>
             </key-store>
         </key-stores>

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/ocsp-responder.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/ocsp-responder.xml
@@ -19,7 +19,7 @@
     <signers>
         <signer name="signer1">
             <type>JKS</type>
-            <key>password=Elytron,keystore=file:target/test-classes/ca/jks/ocsp-responder.keystore</key>
+            <key>password=Elytron,keystore=file:target/test-classes/jks/ocsp-responder.keystore</key>
             <algorithms>
                 <algorithm>SHA256withRSA</algorithm>
             </algorithms>

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_1.xml
@@ -21,29 +21,29 @@
     <authentication-client xmlns="urn:elytron:client:1.1">
         <key-stores>
             <key-store name="ca" type="JKS">
-                <file name="target/test-classes/ca/jks/ca.truststore"/>
+                <file name="target/test-classes/jks/ca.truststore"/>
             </key-store>
             <key-store name="scarab" type="JKS">
-                <file name="target/test-classes/ca/jks/scarab.keystore"/>
+                <file name="target/test-classes/jks/scarab.keystore"/>
             </key-store>
             <key-store name="ladybird" type="JKS">
-                <file name="target/test-classes/ca/jks/ladybird.keystore"/>
+                <file name="target/test-classes/jks/ladybird.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
             <key-store name="rove" type="JKS">
-                <file name="target/test-classes/ica/jks/rove.keystore"/>
+                <file name="target/test-classes/jks/rove.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
             <key-store name="ocsp-checked-good" type="JKS">
-                <file name="target/test-classes/ca/jks/ocsp-checked-good.keystore"/>
+                <file name="target/test-classes/jks/ocsp-checked-good.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
             <key-store name="ocsp-checked-revoked" type="JKS">
-                <file name="target/test-classes/ca/jks/ocsp-checked-revoked.keystore"/>
+                <file name="target/test-classes/jks/ocsp-checked-revoked.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
             <key-store name="ocsp-checked-unknown" type="JKS">
-                <file name="target/test-classes/ca/jks/ocsp-checked-unknown.keystore"/>
+                <file name="target/test-classes/jks/ocsp-checked-unknown.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
         </key-stores>

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_5.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/wildfly-ssl-test-config-v1_5.xml
@@ -21,10 +21,10 @@
     <authentication-client xmlns="urn:elytron:client:1.5">
         <key-stores>
             <key-store name="scarab" type="JKS">
-                <file name="target/test-classes/ca/jks/scarab.keystore"/>
+                <file name="target/test-classes/jks/scarab.keystore"/>
             </key-store>
             <key-store name="ladybird" type="JKS">
-                <file name="target/test-classes/ca/jks/ladybird.keystore"/>
+                <file name="target/test-classes/jks/ladybird.keystore"/>
                 <key-store-clear-password password="Elytron"/>
             </key-store>
         </key-stores>

--- a/tests/common/src/test/java/org/wildfly/security/sasl/test/SaslTestUtil.java
+++ b/tests/common/src/test/java/org/wildfly/security/sasl/test/SaslTestUtil.java
@@ -28,12 +28,11 @@ import javax.security.sasl.SaslClientFactory;
 import javax.security.sasl.SaslServerFactory;
 
 /**
- * A base for the test cases to ensure the provider is registered before the test
- * is executed and removed after the test completes.
+ * A utility class containing common methods for working with SASL mechanisms.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class BaseTestCase {
+public final class SaslTestUtil {
 
     // Utility methods for use by the Test classes.
 
@@ -46,7 +45,7 @@ public class BaseTestCase {
      * @param requiredServerFactory - The server factory we are looking for.
      * @return the located server factory.
      */
-    protected static <T extends SaslServerFactory> T obtainSaslServerFactory(final Class<T> requiredServerFactory) {
+    public static <T extends SaslServerFactory> T obtainSaslServerFactory(final Class<T> requiredServerFactory) {
         Enumeration<SaslServerFactory> serverFactories = Sasl.getSaslServerFactories();
         while (serverFactories.hasMoreElements()) {
             SaslServerFactory current = serverFactories.nextElement();
@@ -67,7 +66,7 @@ public class BaseTestCase {
      * @param requiredClientFactory - The client factory we are looking for.
      * @return the located client factory.
      */
-    protected <T extends SaslClientFactory> T obtainSaslClientFactory(final Class<T> requiredClientFactory) {
+    public static <T extends SaslClientFactory> T obtainSaslClientFactory(final Class<T> requiredClientFactory) {
         Enumeration<SaslClientFactory> clientFactories = Sasl.getSaslClientFactories();
         while (clientFactories.hasMoreElements()) {
             SaslClientFactory current = clientFactories.nextElement();
@@ -84,7 +83,7 @@ public class BaseTestCase {
      *
      * @param mechanisms - the array of mechanisms to verify.
      */
-    protected void assertNoMechanisms(final String[] mechanisms) {
+    public static void assertNoMechanisms(final String[] mechanisms) {
         assertEquals(0, mechanisms.length);
     }
 
@@ -92,7 +91,7 @@ public class BaseTestCase {
      * @param mechanismName
      * @param mechanisms
      */
-    protected void assertSingleMechanism(final String mechanismName, final String[] mechanisms) {
+    public static void assertSingleMechanism(final String mechanismName, final String[] mechanisms) {
         assertEquals(1, mechanisms.length);
         assertEquals(mechanismName, mechanisms[0]);
     }
@@ -103,7 +102,7 @@ public class BaseTestCase {
      * @param expectedMechanisms the expected array of mechanisms
      * @param mechanisms the array of mechanisms to verify
      */
-    protected void assertMechanisms(final String[] expectedMechanisms, final String[] mechanisms) {
+    public static void assertMechanisms(final String[] expectedMechanisms, final String[] mechanisms) {
         assertEquals(expectedMechanisms.length, mechanisms.length);
         assertTrue(Arrays.asList(expectedMechanisms).containsAll(Arrays.asList(mechanisms)));
     }

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
@@ -220,6 +220,29 @@ public class CAGenerationTool implements Closeable {
         }
     }
 
+    public X509Certificate createSelfSignedIdentity(final String alias, final X500Principal principal, final String keyStoreName) {
+        SelfSignedX509CertificateAndSigningKey selfSignedIdentity = SelfSignedX509CertificateAndSigningKey.builder()
+                .setDn(principal)
+                .setKeyAlgorithmName(KEY_ALGORITHM)
+                .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                .build();
+
+        X509Certificate selfSignedCertificate = selfSignedIdentity.getSelfSignedCertificate();
+        File keyStoreFile = new File(workingDir, keyStoreName);
+        KeyStore keyStore = createEmptyKeyStore();
+        try {
+            keyStore.setKeyEntry(alias, selfSignedIdentity.getSigningKey(), PASSWORD,
+                    new X509Certificate[] { selfSignedIdentity.getSelfSignedCertificate() });
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                keyStore.store(out, PASSWORD);
+            }
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        return selfSignedCertificate;
+    }
+
     private X509Certificate createIdentity(final Identity identity) {
         Identity caIdentity = identity.getSignedBy();
         if (caIdentity == null) {

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ssl.test.util;
+
+import static org.wildfly.security.x500.X500.OID_AD_OCSP;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.wildfly.security.x500.GeneralName;
+import org.wildfly.security.x500.cert.AccessDescription;
+import org.wildfly.security.x500.cert.AuthorityInformationAccessExtension;
+import org.wildfly.security.x500.cert.BasicConstraintsExtension;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
+import org.wildfly.security.x500.cert.X509CertificateExtension;
+
+/**
+ * A tool for generating a complete set of certificates backed by a generated certificate authority.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class CAGenerationTool implements Closeable {
+
+    public static final String SIGNATURE_ALGORTHM = "SHA256withRSA";
+
+    private static final String BEETLES_STORE = "beetles.keystore";
+    private static final String KEY_ALGORITHM = "RSA";
+    private static final String KEYSTORE_TYPE = "JKS"; // TODO Switch to PKCS#12
+    private static final int OCSP_PORT = 4854;
+    private static final char[] PASSWORD = "Elytron".toCharArray();
+
+    private static final Set<Identity> BEETLES = Collections
+            .unmodifiableSet(new HashSet<>(Arrays.asList(Identity.LADYBIRD, Identity.SCARAB, Identity.DUNG, Identity.FIREFLY)));
+    private static final Predicate<Identity> INCLUDE_IN_BEETLES = BEETLES::contains;
+
+    private final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+    private final Map<Identity, CAState> caMap = new HashMap<>();
+    private final Map<Identity, X509Certificate> certificateMap = new HashMap<>();
+
+    private final File workingDir;
+
+    protected CAGenerationTool(Builder builder) throws Exception {
+        // Ensure we have the directory created to hold the resulting KeyStores
+        workingDir = new File(builder.baseDir);
+        workingDir.mkdirs();
+
+        KeyStore beetlesStore = createEmptyKeyStore();
+
+        for (Identity currentIdentity : builder.requestedIdentities) {
+            if (currentIdentity.isCertificateAuthority()) {
+                caMap.computeIfAbsent(currentIdentity, this::createCA);
+            } else {
+                X509Certificate certificate = createIdentity(currentIdentity);
+                certificateMap.put(currentIdentity, certificate);
+                if (INCLUDE_IN_BEETLES.test(currentIdentity)) {
+                    beetlesStore.setCertificateEntry(currentIdentity.toString(), certificate);
+                }
+            }
+        }
+
+        try {
+            File keyStoreFile = new File(workingDir, BEETLES_STORE);
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                beetlesStore.store(out, PASSWORD);
+            }
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public X509Certificate getCertificate(final Identity identity) {
+        return certificateMap.get(identity);
+    }
+
+    public PrivateKey getPrivateKey(final Identity identity) {
+        if (!identity.isCertificateAuthority()) {
+            throw new IllegalStateException(String.format("Identity %s if not a CertificateAuthority", identity.toString()));
+        }
+
+        return caMap.computeIfAbsent(identity, this::createCA).signingKey;
+    }
+
+    private CAState createCA(final Identity identity) {
+        CAState caState = new CAState();
+
+        Identity signedBy = identity.getSignedBy();
+        if (signedBy == null) {
+            // As a root CA it will require a self signed certificate.
+            SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
+                    .setDn(identity.getPrincipal())
+                    .setKeyAlgorithmName(KEY_ALGORITHM)
+                    .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                    .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
+                    .build();
+            caState.issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
+            caState.signingKey = issuerSelfSignedX509CertificateAndSigningKey.getSigningKey();
+        } else {
+            try {
+                CAState signerState = caMap.computeIfAbsent(signedBy, this::createCA);
+                KeyPair keyPair = keyPairGenerator.generateKeyPair();
+                X509Certificate intermediateIssuerCertificate = new X509CertificateBuilder()
+                        .setIssuerDn(signedBy.getPrincipal())
+                        .setSubjectDn(identity.getPrincipal())
+                        .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                        .setSigningKey(signerState.signingKey)
+                        .setPublicKey(keyPair.getPublic())
+                        .setSerialNumber(BigInteger.valueOf(signerState.serialNumber++))
+                        .addExtension(new BasicConstraintsExtension(false, true, -1))
+                        .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
+                                new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
+                        )))
+                        .build();
+
+                caState.issuerCertificate = intermediateIssuerCertificate;
+                caState.signingKey = keyPair.getPrivate();
+            } catch (CertificateException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        if (identity.getKeyStoreName() != null) {
+            try {
+                File keyStoreFile = new File(workingDir, identity.getKeyStoreName());
+                final KeyStore keyStore = keyStoreFile.exists() ? loadKeyStore(keyStoreFile) : createEmptyKeyStore();
+                keyStore.setCertificateEntry(identity.toString(), caState.issuerCertificate);
+                try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                    keyStore.store(out, PASSWORD);
+                }
+            } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        certificateMap.put(identity, caState.issuerCertificate);
+        return caState;
+    }
+
+    public X509Certificate createIdentity(final String alias, final X500Principal principal, final String keyStoreName,
+            final Identity ca, final X509CertificateExtension... extensions) {
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        CAState caState = caMap.computeIfAbsent(ca, this::createCA);
+
+        try {
+            X509CertificateBuilder certificateBuilder = new X509CertificateBuilder()
+                    .setIssuerDn(ca.getPrincipal())
+                    .setSubjectDn(principal)
+                    .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                    .setSigningKey(caState.signingKey)
+                    .setPublicKey(keyPair.getPublic())
+                    .setSerialNumber(BigInteger.valueOf(caState.serialNumber++))
+                    .addExtension(new BasicConstraintsExtension(false, false, -1));
+            for (X509CertificateExtension currentExtension : extensions) {
+                certificateBuilder.addExtension(currentExtension);
+            }
+            X509Certificate builtCertificate = certificateBuilder.build();
+
+            File keyStoreFile = new File(workingDir, keyStoreName);
+            KeyStore keyStore = createEmptyKeyStore();
+
+            List<X509Certificate> certificates = new ArrayList<>();
+            certificates.add(builtCertificate);
+
+            Identity caIdentity = ca;
+            do {
+                caState = caMap.get(caIdentity); // We just created a signed cert above, the complete chain must be present.
+                keyStore.setCertificateEntry(caIdentity.toString(), caState.issuerCertificate); // This could be removed as the cert chain is added to the Entry.
+                certificates.add(caState.issuerCertificate);
+                caIdentity = caIdentity.getSignedBy();
+            } while (caIdentity != null);
+
+            keyStore.setKeyEntry(alias, keyPair.getPrivate(), PASSWORD,
+                    certificates.toArray(new X509Certificate[certificates.size()]));
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                keyStore.store(out, PASSWORD);
+            }
+
+            return builtCertificate;
+        } catch (CertificateException | KeyStoreException | IOException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private X509Certificate createIdentity(final Identity identity) {
+        Identity caIdentity = identity.getSignedBy();
+        if (caIdentity == null) {
+            // This should not happen but better than a NPE.
+            throw new IllegalStateException(String.format("Identity %s does not have a CA.", identity.toString()));
+        }
+
+        return createIdentity(identity.toString(), identity.getPrincipal(), identity.getKeyStoreName(), caIdentity);
+    }
+
+    private static KeyStore createEmptyKeyStore() {
+        try {
+            KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
+            ks.load(null,null);
+
+            return ks;
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static KeyStore loadKeyStore(final File location) {
+        try (InputStream caTrustStoreFile = new FileInputStream(location)) {
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+            keyStore.load(caTrustStoreFile, PASSWORD);
+
+            return keyStore;
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        workingDir.delete();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    static class CAState {
+        PrivateKey signingKey;
+        X509Certificate issuerCertificate;
+        int serialNumber = 1;
+    }
+
+    public enum Identity {
+
+        CA("CN=Elytron CA, ST=Elytron, C=UK, EMAILADDRESS=elytron@wildfly.org, O=Root Certificate Authority",
+                null, true, "ca.truststore"),
+        LADYBIRD("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Ladybird",
+                CA, false, "ladybird.keystore"),
+        SCARAB("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Scarab",
+                CA, false, "scarab.keystore"),
+        DUNG("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Dung",
+                CA, false, "dung.keystore"),
+        FIREFLY("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Firefly",
+                CA, false, "firefly.keystore"),
+        INTERMEDIATE("CN=Elytron ICA, ST=Elytron, C=UK, O=Intermediate Certificate Authority",
+                CA, true, null),
+        ROVE("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Rove",
+                INTERMEDIATE, false, "rove.keystore");
+
+        private final X500Principal principal;
+        private final Identity signedBy;
+        private final boolean ca;
+        private final String keyStoreName;
+
+        private Identity(final String distinguishedName, final Identity signedBy, final boolean ca, final String keyStoreName) {
+            this.principal =  new X500Principal(distinguishedName);
+            this.signedBy = signedBy;
+            this.ca = ca;
+            this.keyStoreName = keyStoreName;
+        }
+
+        public X500Principal getPrincipal() {
+            return principal;
+        }
+
+        public Identity getSignedBy() {
+            return signedBy;
+        }
+
+        public boolean isCertificateAuthority() {
+            return ca;
+        }
+
+        public String getKeyStoreName() {
+            return keyStoreName;
+        }
+
+        public String toString() {
+            return this.name().toLowerCase();
+        }
+    }
+
+    public static class Builder {
+
+        private String baseDir = ".";
+        private Identity[] requestedIdentities = {};
+
+        public Builder setBaseDir(final String baseDir) {
+            this.baseDir = baseDir;
+
+            return this;
+        }
+
+        public Builder setRequestIdentities(Identity... requestedIdentities) {
+            this.requestedIdentities = requestedIdentities;
+
+            return this;
+        }
+
+        public CAGenerationTool build() throws Exception {
+            return new CAGenerationTool(this);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR is just moving existing code to generate a certificate authority hierarchy into a re-usable tool so other tests (and test suites) can make use of it to dynamically generate a complete hierarchy on demand knowing it will be valid.

https://issues.redhat.com/browse/ELY-2060

The SSLAuthenticationTest was also very advanced in that it also generated OCSP configurations and certificate revocation list files - those are presently specific to that test case so I have not split out into the utility.  Those could be a candidate later if we decide we do need to repeat CRL or OCSP testing elsehwere.

I am starting off by placing this on hold so I can complete the Elytron Web changes which will depend on this but provided I have no issues I expect I can remove the label in the morning.

This also contains clean up for https://issues.redhat.com/browse/ELY-2061, a number of test cases were extending a common base where presently they only some utility methods so the inheritance was unnecessary. 