### PR TITLE
[ELY-2101] Upgrade Apache sshd-common to a version that depends on slf4j 1.7.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
         <version.org.eclipse.microprofile.jwt.api>1.2.1</version.org.eclipse.microprofile.jwt.api>
-        <version.org.apache.sshd.common>2.3.0</version.org.apache.sshd.common>
+        <version.org.apache.sshd.common>2.6.0</version.org.apache.sshd.common>
 
         <version.org.jboss.logging>3.4.2.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2101
