### PR TITLE
[ELY-1626] Programmatic web authentication (HttpServletRequest.login()) does not trigger sso

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/cache/CachedIdentity.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/cache/CachedIdentity.java
@@ -30,13 +30,15 @@ import org.wildfly.security.auth.server.SecurityIdentity;
  *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  * @author Paul Ferraro
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @see IdentityCache
  */
 public final class CachedIdentity implements Serializable {
 
-    private static final long serialVersionUID = 750487522862481938L;
+    private static final long serialVersionUID = -6408689383511392746L;
 
     private final String mechanismName;
+    private final boolean programmatic;
     private final String name;
     private final transient SecurityIdentity securityIdentity;
 
@@ -44,24 +46,27 @@ public final class CachedIdentity implements Serializable {
      * Creates a new instance based on the given <code>mechanismName</code> and <code>securityIdentity</code>.
      *
      * @param mechanismName the name of the authentication mechanism used to authenticate/authorize the identity
+     * @param programmatic indicates if this identity was created as a result of programmatic authentication
      * @param securityIdentity the identity to cache
      */
-    public CachedIdentity(String mechanismName, SecurityIdentity securityIdentity) {
-        this(mechanismName, checkNotNullParam("securityIdentity", securityIdentity), securityIdentity.getPrincipal());
+    public CachedIdentity(String mechanismName, boolean programmatic, SecurityIdentity securityIdentity) {
+        this(mechanismName, programmatic, checkNotNullParam("securityIdentity", securityIdentity), securityIdentity.getPrincipal());
     }
 
     /**
      * Creates a new instance based on the given <code>mechanismName</code> and <code>principal</code>.
      *
      * @param mechanismName the name of the authentication mechanism used to authenticate/authorize the identity
+     * @param programmatic indicates if this identity was created as a result of programmatic authentication
      * @param principal the principal of this cached identity
      */
-    public CachedIdentity(String mechanismName, Principal principal) {
-        this(mechanismName, null, principal);
+    public CachedIdentity(String mechanismName, boolean programmatic, Principal principal) {
+        this(mechanismName, programmatic, null, principal);
     }
 
-    private CachedIdentity(String mechanismName, SecurityIdentity securityIdentity, Principal principal) {
+    private CachedIdentity(String mechanismName, boolean programmatic, SecurityIdentity securityIdentity, Principal principal) {
         this.mechanismName = checkNotNullParam("mechanismName", mechanismName);
+        this.programmatic = programmatic;
         this.name = checkNotNullParam("name", checkNotNullParam("principal", principal).getName());
         this.securityIdentity = securityIdentity;
     }
@@ -93,8 +98,17 @@ public final class CachedIdentity implements Serializable {
         return this.securityIdentity;
     }
 
+    /**
+     * Returns {@code true} if this identity was established using programmatic authentication, {@code false} otherwise.
+     *
+     * @return {@code true} if this identity was established using programmatic authentication, {@code false} otherwise.
+     */
+    public boolean isProgrammatic() {
+        return programmatic;
+    }
+
     @Override
     public String toString() {
-        return "CachedIdentity{" + mechanismName + ", '" + name + "', " + securityIdentity + "}";
+        return "CachedIdentity{" + mechanismName + ", '" + name + "', " + securityIdentity + ", " + programmatic + "}";
     }
 }

--- a/auth/server/deprecated/src/main/java/org/wildfly/security/auth/server/SecurityIdentityServerMechanismFactory.java
+++ b/auth/server/deprecated/src/main/java/org/wildfly/security/auth/server/SecurityIdentityServerMechanismFactory.java
@@ -91,6 +91,11 @@ class SecurityIdentityServerMechanismFactory implements HttpServerAuthentication
                             : delegate.getNegotiatedProperty(propertyName);
                 }
 
+                @Override
+                public void dispose() {
+                    delegate.dispose();
+                }
+
             };
         }
         return null;

--- a/auth/server/http/src/main/java/org/wildfly/security/auth/server/http/SecurityIdentityServerMechanismFactory.java
+++ b/auth/server/http/src/main/java/org/wildfly/security/auth/server/http/SecurityIdentityServerMechanismFactory.java
@@ -90,6 +90,11 @@ class SecurityIdentityServerMechanismFactory implements HttpServerAuthentication
                             : delegate.getNegotiatedProperty(propertyName);
                 }
 
+                @Override
+                public void dispose() {
+                    delegate.dispose();
+                }
+
             };
         }
         return null;

--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -252,7 +252,7 @@ public class HttpAuthenticator {
                 if (log.isTraceEnabled()) {
                     log.tracef("Caching identity for '%s' against session scope.", identity.getPrincipal().getName());
                 }
-                session.setAttachment(MY_AUTHENTICATED_IDENTITY_KEY, new CachedIdentity(mechanismName, identity));
+                session.setAttachment(MY_AUTHENTICATED_IDENTITY_KEY, new CachedIdentity(mechanismName, true, identity));
             }
 
             @Override

--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -206,7 +206,7 @@ public class HttpAuthenticator {
                 httpExchangeSpi.authenticationFailed(e.getMessage(), programmaticMechanismName);
             }
 
-            log.tracef("Restoring identify '%s' failed, clearing cache from scope.", cachedIdentity.getName());
+            log.tracef("Restoring identity '%s' failed, clearing cache from scope.", cachedIdentity.getName());
             identityCache.remove(); // Whatever was in there no longer works so just
                                     // drop it.
         } else {

--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -70,7 +70,7 @@ public class HttpAuthenticator {
     private final HttpExchangeSpi httpExchangeSpi;
     private final boolean required;
     private final boolean ignoreOptionalFailures;
-    private final String programaticMechanismName;
+    private final String programmaticMechanismName;
     private final Consumer<Runnable> logoutHandlerConsumer;
     private volatile IdentityCache identityCache;
     private volatile boolean authenticated = false;
@@ -78,12 +78,12 @@ public class HttpAuthenticator {
     private HttpAuthenticator(final Builder builder) {
         this.mechanismSupplier = builder.mechanismSupplier;
         this.securityDomain = builder.securityDomain;
-        this.programaticMechanismName = builder.programmaticMechanismName;
+        this.programmaticMechanismName = builder.programmaticMechanismName;
         this.logoutHandlerConsumer = builder.logoutHandlerConsumer;
         this.httpExchangeSpi = builder.httpExchangeSpi;
         this.required = builder.required;
         this.ignoreOptionalFailures = builder.ignoreOptionalFailures;
-        this.identityCacheSupplier = builder.identityCacheSupplier != null ? builder.identityCacheSupplier : () -> createIdentityCache(programaticMechanismName);
+        this.identityCacheSupplier = builder.identityCacheSupplier != null ? builder.identityCacheSupplier : () -> createIdentityCache(programmaticMechanismName);
     }
 
     /**
@@ -115,7 +115,7 @@ public class HttpAuthenticator {
     public SecurityIdentity login(String username, String password) {
         final PasswordGuessEvidence evidence = new PasswordGuessEvidence(checkNotNullParam("password", password).toCharArray());
         try {
-            return login(username, evidence, programaticMechanismName);
+            return login(username, evidence, programmaticMechanismName);
         } finally {
             evidence.destroy();
         }
@@ -210,7 +210,7 @@ public class HttpAuthenticator {
                     return true;
                 }
             } catch (IllegalArgumentException | RealmUnavailableException | IllegalStateException e) {
-                httpExchangeSpi.authenticationFailed(e.getMessage(), programaticMechanismName);
+                httpExchangeSpi.authenticationFailed(e.getMessage(), programmaticMechanismName);
             }
 
             log.tracef("Restoring identify '%s' failed, clearing cache from scope.", cachedIdentity.getName());

--- a/http/base/src/main/java/org/wildfly/security/http/impl/BaseHttpServerRequest.java
+++ b/http/base/src/main/java/org/wildfly/security/http/impl/BaseHttpServerRequest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.impl;
+
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.security.cert.Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.net.ssl.SSLSession;
+
+import org.wildfly.security.http.HttpExchangeSpi;
+import org.wildfly.security.http.HttpScope;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.http.Scope;
+
+/**
+ * A base implementation of {@link HttpServerRequest}
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class BaseHttpServerRequest implements HttpServerRequest {
+
+    private final HttpExchangeSpi httpExchangeSpi;
+
+    protected BaseHttpServerRequest(final HttpExchangeSpi httpExchangeSpi) {
+        this.httpExchangeSpi = httpExchangeSpi;
+    }
+
+    @Override
+    public HttpScope getScope(Scope scope) {
+        return httpExchangeSpi.getScope(scope);
+    }
+
+    @Override
+    public Collection<String> getScopeIds(Scope scope) {
+        return httpExchangeSpi.getScopeIds(scope);
+    }
+
+    @Override
+    public HttpScope getScope(Scope scope, String id) {
+        return httpExchangeSpi.getScope(scope, id);
+    }
+
+    @Override
+    public List<String> getRequestHeaderValues(String headerName) {
+        return httpExchangeSpi.getRequestHeaderValues(headerName);
+    }
+
+    @Override
+    public String getFirstRequestHeaderValue(String headerName) {
+        return httpExchangeSpi.getFirstRequestHeaderValue(headerName);
+    }
+
+    @Override
+    public SSLSession getSSLSession() {
+        return httpExchangeSpi.getSSLSession();
+    }
+
+    @Override
+    public Certificate[] getPeerCertificates() {
+        return httpExchangeSpi.getPeerCertificates(false);
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return httpExchangeSpi.getRemoteUser();
+    }
+
+    @Override
+    public String getRequestMethod() {
+        return httpExchangeSpi.getRequestMethod();
+    }
+
+    @Override
+    public URI getRequestURI() {
+        return httpExchangeSpi.getRequestURI();
+    }
+
+    @Override
+    public String getRequestPath() {
+        return httpExchangeSpi.getRequestPath();
+    }
+
+    @Override
+    public Map<String, List<String>> getParameters() {
+        return httpExchangeSpi.getRequestParameters();
+    }
+
+    @Override
+    public Set<String> getParameterNames() {
+        return httpExchangeSpi.getRequestParameterNames();
+    }
+
+    @Override
+    public List<String> getParameterValues(String name) {
+        return httpExchangeSpi.getRequestParameterValues(name);
+    }
+
+    @Override
+    public String getFirstParameterValue(String name) {
+        return httpExchangeSpi.getFirstRequestParameterValue(name);
+    }
+
+    @Override
+    public List<HttpServerCookie> getCookies() {
+        return httpExchangeSpi.getCookies();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return httpExchangeSpi.getRequestInputStream();
+    }
+
+    @Override
+    public InetSocketAddress getSourceAddress() {
+        return httpExchangeSpi.getSourceAddress();
+    }
+
+}

--- a/http/base/src/main/java/org/wildfly/security/http/impl/package-info.java
+++ b/http/base/src/main/java/org/wildfly/security/http/impl/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Implementation classes which do not form part of the public API.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+package org.wildfly.security.http.impl;

--- a/http/cert/src/main/java/org/wildfly/security/http/cert/ClientCertAuthenticationMechanism.java
+++ b/http/cert/src/main/java/org/wildfly/security/http/cert/ClientCertAuthenticationMechanism.java
@@ -214,7 +214,7 @@ final class ClientCertAuthenticationMechanism implements HttpServerAuthenticatio
 
             @Override
             public void put(SecurityIdentity identity) {
-                CachedIdentity cachedIdentity = new CachedIdentity(CLIENT_CERT_NAME, identity);
+                CachedIdentity cachedIdentity = new CachedIdentity(CLIENT_CERT_NAME, false, identity);
                 httpClientCert.tracef("storing into cache: %s", cachedIdentity);
                 identities.putIfAbsent(securityDomain, cachedIdentity);
             }

--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -145,7 +145,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
                     fixCachedLocation(session, originalSessionID, newSessionID);
                 }
 
-                session.setAttachment(CACHED_IDENTITY_KEY, new CachedIdentity(getMechanismName(), identity));
+                session.setAttachment(CACHED_IDENTITY_KEY, new CachedIdentity(getMechanismName(), false, identity));
             }
 
             @Override

--- a/http/spnego/src/main/java/org/wildfly/security/http/spnego/SpnegoAuthenticationMechanism.java
+++ b/http/spnego/src/main/java/org/wildfly/security/http/spnego/SpnegoAuthenticationMechanism.java
@@ -336,7 +336,7 @@ public final class SpnegoAuthenticationMechanism implements HttpServerAuthentica
                     httpScope.changeID();
                 }
 
-                httpScope.setAttachment(CACHED_IDENTITY_KEY, new CachedIdentity(SPNEGO_NAME, identity));
+                httpScope.setAttachment(CACHED_IDENTITY_KEY, new CachedIdentity(SPNEGO_NAME, false, identity));
             }
 
             @Override

--- a/http/sso/pom.xml
+++ b/http/sso/pom.xml
@@ -48,7 +48,11 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-util</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>

--- a/http/sso/pom.xml
+++ b/http/sso/pom.xml
@@ -39,11 +39,11 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth</artifactId>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http</artifactId>
@@ -62,13 +62,13 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOn.java
@@ -56,6 +56,11 @@ public class DefaultSingleSignOn implements SingleSignOn {
     }
 
     @Override
+    public boolean isProgrammatic() {
+        return this.entry.getCachedIdentity().isProgrammatic();
+    }
+
+    @Override
     public String getName() {
         return this.entry.getCachedIdentity().getName();
     }
@@ -71,7 +76,7 @@ public class DefaultSingleSignOn implements SingleSignOn {
         synchronized (this.entry) {
             CachedIdentity cached = this.entry.getCachedIdentity();
             if (cached.getSecurityIdentity() == null) {
-                this.entry.setCachedIdentity(new CachedIdentity(cached.getMechanismName(), identity));
+                this.entry.setCachedIdentity(new CachedIdentity(cached.getMechanismName(), cached.isProgrammatic(), identity));
             }
         }
     }

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnManager.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnManager.java
@@ -46,9 +46,9 @@ public class DefaultSingleSignOnManager implements SingleSignOnManager {
     }
 
     @Override
-    public SingleSignOn create(String mechanismName, SecurityIdentity identity) {
+    public SingleSignOn create(String mechanismName, boolean programmatic, SecurityIdentity identity) {
         String id = this.identifierFactory.get();
-        SingleSignOnEntry entry = new DefaultSingleSignOnEntry(new CachedIdentity(mechanismName, identity));
+        SingleSignOnEntry entry = new DefaultSingleSignOnEntry(new CachedIdentity(mechanismName, programmatic, identity));
         SingleSignOn sso = new DefaultSingleSignOn(id, entry, () -> this.mutator.accept(id, entry), () -> this.cache.remove(id));
         this.cache.put(id, entry);
         return sso;

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
@@ -60,11 +60,11 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
     private final SingleSignOnSessionContext context;
     private final Function<SecurityIdentity, SingleSignOn> ssoFactory;
 
-    public DefaultSingleSignOnSession(SingleSignOnSessionContext context, HttpServerRequest request, String mechanismName) {
+    public DefaultSingleSignOnSession(SingleSignOnSessionContext context, HttpServerRequest request, String mechanismName, boolean programmatic) {
         this.context = checkNotNullParam("context", context);
         this.request = checkNotNullParam("request", request);
         checkNotNullParam("mechanismName", mechanismName);
-        this.ssoFactory = identity -> context.getSingleSignOnManager().create(mechanismName, identity);
+        this.ssoFactory = identity -> context.getSingleSignOnManager().create(mechanismName, programmatic, identity);
     }
 
     public DefaultSingleSignOnSession(SingleSignOnSessionContext context, HttpServerRequest request, SingleSignOn sso) {
@@ -236,7 +236,8 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
 
     private static CachedIdentity getCachedIdentity(SingleSignOn sso) {
         String mechanism = sso.getMechanism();
+        boolean programmatic = sso.isProgrammatic();
         SecurityIdentity identity = sso.getIdentity();
-        return (identity != null) ? new CachedIdentity(mechanism, identity) : new CachedIdentity(mechanism, new NamePrincipal(sso.getName()));
+        return (identity != null) ? new CachedIdentity(mechanism, programmatic, identity) : new CachedIdentity(mechanism, programmatic, new NamePrincipal(sso.getName()));
     }
 }

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSessionFactory.java
@@ -69,11 +69,11 @@ public class DefaultSingleSignOnSessionFactory implements SingleSignOnSessionFac
     }
 
     @Override
-    public SingleSignOnSession create(HttpServerRequest request, String mechanismName) {
+    public SingleSignOnSession create(HttpServerRequest request, String mechanismName, boolean programmatic) {
         checkNotNullParam("request", request);
         checkNotNullParam("mechanismName", mechanismName);
 
-        return new DefaultSingleSignOnSession(this, request, mechanismName);
+        return new DefaultSingleSignOnSession(this, request, mechanismName, programmatic);
     }
 
     @Override

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
@@ -44,7 +44,9 @@ public interface ImmutableSingleSignOn {
      *
      * @return {@code true} if this single sign on is as a result of programmatic authentication.
      */
-    boolean isProgrammatic();
+    default boolean isProgrammatic() {
+        return false;
+    }
 
     /**
      * Returns the name of the principal associated with this single sign-on entry.

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/ImmutableSingleSignOn.java
@@ -40,6 +40,13 @@ public interface ImmutableSingleSignOn {
     String getMechanism();
 
     /**
+     * Returns {@code true} if this single sign on is as a result of programmatic authentication.
+     *
+     * @return {@code true} if this single sign on is as a result of programmatic authentication.
+     */
+    boolean isProgrammatic();
+
+    /**
      * Returns the name of the principal associated with this single sign-on entry.
      * @return a principal name
      */

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/ProgrammaticSingleSignOnCache.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/ProgrammaticSingleSignOnCache.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.util.sso;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+
+import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.cache.CachedIdentity;
+import org.wildfly.security.cache.IdentityCache;
+import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpExchangeSpi;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.HttpServerMechanismsResponder;
+import org.wildfly.security.http.HttpServerRequest;
+import org.wildfly.security.http.impl.BaseHttpServerRequest;
+import org.wildfly.security.http.util.SimpleHttpServerCookie;
+
+/**
+ * An implementation of {@link IdentityCache} to provide SSO for programmatic authentication.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ProgrammaticSingleSignOnCache implements IdentityCache {
+
+    private final HttpExchangeSpi httpExchangeSpi;
+    private final String mechanismName;
+    private final SingleSignOnSessionFactory singleSignOnSessionFactory;
+    private final SingleSignOnConfiguration configuration;
+
+    /*
+     * Due to the nature of programmatic authentication is it very likely the three
+     * methods will be called from different threads.
+     */
+
+    private volatile HttpServerRequest httpServerRequest;
+    private volatile String ssoSessionId;
+
+    ProgrammaticSingleSignOnCache(HttpExchangeSpi httpExchangeSpi, String mechanismName,
+            SingleSignOnSessionFactory singleSignOnSessionFactory, SingleSignOnConfiguration configuration) {
+        this.httpExchangeSpi = checkNotNullParam("httpExchangeSpi", httpExchangeSpi);
+        this.mechanismName = checkNotNullParam("mechanismName", mechanismName);
+        this.singleSignOnSessionFactory = checkNotNullParam("singleSignOnSessionFactory", singleSignOnSessionFactory);
+        this.configuration = checkNotNullParam("configuration", configuration);
+    }
+
+    @Override
+    public CachedIdentity get() {
+        // This is called early for an incoming request.
+        // Get the SingleSignOnSession but don't create at this point as we don't know if we will use it.
+        try (SingleSignOnSession singleSignOnSession = getSingleSignOnSession(false)) {
+            if (singleSignOnSession == null) {
+                if (ssoSessionId != null && ssoSessionId.length() > 0) {
+                    clearCookie();
+                }
+                return null; // No session so nothing to return from the session.
+            }
+            // Check if this is a logout request, if so close the session and return null.
+            if (singleSignOnSession.logout()) {
+                singleSignOnSession.close();
+                return null; // This was a logout call, nothing else to do.
+            }
+
+            CachedIdentity cachedIdentity = singleSignOnSession.get();
+            if (cachedIdentity != null && cachedIdentity.isProgrammatic()
+                    && mechanismName.equals(cachedIdentity.getMechanismName())) {
+                return cachedIdentity; // The identity is ours so use it.
+            }
+
+            return null;
+        }
+    }
+
+    @Override
+    public void put(SecurityIdentity identity) {
+        try (SingleSignOnSession singleSignOnSession = getSingleSignOnSession(true)) {
+            singleSignOnSession.put(identity);
+            ssoSessionId = singleSignOnSession.getId();
+            setCookie();
+        }
+    }
+
+    @Override
+    public CachedIdentity remove() {
+        try (SingleSignOnSession singleSignOnSession = getSingleSignOnSession(false)) {
+            if (getCookie() != null) {
+                clearCookie();
+            }
+
+            if (singleSignOnSession != null) {
+                return singleSignOnSession.remove();
+            }
+        }
+
+        return null;
+    }
+
+    private HttpServerRequest getOrCreateHttpServerRequest() {
+        if (httpServerRequest == null) {
+            httpServerRequest = new SSOHttpServerRequest(httpExchangeSpi);
+        }
+
+        return httpServerRequest;
+    }
+
+    private String getSSOSessionId() {
+        if (ssoSessionId == null) {
+            HttpServerCookie cookie = getCookie();
+            ssoSessionId = (cookie != null) ? cookie.getValue() : ""; // Use empty string so we know we queried the cookies once.
+        }
+
+        return ssoSessionId;
+    }
+
+    private SingleSignOnSession getSingleSignOnSession(boolean create) {
+        String ssoSessionId = getSSOSessionId();
+
+        SingleSignOnSession singleSignOnSession = (ssoSessionId != null && ssoSessionId.length() > 0)
+                ? singleSignOnSessionFactory.find(ssoSessionId, getOrCreateHttpServerRequest())
+                : null;
+
+        if (singleSignOnSession == null && create) {
+            singleSignOnSession = singleSignOnSessionFactory.create(getOrCreateHttpServerRequest(), mechanismName, true);
+        }
+
+        return singleSignOnSession;
+    }
+
+    private HttpServerCookie getCookie() {
+        final String expectedCookieName = configuration.getCookieName();
+        for (HttpServerCookie currentCookie : httpExchangeSpi.getCookies()) {
+            if (expectedCookieName.equals(currentCookie.getName())) {
+                return currentCookie;
+            }
+        }
+
+        return null;
+    }
+
+    private void setCookie() {
+        httpExchangeSpi.setResponseCookie(
+                SimpleHttpServerCookie.newInstance(configuration.getCookieName(), ssoSessionId, configuration.getDomain(), -1,
+                        configuration.getPath(), configuration.isSecure(), 0, configuration.isHttpOnly()));
+    }
+
+    private void clearCookie() {
+        ssoSessionId = null;
+        httpExchangeSpi.setResponseCookie(
+                SimpleHttpServerCookie.newInstance(configuration.getCookieName(), null, configuration.getDomain(), 0,
+                        configuration.getPath(), configuration.isSecure(), 0, configuration.isHttpOnly()));
+    }
+
+    public static IdentityCache newInstance(HttpExchangeSpi httpExchangeSpi, String mechanismName,
+            SingleSignOnSessionFactory singleSignOnSessionFactory, SingleSignOnConfiguration configuration) {
+        return new ProgrammaticSingleSignOnCache(httpExchangeSpi, mechanismName, singleSignOnSessionFactory, configuration);
+    }
+
+    /**
+     * An implementation of {@link HttpServerRequest} which can be used with the {link SingleSignOnSessionFactory}.
+     *
+     * As this is only expected to be used for programmatic authentication the callback methods are not supported.
+     */
+    private static class SSOHttpServerRequest extends BaseHttpServerRequest {
+
+        SSOHttpServerRequest(final HttpExchangeSpi httpExchangeSpi) {
+            super(httpExchangeSpi);
+        }
+
+        @Override
+        public void noAuthenticationInProgress(HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void authenticationInProgress(HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void authenticationComplete(HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void authenticationComplete(HttpServerMechanismsResponder responder, Runnable logoutHandler) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void authenticationFailed(String message, HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void badRequest(HttpAuthenticationException failure, HttpServerMechanismsResponder responder) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean suspendRequest() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean resumeRequest() {
+            throw new IllegalStateException();
+        }
+
+    }
+
+}

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnConfiguration.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.util.sso;
+
+/**
+ * The relevent configuration for SingleSignOn.
+ *
+ * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
+ */
+public class SingleSignOnConfiguration {
+
+    private final String cookieName;
+    private final String domain;
+    private final String path;
+    private final boolean httpOnly;
+    private final boolean secure;
+
+    public SingleSignOnConfiguration(String cookieName, String domain, String path, boolean httpOnly, boolean secure) {
+        this.cookieName = cookieName;
+        this.domain = domain;
+        this.path = path;
+        this.httpOnly = httpOnly;
+        this.secure = secure;
+    }
+
+    public String getCookieName() {
+        return cookieName;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+}

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnManager.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnManager.java
@@ -27,10 +27,11 @@ public interface SingleSignOnManager {
     /**
      * Creates a single sign-on entry using the specified mechanism and security identity
      * @param mechanismName an authentication mechanism name
+     * @param programmatic indicates if this identity was created as a result of programmatic authentication
      * @param identity a security identity of the authenticated user
      * @return a single sign-on entry
      */
-    SingleSignOn create(String mechanismName, SecurityIdentity identity);
+    SingleSignOn create(String mechanismName, boolean programmatic, SecurityIdentity identity);
 
     /**
      * Locates the single sign-on entry with the specified identifier, or null if none exists.

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnManager.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnManager.java
@@ -31,7 +31,20 @@ public interface SingleSignOnManager {
      * @param identity a security identity of the authenticated user
      * @return a single sign-on entry
      */
-    SingleSignOn create(String mechanismName, boolean programmatic, SecurityIdentity identity);
+    default SingleSignOn create(String mechanismName, boolean programmatic, SecurityIdentity identity) {
+        return create(mechanismName, identity);
+    };
+
+    /**
+     * Creates a single sign-on entry using the specified mechanism and security identity
+     * @param mechanismName an authentication mechanism name
+     * @param identity a security identity of the authenticated user
+     * @return a single sign-on entry
+     */
+    @Deprecated
+    default SingleSignOn create(String mechanismName, SecurityIdentity identity) {
+        throw new IllegalStateException("Method being replaced by - create(String mechanismName, boolean programmatic, SecurityIdentity identity)");
+    };
 
     /**
      * Locates the single sign-on entry with the specified identifier, or null if none exists.

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -100,7 +100,7 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                 String signOnSessionId = (cookie != null) ? cookie.getValue() : null;
                 SingleSignOnSession singleSignOnSession = (signOnSessionId != null) ? singleSignOnSessionFactory.find(signOnSessionId, request) : null;
 
-                return (singleSignOnSession == null) ? singleSignOnSessionFactory.create(request, mechanismName) : singleSignOnSession;
+                return (singleSignOnSession == null) ? singleSignOnSessionFactory.create(request, mechanismName, false) : singleSignOnSession;
             }
 
             private HttpServerAuthenticationMechanism getTargetMechanism(String mechanismName, SingleSignOnSession singleSignOnSession) throws HttpAuthenticationException {

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -216,7 +216,14 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
             }
 
             HttpServerCookie getCookie(HttpServerRequest request) {
-                return request.getCookies().stream().filter(current -> configuration.getCookieName().equals(current.getName())).findFirst().orElse(null);
+                final String expectedCookieName = configuration.getCookieName();
+                for (HttpServerCookie currentCookie : request.getCookies()) {
+                    if (expectedCookieName.equals(currentCookie.getName())) {
+                        return currentCookie;
+                    }
+                }
+
+                return null;
             }
 
             HttpServerCookie createCookie(String value, int maxAge) {

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -30,6 +30,7 @@ import org.wildfly.security.http.HttpServerMechanismsResponder;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerRequestWrapper;
 import org.wildfly.security.http.HttpServerResponse;
+import org.wildfly.security.http.util.SimpleHttpServerCookie;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -227,47 +228,8 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
             }
 
             HttpServerCookie createCookie(String value, int maxAge) {
-                return new HttpServerCookie() {
-                    @Override
-                    public String getName() {
-                        return configuration.getCookieName();
-                    }
-
-                    @Override
-                    public String getValue() {
-                        return value;
-                    }
-
-                    @Override
-                    public String getDomain() {
-                        return configuration.getDomain();
-                    }
-
-                    @Override
-                    public int getMaxAge() {
-                        return maxAge;
-                    }
-
-                    @Override
-                    public String getPath() {
-                        return configuration.getPath();
-                    }
-
-                    @Override
-                    public boolean isSecure() {
-                        return configuration.isSecure();
-                    }
-
-                    @Override
-                    public int getVersion() {
-                        return 0;
-                    }
-
-                    @Override
-                    public boolean isHttpOnly() {
-                        return configuration.isHttpOnly();
-                    }
-                };
+                return SimpleHttpServerCookie.newInstance(configuration.getCookieName(), value, configuration.getDomain(),
+                        maxAge, configuration.getPath(), configuration.isSecure(), 0, configuration.isHttpOnly());
             }
         };
     }

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -52,7 +52,7 @@ import static org.wildfly.security.http.util.sso.ElytronMessages.log;
 public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticationMechanismFactory {
 
     private final HttpServerAuthenticationMechanismFactory delegate;
-    private final SingleSignOnConfiguration configuration;
+    private final org.wildfly.security.http.util.sso.SingleSignOnConfiguration configuration;
     private final SingleSignOnSessionFactory singleSignOnSessionFactory;
 
     /**
@@ -62,10 +62,22 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
      * @param singleSignOnSessionFactory a custom {@link SingleSignOnManager}
      * @param configuration the configuration related with the cookie representing user's session
      */
-    public SingleSignOnServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate, SingleSignOnSessionFactory singleSignOnSessionFactory, SingleSignOnConfiguration configuration) {
+    public SingleSignOnServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate, SingleSignOnSessionFactory singleSignOnSessionFactory, org.wildfly.security.http.util.sso.SingleSignOnConfiguration configuration) {
         this.delegate = delegate;
         this.configuration = configuration;
         this.singleSignOnSessionFactory = singleSignOnSessionFactory;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param delegate the factory holding the target mechanisms
+     * @param singleSignOnSessionFactory a custom {@link SingleSignOnManager}
+     * @param configuration the configuration related with the cookie representing user's session
+     */
+    @Deprecated
+    public SingleSignOnServerMechanismFactory(HttpServerAuthenticationMechanismFactory delegate, SingleSignOnSessionFactory singleSignOnSessionFactory, SingleSignOnConfiguration configuration) {
+        this(delegate, singleSignOnSessionFactory, configuration.convert());
     }
 
     @Override
@@ -270,6 +282,7 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
         };
     }
 
+    @Deprecated
     public static final class SingleSignOnConfiguration {
 
         private final String cookieName;
@@ -304,6 +317,10 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
 
         public boolean isHttpOnly() {
             return httpOnly;
+        }
+
+        org.wildfly.security.http.util.sso.SingleSignOnConfiguration convert() {
+            return new org.wildfly.security.http.util.sso.SingleSignOnConfiguration(cookieName, domain, path, httpOnly, secure);
         }
     }
 }

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSession.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSession.java
@@ -35,7 +35,7 @@ public interface SingleSignOnSession extends IdentityCache, AutoCloseable {
     String getId();
 
     /**
-     * Performs a local logout where only the local session is invalidated.
+     * Performs a local logout if the incoming request is a logout message, otherwise do nothing.
      *
      * @return {@code true} if local session was invalidated. Otherwise, {@code false}
      */

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSessionFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnSessionFactory.java
@@ -42,7 +42,8 @@ public interface SingleSignOnSessionFactory {
      *
      * @param request the current request
      * @param mechanismName the name of the authentication mechanism
+     * @param programmatic {@code true} if the session if being created for programmatic authentication
      * @return a {@link SingleSignOnSession} instance associated with the specified identifier and request
      */
-    SingleSignOnSession create(HttpServerRequest request, String mechanismName);
+    SingleSignOnSession create(HttpServerRequest request, String mechanismName, boolean programmatic);
 }

--- a/http/util/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
+++ b/http/util/src/main/java/org/wildfly/security/http/util/SetMechanismInformationMechanismFactory.java
@@ -118,6 +118,12 @@ public class SetMechanismInformationMechanismFactory implements HttpServerAuthen
 
                 mechanism.evaluateRequest(request);
             }
+
+            @Override
+            public void dispose() {
+                mechanism.dispose();
+            }
+
         } : null;
     }
 

--- a/http/util/src/main/java/org/wildfly/security/http/util/SimpleHttpServerCookie.java
+++ b/http/util/src/main/java/org/wildfly/security/http/util/SimpleHttpServerCookie.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.util;
+
+import org.wildfly.security.http.HttpServerCookie;
+
+/**
+ * A simple implementation of {@link HttpServerCookie}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SimpleHttpServerCookie implements HttpServerCookie {
+
+    private final String name;
+    private final String value;
+    private final String domain;
+    private final int maxAge;
+    private final String path;
+    private final boolean secure;
+    private final int version;
+    private final boolean httpOnly;
+
+    SimpleHttpServerCookie(String name, String value, String domain, int maxAge, String path, boolean secure, int version, boolean httpOnly) {
+        super();
+        this.name = name;
+        this.value = value;
+        this.domain = domain;
+        this.maxAge = maxAge;
+        this.path = path;
+        this.secure = secure;
+        this.version = version;
+        this.httpOnly = httpOnly;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getDomain() {
+        return domain;
+    }
+
+    @Override
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return secure;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    @Override
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    public static HttpServerCookie newInstance(String name, String value, String domain, int maxAge, String path, boolean secure, int version, boolean httpOnly) {
+        return new SimpleHttpServerCookie(name, value, domain, maxAge, path, secure, version, httpOnly);
+    }
+}

--- a/http/util/src/main/java/org/wildfly/security/http/util/SocketAddressCallbackServerMechanismFactory.java
+++ b/http/util/src/main/java/org/wildfly/security/http/util/SocketAddressCallbackServerMechanismFactory.java
@@ -81,6 +81,17 @@ public final class SocketAddressCallbackServerMechanismFactory implements HttpSe
 
                 mechanism.evaluateRequest(request);
             }
+
+            @Override
+            public Object getNegotiatedProperty(String propertyName) {
+                return mechanism.getNegotiatedProperty(propertyName);
+            }
+
+            @Override
+            public void dispose() {
+                mechanism.dispose();
+            }
+
         } : null;
     }
 }


### PR DESCRIPTION
I am just raising as a draft PR for now as I have a few tasks to complete but I will need to handle them after the WildFly feature freeze as I need to get back to some feature development work in the meantime but I would like to get the reviews started on this approach to enable SSO for programmatic authentication.

For programmatic authentication this essentially takes the opposite approach to the approach used in the mechanisms and instead completely wraps the SSO access behind an IdentityCache - this does feel like it keeps the SSO session handling quite well constrained.

Debugging this issue did discover some additional issues which are included in this PR.

https://issues.redhat.com/browse/ELY-1626
https://issues.redhat.com/browse/ELY-2076
https://issues.redhat.com/browse/ELY-2077

