### PR TITLE
[ELY-2102] Fix slf4j warning messages when using Elytron Tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -887,7 +887,11 @@
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
                 <version>${version.org.jboss.logmanager}</version>
-                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.slf4j</groupId>
+                <artifactId>slf4j-jboss-logmanager</artifactId>
+                <version>${version.org.jboss.slf4j}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.modules</groupId>
@@ -1077,12 +1081,6 @@
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>log4j-jboss-logmanager</artifactId>
                 <version>${version.org.jboss.logmanager.log4j-jboss}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.slf4j</groupId>
-                <artifactId>slf4j-jboss-logmanager</artifactId>
-                <version>${version.org.jboss.slf4j}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -283,6 +283,14 @@
             <artifactId>sshd-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
@@ -297,17 +305,7 @@
          -->
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
             <artifactId>log4j-jboss-logmanager</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.slf4j</groupId>
-            <artifactId>slf4j-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2102

We have to include org.slf4j.impl.* and org.jboss.logmanager.* in Elytron tool jar. 