### PR TITLE
[ELY-2194] JWK implementation in JwkManager does not work properly on key rotation

### DIFF
--- a/ELY_Messages.txt
+++ b/ELY_Messages.txt
@@ -67,6 +67,7 @@
 01041 - 01153    wildfly-elytron-realm-ldap
 04025            wildfly-elytron-realm-ldap
 01104 - 01180    wildfly-elytron-realm-token
+01181 - 01185    wildfly-elytron-realm-token
 01157            wildfly-elytron-sasl
 05001 - 05163    wildfly-elytron-sasl
 01066 - 01077    wildfly-elytron-ssl

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/_private/ElytronMessages.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/_private/ElytronMessages.java
@@ -20,6 +20,8 @@ package org.wildfly.security.auth.realm.token._private;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.net.URL;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -38,7 +40,8 @@ import org.wildfly.security.auth.server.RealmUnavailableException;
  */
 @MessageLogger(projectCode = "ELY", length = 5)
 @ValidIdRanges({
-    @ValidIdRange(min = 1104, max = 1180)
+    @ValidIdRange(min = 1104, max = 1180),
+    @ValidIdRange(min = 1181, max = 1185)
 })
 public interface ElytronMessages extends BasicLogger {
 
@@ -92,5 +95,8 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1180, value = "Fetched jwk does not contain \"%1$s\" claim, ignoring...")
     void tokenRealmJwkMissingClaim(String claim);
 
+    @LogMessage(level = WARN)
+    @Message(id = 1181, value = "Not sending new request to jwks url \"%s\". Last request time was %d.")
+    void avoidingFetchJwks(URL url, long timestamp);
 }
 

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwkManager.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwkManager.java
@@ -37,9 +37,9 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.wildfly.security.auth.realm.token._private.ElytronMessages.log;
 
@@ -50,19 +50,20 @@ import static org.wildfly.security.auth.realm.token._private.ElytronMessages.log
  */
 class JwkManager {
 
-    private final Map<URL, Map<String, RSAPublicKey>> keys = new LinkedHashMap<>();
-    private final Map<URL, Long> timeouts = new ConcurrentHashMap<>();
+    private final Map<URL, CacheEntry> keys = new LinkedHashMap<>();
     private final SSLContext sslContext;
     private final HostnameVerifier hostnameVerifier;
 
     private final long updateTimeout;
+    private final int minTimeBetweenRequests;
 
     private static final int CONNECTION_TIMEOUT = 2000;//2s
 
-    JwkManager(SSLContext sslContext, HostnameVerifier hostnameVerifier, long updateTimeout) {
+    JwkManager(SSLContext sslContext, HostnameVerifier hostnameVerifier, long updateTimeout, int minTimeBetweenRequests) {
         this.sslContext = sslContext;
         this.hostnameVerifier = hostnameVerifier;
         this.updateTimeout = updateTimeout;
+        this.minTimeBetweenRequests = minTimeBetweenRequests;
     }
 
     /**
@@ -72,7 +73,7 @@ class JwkManager {
      * @return signature verification public key if found, null otherwise
      */
     public PublicKey getPublicKey(String kid, URL url) {
-        Map<String, RSAPublicKey> urlKeys = checkRemote(url);
+        Map<String, RSAPublicKey> urlKeys = checkRemote(kid, url);
 
         if (urlKeys == null) {
             return null;
@@ -86,37 +87,51 @@ class JwkManager {
         return pk;
     }
 
-    private Map<String, RSAPublicKey> checkRemote(URL url) {
+    private Map<String, RSAPublicKey> checkRemote(String kid, URL url) {
+        Assert.checkNotNullParam("kid", kid);
         Assert.checkNotNullParam("url", url);
 
-        long lastUpdate = 0;
-
+        CacheEntry cacheEntry;
+        long lastUpdate;
         Map<String, RSAPublicKey> urlKeys;
 
         synchronized (keys) {
-            urlKeys = keys.get(url);
-            if (urlKeys == null) {
-                urlKeys = new ConcurrentHashMap<>();
-                keys.put(url, urlKeys);
+            cacheEntry = keys.get(url);
+            if (cacheEntry == null) {
+                cacheEntry = new CacheEntry();
+                keys.put(url, cacheEntry);
             }
+            lastUpdate = cacheEntry.getTimestamp();
+            urlKeys = cacheEntry.getKeys();
         }
 
-        synchronized (urlKeys) {
-            if (timeouts.containsKey(url)) {
-                lastUpdate = timeouts.get(url);
-            }
+        long currentTime = System.currentTimeMillis();
 
-            if (lastUpdate + updateTimeout <= System.currentTimeMillis()) {
+        // check kid is in the entry and lastUpdate is inside the TTL
+        if (urlKeys.containsKey(kid) && lastUpdate + updateTimeout > currentTime) {
+            return urlKeys;
+        }
+
+        // check the minimum timeout to avoid flooding
+        if (lastUpdate + minTimeBetweenRequests > currentTime) {
+            log.avoidingFetchJwks(url, currentTime);
+            return urlKeys;
+        }
+
+        // update the cached entry because cache is not valid
+        synchronized (cacheEntry) {
+            // re-check just in case another thread updated the entry
+            if ((!cacheEntry.getKeys().containsKey(kid) || cacheEntry.getTimestamp() + updateTimeout <= currentTime)
+                    && cacheEntry.getTimestamp() + minTimeBetweenRequests <= currentTime) {
                 Map<String, RSAPublicKey> newJwks = getJwksFromUrl(url, sslContext, hostnameVerifier);
                 if (newJwks == null) {
                     log.unableToFetchJwks(url.toString());
                     return null;
                 }
-                urlKeys.clear();
-                urlKeys.putAll(newJwks);
-                timeouts.put(url, System.currentTimeMillis());
+                cacheEntry.setKeys(newJwks);
+                cacheEntry.setTimestamp(currentTime);
             }
-            return urlKeys;
+            return cacheEntry.getKeys();
         }
     }
 
@@ -182,11 +197,35 @@ class JwkManager {
                 RSAPublicKey publicKey = (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(keySpec);
                 res.put(kid, publicKey);
             } catch (InvalidKeySpecException | NoSuchAlgorithmException ex) {
-                log.info("Fetched jwk could not be parsed, ignoring...");
-                ex.printStackTrace();
-                continue;
+                log.info("Fetched jwk could not be parsed, ignoring...", ex);
             }
         }
         return res;
+    }
+
+    private static class CacheEntry {
+        private Map<String, RSAPublicKey> keys;
+        private long timestamp;
+
+        public CacheEntry() {
+            this.keys = Collections.emptyMap();
+            this.timestamp = 0;
+        }
+
+        public Map<String, RSAPublicKey> getKeys() {
+            return keys;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public void setKeys(Map<String, RSAPublicKey> keys) {
+            this.keys = keys;
+        }
+
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
     }
 }

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -89,7 +89,7 @@ public class JwtValidator implements TokenValidator {
         if (configuration.sslContext != null) {
             this.jwkManager = new JwkManager(configuration.sslContext,
                                             configuration.hostnameVerifier != null ? configuration.hostnameVerifier : HttpsURLConnection.getDefaultHostnameVerifier(),
-                                            configuration.updateTimeout);
+                                            configuration.updateTimeout, configuration.minTimeBetweenRequests);
         }
         else {
             log.tokenRealmJwtNoSSLIgnoringJku();
@@ -320,6 +320,7 @@ public class JwtValidator implements TokenValidator {
     }
 
     public static class Builder {
+        private static final int MIN_TIME_BETWEEN_REQUESTS = 10000; // 10s
 
         private Set<String> issuers = new LinkedHashSet<>();
         private Set<String> audience = new LinkedHashSet<>();
@@ -328,6 +329,7 @@ public class JwtValidator implements TokenValidator {
         private HostnameVerifier hostnameVerifier;
         private SSLContext sslContext;
         private long updateTimeout = 120000;
+        private int minTimeBetweenRequests = MIN_TIME_BETWEEN_REQUESTS;
 
         private Builder() {
         }
@@ -438,6 +440,18 @@ public class JwtValidator implements TokenValidator {
          */
         public Builder setJkuTimeout(long timeout) {
             this.updateTimeout = timeout;
+            return this;
+        }
+
+        /**
+         * <p>The time in which there will be no more requests to retrieve
+         * the keys from the jkws URL.</p>
+         *
+         * @param minTimeBetweenRequests The time in millis
+         * @return this instance
+         */
+        public Builder setJkuMinTimeBetweenRequests(int minTimeBetweenRequests) {
+            this.minTimeBetweenRequests = minTimeBetweenRequests;
             return this;
         }
 

--- a/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
@@ -246,6 +246,7 @@ public class JwtSecurityRealmTest extends BaseTestCase {
                         .issuer("elytron-oauth2-realm")
                         .audience("my-app-valid")
                         .setJkuTimeout(0) //refresh jwks every time
+                        .setJkuMinTimeBetweenRequests(0)
                         .useSslContext(sslContext)
                         .useSslHostnameVerifier((a,b) -> true).build())
                 .build();
@@ -258,6 +259,72 @@ public class JwtSecurityRealmTest extends BaseTestCase {
         assertIdentityNotExist(securityRealm, evidence1);
 
         server.setDispatcher(createTokenDispatcher(jwksResponse));
+    }
+
+    @Test
+    public void testNewRotationKeys() throws Exception {
+        // set the jku url only with key 1
+        server.setDispatcher(createTokenDispatcher(jwksToJson(jwk1).toString()));
+
+        BearerTokenEvidence evidence1 = new BearerTokenEvidence(createJwt(keyPair1, 60, -1, "1", new URI("https://localhost:50831")));
+
+        X509TrustManager tm = getTrustManager();
+        SSLContext sslContext = new SSLContextBuilder().setTrustManager(tm).setClientMode(true).setSessionTimeout(10).build().create();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setJkuTimeout(60000L) // 60s of cache
+                        .setJkuMinTimeBetweenRequests(0) // no time betweeen requests
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a,b) -> true).build())
+                .build();
+
+        // key 1 should exist
+        assertIdentityExist(securityRealm, evidence1);
+
+        // add a new key 2 to the url using normal response
+        server.setDispatcher(createTokenDispatcher(jwksResponse));
+        BearerTokenEvidence evidence2 = new BearerTokenEvidence(createJwt(keyPair2, 60, -1, "2", new URI("https://localhost:50831")));
+
+        // key 1 and 2 should exist now because time between requests is 0
+        assertIdentityExist(securityRealm, evidence1);
+        assertIdentityExist(securityRealm, evidence2);
+    }
+
+    @Test
+    public void testNewRotationKeysTimeBetweenRequests() throws Exception {
+        // set the jku url only with key 1
+        server.setDispatcher(createTokenDispatcher(jwksToJson(jwk1).toString()));
+
+        BearerTokenEvidence evidence1 = new BearerTokenEvidence(createJwt(keyPair1, 60, -1, "1", new URI("https://localhost:50831")));
+
+        X509TrustManager tm = getTrustManager();
+        SSLContext sslContext = new SSLContextBuilder().setTrustManager(tm).setClientMode(true).setSessionTimeout(10).build().create();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setJkuTimeout(60000L) // 60s of cache
+                        .setJkuMinTimeBetweenRequests(10000) // 10s between calls
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a,b) -> true).build())
+                .build();
+
+        // key 1 should exist
+        assertIdentityExist(securityRealm, evidence1);
+
+        // add a new key 2 to the url using normal response
+        server.setDispatcher(createTokenDispatcher(jwksResponse));
+        BearerTokenEvidence evidence2 = new BearerTokenEvidence(createJwt(keyPair2, 60, -1, "2", new URI("https://localhost:50831")));
+
+        // Same result because the minimum time between request avoids the call
+        assertIdentityExist(securityRealm, evidence1);
+        assertIdentityNotExist(securityRealm, evidence2);
     }
 
     @Test
@@ -363,6 +430,7 @@ public class JwtSecurityRealmTest extends BaseTestCase {
                         .issuer("elytron-oauth2-realm")
                         .audience("my-app-valid")
                         .setJkuTimeout(0) //Keys will be downloaded on every request
+                        .setJkuMinTimeBetweenRequests(0)
                         .useSslContext(sslContext)
                         .useSslHostnameVerifier((a,b) -> true).build())
                 .build();


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2194

The cache in `JwkManager` has been slightly modified:
* The cache is now just one map that contains the returned keys and the update timestamp all together.
* If the `kid` requested is not present in the cached entry the jwks endpoint is refreshed.
* To avoid lots of requests because of the previous point a new `minTimeBetweenRequests` option is introduced (between that time no requests are allowed to the same jwks endpoint).

@fjuma this is just the PR for the maintenance branch 1.10.x. There are several changes in this part of the code so conflicts will be present in main 1.x and maintenance 1.15.x branches when cherry-picking. If you want me to provide PRs for them just let me know. As always if you see any problem or improvement comments are welcomed. :smiley: 

Thanks!