### PR TITLE
Revert "[ELY-2099] Ensure only WildFly Elytron classes are included in the shaded JAR"

### DIFF
--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -170,9 +170,9 @@
                             <createSourcesJar>true</createSourcesJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
-                                <includes>
-                                    <include>org.wildfly.security:*</include>
-                                </includes>
+                                <excludes>
+                                    <exclude>org.wildfly.common:wildfly-common</exclude>
+                                </excludes>
                             </artifactSet>
                             <transformers>
                                 <transformer


### PR DESCRIPTION
Reverts https://github.com/wildfly-security/wildfly-elytron/pull/1495

It turns out that there are places in WildFly Core and WildFly where we were erroneously relying on some non-Elytron classes being included in the shaded JAR so the removal of these classes has resulted in test failures.

We will clean things up properly when we update the Maven dependencies in WildFly Core and WildFly to reference individual Elytron modules (see https://issues.redhat.com/browse/WFCORE-4261 and https://issues.redhat.com/browse/WFLY-11540).