### PR TITLE
[ELY-2069] JWT token validation uses int instead of long for the dates: exp (expiration) and nbf

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -135,16 +135,17 @@ public class JwtValidator implements TokenValidator {
     }
 
     private boolean verifyTimeConstraints(JsonObject claims) {
-        int currentTime = currentTimeInSeconds();
-        boolean expired = currentTime > claims.getInt("exp", -1);
+        long currentTime = currentTimeInSeconds();
+        if (claims.containsKey("exp")) {
+            boolean expired = currentTime > claims.getJsonNumber("exp").longValue();
 
-        if (expired) {
-            log.debug("Token expired");
-            return false;
+            if (expired) {
+                log.debug("Token expired");
+                return false;
+            }
         }
-
         if (claims.containsKey("nbf")) {
-            boolean notBefore = currentTime >= claims.getInt("nbf");
+            boolean notBefore = currentTime >= claims.getJsonNumber("nbf").longValue();
 
             if (!notBefore) {
                 log.debugf("Token is before [%s]", notBefore);
@@ -314,8 +315,8 @@ public class JwtValidator implements TokenValidator {
         }
     }
 
-    private static int currentTimeInSeconds() {
-        return ((int) (System.currentTimeMillis() / 1000));
+    private static long currentTimeInSeconds() {
+        return System.currentTimeMillis() / 1000;
     }
 
     public static class Builder {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-20939
Upstream issue: https://issues.redhat.com/browse/ELY-2069
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1479