### PR TITLE
ELY-2189 Token Realm Validator timeouts

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -89,7 +89,7 @@ public class JwtValidator implements TokenValidator {
         if (configuration.sslContext != null) {
             this.jwkManager = new JwkManager(configuration.sslContext,
                                             configuration.hostnameVerifier != null ? configuration.hostnameVerifier : HttpsURLConnection.getDefaultHostnameVerifier(),
-                                            configuration.updateTimeout);
+                                            configuration.updateTimeout, configuration.connectionTimeout, configuration.readTimeout);
         }
         else {
             log.tokenRealmJwtNoSSLIgnoringJku();
@@ -324,7 +324,7 @@ public class JwtValidator implements TokenValidator {
     }
 
     public static class Builder {
-
+        private static final int CONNECTION_TIMEOUT = 2000;//2s
         private Set<String> issuers = new LinkedHashSet<>();
         private Set<String> audience = new LinkedHashSet<>();
         private PublicKey publicKey;
@@ -332,6 +332,8 @@ public class JwtValidator implements TokenValidator {
         private HostnameVerifier hostnameVerifier;
         private SSLContext sslContext;
         private long updateTimeout = 120000;
+        private int connectionTimeout = CONNECTION_TIMEOUT;
+        private int readTimeout = CONNECTION_TIMEOUT;
 
         private Builder() {
         }
@@ -442,6 +444,28 @@ public class JwtValidator implements TokenValidator {
          */
         public Builder setJkuTimeout(long timeout) {
             this.updateTimeout = timeout;
+            return this;
+        }
+
+        /**
+         * Sets the connection timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when connecting
+         * to a resource. A timeout of zero is interpreted as an infinite timeout.
+         * @param connectionTimeout the connection timeout
+         * @return this instance
+         */
+        public Builder connectionTimeout(int connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        /**
+         * Sets the read timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when reading
+         * from Input stream when a connection is established to a resource. A timeout of zero is interpreted as an infinite timeout.
+         * @param readTimeout the read timeout
+         * @return this instance
+         */
+        public Builder readTimeout(int readTimeout) {
+            this.readTimeout = readTimeout;
             return this;
         }
 

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
@@ -69,6 +69,8 @@ public class OAuth2IntrospectValidator implements TokenValidator {
     private final String clientSecret;
     private final SSLContext sslContext;
     private final HostnameVerifier hostnameVerifier;
+    private final int connectionTimeout;
+    private final int readTimeout;
 
     OAuth2IntrospectValidator(Builder configuration) {
         this.tokenIntrospectionUrl = Assert.checkNotNullParam("tokenIntrospectionUrl", configuration.tokenIntrospectionUrl);
@@ -81,6 +83,8 @@ public class OAuth2IntrospectValidator implements TokenValidator {
 
         this.sslContext = configuration.sslContext;
         this.hostnameVerifier = configuration.hostnameVerifier;
+        this.connectionTimeout = configuration.connectionTimeout;
+        this.readTimeout = configuration.readTimeout;
     }
 
     @Override
@@ -184,6 +188,8 @@ public class OAuth2IntrospectValidator implements TokenValidator {
                     https.setHostnameVerifier(hostnameVerifier);
                 }
             }
+            connection.setConnectTimeout(connectionTimeout);
+            connection.setReadTimeout(readTimeout);
 
             return connection;
         } catch (IOException cause) {
@@ -211,6 +217,8 @@ public class OAuth2IntrospectValidator implements TokenValidator {
         private URL tokenIntrospectionUrl;
         private SSLContext sslContext;
         private HostnameVerifier hostnameVerifier;
+        private int connectionTimeout;
+        private int readTimeout;
 
         private Builder() {
         }
@@ -274,6 +282,28 @@ public class OAuth2IntrospectValidator implements TokenValidator {
          */
         public Builder useSslHostnameVerifier(HostnameVerifier hostnameVerifier) {
             this.hostnameVerifier = hostnameVerifier;
+            return this;
+        }
+
+        /**
+         * Sets the connection timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when connecting
+         * to a resource. A timeout of zero is interpreted as an infinite timeout.
+         * @param connectionTimeout the connection timeout
+         * @return this instance
+         */
+        public Builder connectionTimeout(int connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        /**
+         * Sets the read timeout to a specified timeout, in milliseconds. A non-zero value specifies the timeout when reading
+         * from Input stream when a connection is established to a resource. A timeout of zero is interpreted as an infinite timeout.
+         * @param readTimeout the read timeout
+         * @return this instance
+         */
+        public Builder readTimeout(int readTimeout) {
+            this.readTimeout = readTimeout;
             return this;
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2189

Note: I did not change the OAuth2Validator default timeouts (0), but, for consistency, they should be the same for both validators.