### PR TITLE
[ELY-2184] Refactor the Digest mechanisms to use MessageDigest#isEqual instead of Arrays#equals

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -47,7 +47,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
@@ -227,7 +226,7 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
 
         byte[] calculatedResponse = calculateResponseDigest(messageDigest, hA1, nonce, request.getRequestMethod(), digestUri, responseTokens.get(QOP), responseTokens.get(CNONCE), responseTokens.get(NC));
 
-        if (Arrays.equals(response, calculatedResponse) == false) {
+        if (MessageDigest.isEqual(response, calculatedResponse) == false) {
             httpDigest.trace("Failed: invalid proof");
             fail();
             request.authenticationFailed(httpDigest.mechResponseTokenMismatch(getMechanismName()), httpResponse -> prepareResponse(selectedRealm, httpResponse, false));

--- a/http/digest/src/main/java/org/wildfly/security/http/digest/NonceManager.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/NonceManager.java
@@ -23,6 +23,7 @@ import java.security.DigestException;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.wildfly.common.array.Arrays2;
 import org.wildfly.common.iteration.ByteIterator;
 import org.wildfly.common.iteration.CodePointIterator;
 import org.wildfly.security.mechanism._private.ElytronMessages;
@@ -225,7 +225,9 @@ public class NonceManager {
                 throw log.invalidNonceLength();
             }
 
-            if (Arrays2.equals(nonceBytes, PREFIX_LENGTH, digest(nonceBytes, 0, PREFIX_LENGTH, salt, messageDigest)) == false) {
+            byte[] nonceBytesWithoutPrefix = Arrays.copyOfRange(nonceBytes, PREFIX_LENGTH, nonceBytes.length);
+            byte[] expectedNonce = digest(nonceBytes, 0, PREFIX_LENGTH, salt, messageDigest);
+            if (MessageDigest.isEqual(nonceBytesWithoutPrefix, expectedNonce) == false) {
                 if (log.isTraceEnabled()) {
                     String saltString = salt == null ? "null" : ByteIterator.ofBytes(salt).hexEncode().drainToString();
                     log.tracef("Nonce %s rejected due to failed comparison using secret key with seed %s.", nonce,

--- a/sasl/digest/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
+++ b/sasl/digest/src/main/java/org/wildfly/security/sasl/digest/DigestSaslServer.java
@@ -28,8 +28,8 @@ import static org.wildfly.security.sasl.digest._private.DigestUtil.digestRespons
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.Provider;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.function.Predicate;
@@ -221,7 +221,7 @@ final class DigestSaslServer extends AbstractDigestMechanism implements SaslServ
         }
 
         byte[] nonceFromClient = parsedDigestResponse.get("nonce");
-        if (!Arrays.equals(nonce, nonceFromClient)) {
+        if (! MessageDigest.isEqual(nonce, nonceFromClient)) {
             throw saslDigest.mechNoncesDoNotMatch().toSaslException();
         }
 
@@ -270,7 +270,7 @@ final class DigestSaslServer extends AbstractDigestMechanism implements SaslServ
         if (parsedDigestResponse.get("response") == null) {
             throw saslDigest.mechMissingDirective("response").toSaslException();
         }
-        if ( ! Arrays.equals(expectedResponse, parsedDigestResponse.get("response"))) {
+        if (! MessageDigest.isEqual(expectedResponse, parsedDigestResponse.get("response"))) {
             throw saslDigest.mechAuthenticationRejectedInvalidProof().toSaslException();
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2184