### PR TITLE
[ELY-2200] Update org.apache.sshd:sshd-common:2.3.0 to 2.7.0 to eliminate CVE-2021-30129

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
         <version.org.eclipse.microprofile.jwt.api>1.2.2</version.org.eclipse.microprofile.jwt.api>
-        <version.org.apache.sshd.common>2.3.0</version.org.apache.sshd.common>
+        <version.org.apache.sshd.common>2.7.0</version.org.apache.sshd.common>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
 
         <version.org.jboss.logging>3.4.2.Final</version.org.jboss.logging>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2200

WF-Core upgrade: https://issues.redhat.com/browse/WFCORE-5538