### PR TITLE
[ELY-2117] SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate) on IBM JDK after ELY-2026

### DIFF
--- a/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLServerSocketFactory.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLServerSocketFactory.java
@@ -57,6 +57,14 @@ final class ConfiguredSSLServerSocketFactory extends AbstractDelegatingSSLServer
         return wrap(super.createServerSocket(port, backlog, ifAddress));
     }
 
+    public String[] getDefaultCipherSuites() {
+        return sslConfigurator.getDefaultSSLParameters(sslContext, sslContext.getDefaultSSLParameters()).getCipherSuites();
+    }
+
+    public String[] getSupportedCipherSuites() {
+        return sslConfigurator.getSupportedSSLParameters(sslContext, sslContext.getSupportedSSLParameters()).getCipherSuites();
+    }
+
     private ServerSocket wrap(ServerSocket original) throws IOException {
         if (original instanceof SSLServerSocket) {
             final SSLServerSocket sslServerSocket = (SSLServerSocket) original;

--- a/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLSocketFactory.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLSocketFactory.java
@@ -71,6 +71,14 @@ final class ConfiguredSSLSocketFactory extends AbstractDelegatingSSLSocketFactor
         return wrap(super.createSocket(socket, inputStream, autoClose));
     }
 
+    public String[] getDefaultCipherSuites() {
+        return sslConfigurator.getDefaultSSLParameters(sslContext, sslContext.getDefaultSSLParameters()).getCipherSuites();
+    }
+
+    public String[] getSupportedCipherSuites() {
+        return sslConfigurator.getSupportedSSLParameters(sslContext, sslContext.getSupportedSSLParameters()).getCipherSuites();
+    }
+
     private Socket wrap(Socket orig) {
         if (orig instanceof SSLSocket) {
             final SSLSocket sslSocket = (SSLSocket) orig;


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2117