### PR TITLE
[ELY-2145] Default platform encoding used in OAuth2IntrospectValidator and OAuth2CredentialSource.

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
+++ b/auth/client/src/main/java/org/wildfly/security/credential/source/OAuth2CredentialSource.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
@@ -155,7 +156,7 @@ public class OAuth2CredentialSource implements CredentialSource {
                     if (connection != null && connection.getErrorStream() != null) {
                         errorStream = connection.getErrorStream();
 
-                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream))) {
+                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream, StandardCharsets.UTF_8))) {
                             StringBuffer response = reader.lines().reduce(new StringBuffer(), StringBuffer::append, (buffer1, buffer2) -> buffer1);
                             saslOAuth2.errorf(ioe, "Unexpected response from server [%s]. Response: [%s]", tokenEndpointUri, response);
                         } catch (IOException ignore) {

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -149,7 +150,7 @@ public class OAuth2IntrospectValidator implements TokenValidator {
             if (connection != null && connection.getErrorStream() != null) {
                 InputStream errorStream = connection.getErrorStream();
 
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream))) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(errorStream, StandardCharsets.UTF_8))) {
                     StringBuffer response = reader.lines().reduce(new StringBuffer(), StringBuffer::append, (buffer1, buffer2) -> buffer1);
                     log.errorf(ioe, "Unexpected response from token introspection endpoint [%s]. Response: [%s]", tokenIntrospectionUrl, response);
                 } catch (IOException e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2145