### PR TITLE
ELY-2120 Avoid an NPE in ServerAuthenticationContext when the peer's IP address is not known

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1057,8 +1057,12 @@ public final class ServerAuthenticationContext implements AutoCloseable {
                     log.tracef("Handling SocketAddressCallback");
                     if (socketAddressCallback.getKind() == SocketAddressCallback.Kind.PEER) {
                         Attributes runtimeAttributes = new MapAttributes();
-                        runtimeAttributes.addFirst(KEY_SOURCE_ADDRESS, ((InetSocketAddress) socketAddressCallback.getAddress()).getAddress().getHostAddress());
-                        addRuntimeAttributes(runtimeAttributes);
+                        if ((socketAddressCallback.getAddress() != null) && ((InetSocketAddress) socketAddressCallback.getAddress()).getAddress() != null) {
+                            runtimeAttributes.addFirst(KEY_SOURCE_ADDRESS, ((InetSocketAddress) socketAddressCallback.getAddress()).getAddress().getHostAddress());
+                            addRuntimeAttributes(runtimeAttributes);
+                        } else {
+                            log.tracef("Client's IP address is unknown.");
+                        }
                     }
                     handleOne(callbacks, idx + 1);
                 } else if (callback instanceof SecurityIdentityCallback) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-21852
Upstream issue: https://issues.redhat.com/browse/ELY-2120
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1517