### PR TITLE
[ELY-2109] Upgrade JBoss LogManager to 2.1.18.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.org.apache.sshd.common>2.3.0</version.org.apache.sshd.common>
 
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
-        <version.org.jboss.logmanager>2.1.17.Final</version.org.jboss.logmanager>
+        <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.2.1.Final</version.org.jboss.logging.tools>
         <version.org.jboss.modules>1.9.2.Final</version.org.jboss.modules>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2109