### PR TITLE
[ELY-2149] Enhance logging for silent BASIC authentication mechanism

### DIFF
--- a/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
+++ b/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
@@ -202,6 +202,8 @@ final class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationM
             //otherwise we assume another method will send the challenge
             String authHeader = request.getFirstRequestHeaderValue(AUTHORIZATION);
             if(authHeader == null) {
+                httpBasic.tracef("BASIC authentication mechanism ignored - " +
+                        "configuration is set to silent and request does not contain Authorization header");
                 return;     //CHALLENGE NOT SENT
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2149

Added trace log to indicate the BASIC authentication mechanism is ignored when silent is set and AUTHORIZATION header is not present