### PR TITLE
[ELY-2162] Add parameter validation to the builder setters in JdbcSecurityRealmBuilder

### DIFF
--- a/auth/realm/jdbc/src/main/java/org/wildfly/security/auth/realm/jdbc/JdbcSecurityRealmBuilder.java
+++ b/auth/realm/jdbc/src/main/java/org/wildfly/security/auth/realm/jdbc/JdbcSecurityRealmBuilder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.wildfly.common.Assert;
 import org.wildfly.security.auth.server.RealmIdentity;
 
 /**
@@ -67,6 +68,7 @@ public class JdbcSecurityRealmBuilder {
      * @return this builder.
      */
     public JdbcSecurityRealmBuilder setProviders(Supplier<Provider[]> providers) {
+        Assert.checkNotNullParam("providers", providers);
         this.providers = providers;
 
         return this;
@@ -79,6 +81,7 @@ public class JdbcSecurityRealmBuilder {
      * @return this builder
      */
     public JdbcSecurityRealmBuilder setHashCharset(Charset hashCharset) {
+        Assert.checkNotNullParam("hashCharset", hashCharset);
         this.hashCharset = hashCharset;
 
         return this;


### PR DESCRIPTION
#### Things done:
1. Assert imported
2. Checked providers
3. Checked hashCharset