### PR TITLE
[ELY-2112] Automatic registration of client side / JVM wide default SSLContext

### DIFF
--- a/auth/client/pom.xml
+++ b/auth/client/pom.xml
@@ -107,7 +107,6 @@
         <dependency>
             <groupId>org.wildfly.client</groupId>
             <artifactId>wildfly-client-config</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/AuthenticationContext.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/AuthenticationContext.java
@@ -244,8 +244,15 @@ public final class AuthenticationContext implements Contextual<AuthenticationCon
     RuleNode<SecurityFactory<SSLContext>> sslRuleMatching(URI uri, String abstractType, String abstractTypeAuthority) {
         RuleNode<SecurityFactory<SSLContext>> node = this.sslRules;
         while (node != null) {
-            if (node.getRule().matches(uri, abstractType, abstractTypeAuthority)) return node;
-            node = node.getNext();
+            if (uri == null) {
+                if (node.getRule().equals(MatchRule.ALL)) {
+                    return node;
+                }
+                node = node.getNext();
+            } else {
+                if (node.getRule().matches(uri, abstractType, abstractTypeAuthority)) return node;
+                node = node.getNext();
+            }
         }
         return null;
     }

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/AuthenticationContextConfigurationClient.java
@@ -197,6 +197,16 @@ public final class AuthenticationContextConfigurationClient {
     }
 
     /**
+     * Get the configured SSL context which matches ALL rules from provided AuthenticationContext, or {@link SSLContext#getDefault()} if there is none.
+     *
+     * @param authenticationContext the authentication context to examine (must not be {@code null})
+     * @return the SSL context from provided AuthenticationContext that matches ALL rules
+     */
+    public SSLContext getSSLContext(AuthenticationContext authenticationContext) throws GeneralSecurityException {
+        return getSSLContext(null,  authenticationContext, null, null);
+    }
+
+    /**
      * Get the SSL context which matches the given URI, or {@link SSLContext#getDefault()} if there is none.
      *
      * @param uri the URI to match (must not be {@code null})
@@ -223,14 +233,13 @@ public final class AuthenticationContextConfigurationClient {
     /**
      * Get the SSL context factory which matches the given URI and type, or {@link SSLContext#getDefault()} if there is none.
      *
-     * @param uri the URI to match (must not be {@code null})
+     * @param uri the URI to match
      * @param authenticationContext the authentication context to examine (must not be {@code null})
      * @param abstractType the abstract type (may be {@code null})
      * @param abstractTypeAuthority the abstract type authority (may be {@code null})
      * @return the matching SSL context factory (not {@code null})
      */
     public SecurityFactory<SSLContext> getSSLContextFactory(URI uri, AuthenticationContext authenticationContext, String abstractType, String abstractTypeAuthority) {
-        Assert.checkNotNullParam("uri", uri);
         Assert.checkNotNullParam("authenticationContext", authenticationContext);
         final RuleNode<SecurityFactory<SSLContext>> node = authenticationContext.sslRuleMatching(uri, abstractType, abstractTypeAuthority);
         if (node == null) return SSLContext::getDefault;

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/WildFlyElytronClientDefaultSSLContextProvider.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/WildFlyElytronClientDefaultSSLContextProvider.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.client;
+
+import org.kohsuke.MetaInfServices;
+import org.wildfly.client.config.ConfigXMLParseException;
+import org.wildfly.security.auth.client._private.ElytronMessages;
+import static org.wildfly.security.auth.client._private.ElytronMessages.log;
+
+import java.io.FileNotFoundException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provider that loads Elytron client configuration and provides default SSLContext which can be returned with SSLContext.getDefault() call.
+ * Default SSLContext is the configured SSL context that does not have any specific rule when it should be used, so it matches all rules.
+ */
+@MetaInfServices(value = Provider.class)
+public final class WildFlyElytronClientDefaultSSLContextProvider extends Provider {
+
+    private static final long serialVersionUID = -8281186085283177185L;
+    public static final String ELYTRON_CLIENT_DEFAULT_SSL_CONTEXT_PROVIDER_NAME = "WildFlyElytronClientDefaultSSLContextProvider";
+
+    /**
+     * WildFlyElytronClientDefaultSSLContextProvider that uses Elytron client configuration found on classpath.
+     */
+    public WildFlyElytronClientDefaultSSLContextProvider() {
+        this(null);
+    }
+
+    /**
+     * WildFlyElytronClientDefaultSSLContextProvider that uses Elytron client configuration found on provided path.
+     *
+     * @param configPath path to Elytron client configuration path
+     */
+    public WildFlyElytronClientDefaultSSLContextProvider(String configPath) {
+        super(ELYTRON_CLIENT_DEFAULT_SSL_CONTEXT_PROVIDER_NAME, 1.0, "Elytron client provider for default SSLContext");
+        putService(new ClientSSLContextProviderService(this, "SSLContext", "Default", "org.wildfly.security.auth.client.provider.WildFlyElytronClientDefaultSSLContextSpi", null, null, configPath));
+    }
+
+    /**
+     * Configures WildFlyElytronClientDefaultSSLContextProvider with the provided Elytron client configuration path
+     *
+     * @param configPath path to Elytron client configuration path
+     */
+    public Provider configure(String configPath) {
+        Service service = getService("SSLContext", "Default");
+        if (service instanceof ClientSSLContextProviderService) {
+            ((ClientSSLContextProviderService) getService("SSLContext", "Default")).setConfigPath(configPath);
+        } else {
+            putService(new ClientSSLContextProviderService(this, "SSLContext", "Default", "org.wildfly.security.auth.client.provider.WildFlyElytronClientDefaultSSLContextSpi", null, null, configPath));
+        }
+        return this;
+    }
+
+    private static final class ClientSSLContextProviderService extends Provider.Service {
+        String configPath;
+        // this is Integer because we need to count the number of times entered
+        // entered.get()==2 means we requested this provider second time, creating a loop, so we throw an sslContextForSecurityProviderCreatesInfiniteLoop exception
+        // AuthenticationContextConfigurationClient receives sslContextForSecurityProviderCreatesInfiniteLoop exception during obtaining of default SSL context and will therefore request default SSL context from other providers
+        // after default SSL context from other provider is returned, we must check the entered variable again and throw an exception to inform users that this provider was unsuccessful because of invalid configuration
+        private final ThreadLocal<Integer> entered = new ThreadLocal<>();
+
+        ClientSSLContextProviderService(Provider provider, String type, String algorithm, String className, List<String> aliases,
+                                        Map<String, String> attributes, String configPath) {
+            super(provider, type, algorithm, className, aliases, attributes);
+            this.configPath = configPath;
+        }
+
+        public void setConfigPath(String configPath) {
+            this.configPath = configPath;
+        }
+
+        /**
+         * There is a risk of looping if the Elytron client configuration is invalid.
+         * Loop will happen when Elytron client provider has configured default SSL context to be SSLContext::getDefault.
+         * Entered variable counts the number of entrances in order to avoid this loop.
+         * When it is equal or higher than 2 the NoSuchAlgorithmException will be thrown.
+         * When this exception is encountered, JVM tries to obtain default SSLContext from providers of lower priority
+         * and returns it to Elytron client as the default SSL context.
+         * Since we do not want to wrap the SSL context from other provider with this provider, we will throw an exception again
+         * which makes JVM escape this provider entirely and continue in the list of other providers.
+         */
+        @Override
+        public Object newInstance(Object ignored) throws NoSuchAlgorithmException {
+            Integer enteredCountTmp = entered.get();
+            entered.set(enteredCountTmp == null ? 1 : enteredCountTmp + 1);
+            if (entered.get() >= 2) {
+                // we do not do clean up entered variable here because it is needed for the second check and possible throwing of second exception below
+                throw ElytronMessages.log.sslContextForSecurityProviderCreatesInfiniteLoop();
+            }
+
+            WildFlyElytronClientDefaultSSLContextSpi sslContext;
+            try {
+                if (configPath == null) {
+                    sslContext = new WildFlyElytronClientDefaultSSLContextSpi(AuthenticationContext.captureCurrent());
+                } else {
+                    sslContext = new WildFlyElytronClientDefaultSSLContextSpi(this.configPath);
+                }
+                // if we had an exception previously, then default SSLContext was still returned from other security provider of lower priority in
+                // AuthenticationContextConfigurationClient#getSSLContextFactory method.
+                // Since we do not want to wrap SSLContext from other provider with this provider, we need to check entered variable again
+                // and throw an exception which makes JVM ignore this provider and probe other providers again
+                if (entered.get() >= 2) {
+                    throw ElytronMessages.log.sslContextForSecurityProviderCreatesInfiniteLoop();
+                }
+            } catch (ConfigXMLParseException | GeneralSecurityException e) {
+                if (e.getCause() instanceof FileNotFoundException) {
+                    throw log.clientConfigurationFileNotFound();
+                }
+                throw log.couldNotObtainClientDefaultSSLContext();
+            } finally {
+                entered.remove();
+            }
+            return sslContext;
+        }
+    }
+}

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/WildFlyElytronClientDefaultSSLContextSpi.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/WildFlyElytronClientDefaultSSLContextSpi.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.auth.client;
+
+import org.wildfly.client.config.ConfigXMLParseException;
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.client._private.ElytronMessages;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLContextSpi;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.GeneralSecurityException;
+import java.security.PrivilegedAction;
+import java.security.SecureRandom;
+
+/**
+ * SSLContextSpi that is used by WildFlyElytronClientDefaultSSLContextProvider
+ */
+public class WildFlyElytronClientDefaultSSLContextSpi extends SSLContextSpi {
+
+    private SSLContext configuredDefaultClientSSLContext;
+
+    /**
+     * SSLContextSpi used by WildFlyElytronClientDefaultSSLContextProvider that uses AuthenticationContext found on the classpath to retrieve default SSLContext.
+     */
+    public WildFlyElytronClientDefaultSSLContextSpi() throws GeneralSecurityException {
+        this(AuthenticationContext.captureCurrent());
+    }
+
+    /**
+     * SSLContextSpi used by WildFlyElytronClientDefaultSSLContextProvider that uses Elytron client configuration from provided path to retrieve default SSLContext.
+     *
+     * @param configPath path to the Elytron client configuration file
+     */
+    public WildFlyElytronClientDefaultSSLContextSpi(String configPath) throws GeneralSecurityException, ConfigXMLParseException {
+        this(ElytronXmlParser.parseAuthenticationClientConfiguration(configPathUrlToUri(configPath)).create());
+    }
+
+    /**
+     * SSLContextSpi used by WildFlyElytronClientDefaultSSLContextProvider that uses Elytron client configuration from provided authentication context.
+     *
+     * @param authenticationContext authentication context used to retrieve default SSLContext
+     */
+    public WildFlyElytronClientDefaultSSLContextSpi(AuthenticationContext authenticationContext) throws GeneralSecurityException {
+        Assert.checkNotNullParam("authenticationContext", authenticationContext);
+
+        AuthenticationContextConfigurationClient AUTH_CONTEXT_CLIENT = AccessController.doPrivileged((PrivilegedAction<AuthenticationContextConfigurationClient>) AuthenticationContextConfigurationClient::new);
+        this.configuredDefaultClientSSLContext = AUTH_CONTEXT_CLIENT.getSSLContext(authenticationContext);
+    }
+
+    @Override
+    protected void engineInit(KeyManager[] keyManagers, TrustManager[] trustManagers, SecureRandom secureRandom) {
+        // ignore
+    }
+
+    @Override
+    protected SSLSocketFactory engineGetSocketFactory() {
+        return this.configuredDefaultClientSSLContext.getSocketFactory();
+    }
+
+    @Override
+    protected SSLServerSocketFactory engineGetServerSocketFactory() {
+        return this.configuredDefaultClientSSLContext.getServerSocketFactory();
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine() {
+        return this.configuredDefaultClientSSLContext.createSSLEngine();
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine(String s, int i) {
+        return this.configuredDefaultClientSSLContext.createSSLEngine(s, i);
+    }
+
+    @Override
+    protected SSLSessionContext engineGetServerSessionContext() {
+        return this.configuredDefaultClientSSLContext.getServerSessionContext();
+    }
+
+    @Override
+    protected SSLSessionContext engineGetClientSessionContext() {
+        return this.configuredDefaultClientSSLContext.getClientSessionContext();
+    }
+
+    /**
+     * Source: A utility method taken from https://github.com/wildfly/wildfly-client-config/blob/master/src/main/java/org/wildfly/client/config/ClientConfiguration.java on March 2022
+     */
+    static URI configPathUrlToUri(String wildFlyConfig) {
+        if (wildFlyConfig == null || wildFlyConfig.isEmpty()) {
+            throw ElytronMessages.log.clientConfigurationFileNotValid();
+        }
+        if (File.separator.equals("\\") && wildFlyConfig.contains("\\")) { // we are on the windows and path is for windows
+            File f = new File(wildFlyConfig);
+            return f.toPath().toUri();
+        } else {
+            try {
+                URI uri = new URI(wildFlyConfig);
+                if (!uri.isAbsolute()) { // URI does not include schema
+                    if (uri.getPath().charAt(0) != File.separatorChar && uri.getPath().charAt(0) != '/') { // relative path
+                        String userDir = System.getProperty("user.dir").replace(File.separatorChar, '/');
+                        return Paths.get(userDir, uri.getPath()).toUri();
+                    } else { // absolute path
+                        return Paths.get(uri.getPath()).toUri();
+                    }
+                }
+                return uri;
+            } catch (URISyntaxException e) {
+                // no config file there
+                return null;
+            }
+        }
+    }
+}

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/_private/ElytronMessages.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/_private/ElytronMessages.java
@@ -201,4 +201,16 @@ public interface ElytronMessages extends BasicLogger {
 
     @Message(id = 14004, value = "Password callback handling was unsuccessful")
     ConfigXMLParseException passwordCallbackHandlingWasUnsuccessful();
+
+    @Message(id = 14005, value = "Default SSL context in security provider creates infinite loop")
+    NoSuchAlgorithmException sslContextForSecurityProviderCreatesInfiniteLoop();
+
+    @Message(id = 14006, value = "Configuration file path passed to WildFlyElytronClientDefaultSSLContextProvider not found")
+    IllegalArgumentException clientConfigurationFileNotFound();
+
+    @Message(id = 14007, value = "Invalid path passed to WildFlyElytronClientDefaultSSLContextProvider")
+    IllegalArgumentException clientConfigurationFileNotValid();
+
+    @Message(id = 14008, value = "WildFlyElytronClientDefaultSSLContextProvider could not obtain client default SSLContext")
+    NoSuchAlgorithmException couldNotObtainClientDefaultSSLContext();
 }

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextEmptyPathTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextEmptyPathTest.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that default SSLContext provider will throw an exception when configured file path is empty
+ */
+public class DefaultSSLContextEmptyPathTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultSSLContextNonexistentConfigFileTest() {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(""), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        AuthenticationContext authenticationContext = AuthenticationContext.captureCurrent();
+        authenticationContext.run(() -> {
+            try {
+                SSLContext.getDefault();
+            } catch (NoSuchAlgorithmException e) {
+                Assert.fail("Obtaining default SSL context from provider with invalid path threw incorrect exception");
+            }
+        });
+    }
+}

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextFromFileWorksAndHasPrecedenceTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextFromFileWorksAndHasPrecedenceTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that configuration file passed to Elytron client provider has precedence over programmatic configuration
+ */
+public class DefaultSSLContextFromFileWorksAndHasPrecedenceTest {
+    private static final String CONFIG_FILE = "./src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-client-default-sslcontext.xml";
+
+    @Test
+    public void testDefaultSSLContextFromFileWorksAndHasPrecedence() {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(CONFIG_FILE), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        AuthenticationContext.empty().run(() -> {    // This will be ignored because file passed to provider has precedence
+            SSLContext defaultSSLContext = null;
+            try {
+                defaultSSLContext = SSLContext.getDefault();
+            } catch (NoSuchAlgorithmException e) {
+                Assert.fail("Obtaining of default SSLContext with both config file and programmatic configuration present threw NoSuchAlgorithmException exception.");
+            }
+            Assert.assertNotNull(defaultSSLContext);
+            Assert.assertNotNull(defaultSSLContext.getSocketFactory());
+            // if programmatic configuration was used, it would not find the default SSLContext configured and the provider would be ignored
+            // because the file was used, the default SSL context was present and returned with SSLContext.getDefault() call
+            Assert.assertEquals(WildFlyElytronClientDefaultSSLContextProvider.class.getSimpleName(), defaultSSLContext.getProvider().getName());
+            Assert.assertEquals(defaultSSLContext.createSSLEngine().getSSLParameters().getProtocols().length, 1);
+            Assert.assertEquals(defaultSSLContext.getSocketFactory().getSupportedCipherSuites().length, 1);
+        });
+    }
+}

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextNonexistentConfigFileTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextNonexistentConfigFileTest.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that default SSLContext provider will throw an exception when configured file path does not exist
+ */
+public class DefaultSSLContextNonexistentConfigFileTest {
+
+    private static final String CONFIG_FILE = "./src/test/resources/org/wildfly/security/auth/client/wildfly-config-invalid-path.xml";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void defaultSSLContextNonexistentConfigFileTest() {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(CONFIG_FILE), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        AuthenticationContext authenticationContext = AuthenticationContext.captureCurrent();
+        authenticationContext.run(() -> {
+            try {
+                SSLContext.getDefault();
+            } catch (NoSuchAlgorithmException e) {
+                Assert.fail("Obtaining default SSL context from provider with invalid path threw incorrect exception");
+            }
+        });
+    }
+}

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderDoesNotLoopTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderDoesNotLoopTest.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.client.config.ConfigXMLParseException;
+
+import javax.net.ssl.SSLContext;
+import java.io.File;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that default SSLContext provider will be ignored when configuration is looping or no default SSL context is configured
+ */
+public class DefaultSSLContextProviderDoesNotLoopTest {
+    private static final String CONFIG_FILE = "./src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-default-ssl-context-invalid-looping.xml";
+
+    @Test
+    public void testDefaultSSLContextProviderDoesNotLoopTestCase() throws GeneralSecurityException, ConfigXMLParseException, IOException {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        AuthenticationContext authenticationContext = ElytronXmlParser.parseAuthenticationClientConfiguration(new File(CONFIG_FILE).getCanonicalFile().toURI()).create();
+        authenticationContext.run(() -> {
+            SSLContext defaultSSLContext = null;
+            try {
+                defaultSSLContext = SSLContext.getDefault();
+            } catch (NoSuchAlgorithmException e) {
+                Assert.fail("Default SSL context provider should have been ignored because the configuration loops");
+            }
+            Assert.assertNotNull(defaultSSLContext);
+            Assert.assertNotEquals(WildFlyElytronClientDefaultSSLContextProvider.class.getSimpleName(), defaultSSLContext.getProvider().getName()); // diff provider was used since elytron provider is looping
+            Assert.assertNotNull(defaultSSLContext.getSocketFactory());
+        });
+    }
+}

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderIsIgnoredWhenConfigIsMissingTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderIsIgnoredWhenConfigIsMissingTest.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that when no config path passed to provider and there is no configuration present in the code, the provider will be ignored
+ */
+public class DefaultSSLContextProviderIsIgnoredWhenConfigIsMissingTest {
+
+    @Test
+    public void defaultSSLContextProviderIsIgnoredWhenConfigIsMissingTest() {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        SSLContext defaultSSLContext = null;
+        try {
+            defaultSSLContext = SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            Assert.fail("Default SSL context from provider was not ignored when no configuration was present");
+        }
+        Assert.assertNotNull(defaultSSLContext);
+        Assert.assertNotEquals(WildFlyElytronClientDefaultSSLContextProvider.class.getSimpleName(), defaultSSLContext.getProvider().getName()); // different provider was used since no default SSL context configured in Elytron client
+        Assert.assertNotNull(defaultSSLContext.getSocketFactory());
+    }
+}

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderProgrammaticConfigurationTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/DefaultSSLContextProviderProgrammaticConfigurationTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.auth.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.client.config.ConfigXMLParseException;
+
+import javax.net.ssl.SSLContext;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+/**
+ * Test that default SSLContext from provider can use programmatic configuration
+ */
+public class DefaultSSLContextProviderProgrammaticConfigurationTest {
+    private static final String CONFIG_FILE = "file:./src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-client-default-sslcontext.xml";
+
+    @Test
+    public void testDefaultSSLContextProgrammaticConfiguration() throws GeneralSecurityException, URISyntaxException, ConfigXMLParseException {
+        Security.insertProviderAt(new WildFlyElytronClientDefaultSSLContextProvider(), 1);
+        Assert.assertNotNull(Security.getProvider("WildFlyElytronClientDefaultSSLContextProvider"));
+        AuthenticationContext authenticationContext = ElytronXmlParser.parseAuthenticationClientConfiguration(new URI(CONFIG_FILE)).create();
+        authenticationContext.run(() -> {
+            SSLContext defaultSSLContext = null;
+            try {
+                defaultSSLContext = SSLContext.getDefault();
+            } catch (NoSuchAlgorithmException e) {
+                Assert.fail("Default SSL context from provider threw an exception when obtaining default SSL context from programmatic configuration ");
+            }
+            Assert.assertNotNull(defaultSSLContext);
+            Assert.assertEquals(WildFlyElytronClientDefaultSSLContextProvider.class.getSimpleName(), defaultSSLContext.getProvider().getName());
+            Assert.assertNotNull(defaultSSLContext.getSocketFactory());
+            // this will make sure the file is used instead of the empty AuthenticationContext
+            Assert.assertEquals(defaultSSLContext.createSSLEngine().getSSLParameters().getProtocols().length, 1);
+            Assert.assertEquals(defaultSSLContext.getSocketFactory().getSupportedCipherSuites().length, 1);
+        });
+    }
+}

--- a/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-client-default-sslcontext.xml
+++ b/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-client-default-sslcontext.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.7">
+        <key-stores>
+            <key-store name="keystore1" type="JKS">
+                <file name="src/test/resources/client.keystore"/>
+                <key-store-clear-password password="password"/>
+            </key-store>
+        </key-stores>
+        <ssl-contexts>
+            <default-ssl-context name="other-provider-default-sslcontext"/>
+            <ssl-context name="default-context">
+                <providers>
+                    <global/>
+                </providers>
+                <key-store-ssl-certificate key-store-name="keystore1">
+                    <key-store-clear-password password="password"/>
+                </key-store-ssl-certificate>
+                <protocol names="TLSv1.2" />
+                <cipher-suite selector="TLS_RSA_WITH_AES_128_CBC_SHA256" />
+            </ssl-context>
+        </ssl-contexts>
+        <ssl-context-rules>
+            <rule use-ssl-context="other-provider-default-sslcontext">
+                <match-port number="12345"/>
+            </rule>
+            <rule use-ssl-context="default-context">
+            </rule>
+        </ssl-context-rules>
+    </authentication-client>
+</configuration>

--- a/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-default-ssl-context-invalid-looping.xml
+++ b/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-default-ssl-context-invalid-looping.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.7">
+        <ssl-contexts>
+            <default-ssl-context name="looping-default-sslcontext"/>
+        </ssl-contexts>
+        <ssl-context-rules>
+            <rule use-ssl-context="looping-default-sslcontext">
+            </rule>
+        </ssl-context-rules>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2112

Adds Elytron client provider that provides default SSLContext which can be returned by `SSLContext.getDefault()` call. The default SSLContext is considered to be the one that matches all rules.