### PR TITLE
[ELY-2118] Elytron tool command execution fails with java.lang.UnsupportedOperationException on AIX OS.

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -146,7 +146,7 @@ class CredentialStoreCommand extends Command {
                     attrs.put(prefix + e.getKey(), e.getValue());
                 }
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             // A view can be supported but the operation is later reported
             // as not supported, so just add the attributes if possible.
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-21588
Upstream issue: https://issues.redhat.com/browse/ELY-2118
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1515
EAP 7.4.x: https://issues.redhat.com/browse/JBEAP-21587
EAP 7.4.x (1.15.x) PR: https://github.com/wildfly-security/wildfly-elytron/pull/1519
