### PR TITLE
[ELY-2232] Iterate over source `resourceAccessValueMap` instead of empty `resourceAccessClaim`

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/AccessToken.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/AccessToken.java
@@ -77,7 +77,7 @@ public class AccessToken extends JsonWebToken {
         }
         Map<String, Object> resourceAccessValueMap = (Map<String, Object>) resourceAccessValue;
         Map<String, RealmAccessClaim> resourceAccessClaim = new HashMap<>(resourceAccessValueMap.size());
-        for (String key : resourceAccessClaim.keySet()) {
+        for (String key : resourceAccessValueMap.keySet()) {
             Object val = resourceAccessValueMap.get(key);
             resourceAccessClaim.put(key, val == null ? null : new RealmAccessClaim((Map<String, Object>)val));
         }


### PR DESCRIPTION
https://issues.redhat.com/projects/ELY/issues/ELY-2232