### PR TITLE
[ELY-2242] Changed OidcRequestAuthenticator.rewrittenRedirectUri to …

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientContext.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientContext.java
@@ -492,6 +492,11 @@ public class OidcClientContext {
         }
 
         @Override
+        public Map<String, String> getRedirectRewriteRules() {
+            return delegate.getRedirectRewriteRules();
+        }
+
+        @Override
         public boolean isVerifyTokenAudience() {
             return delegate.isVerifyTokenAudience();
         }

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
@@ -387,20 +387,24 @@ public class OidcRequestAuthenticator {
 
     private String rewrittenRedirectUri(String originalUri) {
         Map<String, String> rewriteRules = deployment.getRedirectRewriteRules();
-        if (rewriteRules != null && ! rewriteRules.isEmpty()) {
-            try {
-                URL url = new URL(originalUri);
-                Map.Entry<String, String> rule =  rewriteRules.entrySet().iterator().next();
-                StringBuilder redirectUriBuilder = new StringBuilder(url.getProtocol());
-                redirectUriBuilder.append("://"+ url.getAuthority());
-                redirectUriBuilder.append(url.getPath().replaceFirst(rule.getKey(), rule.getValue()));
-                return redirectUriBuilder.toString();
-            } catch (MalformedURLException ex) {
-                log.error("Not a valid request url");
-                throw new RuntimeException(ex);
+        try {
+            URL url = new URL(originalUri);
+            Map.Entry<String, String> rule = null;
+            if (rewriteRules != null && ! rewriteRules.isEmpty()) {
+                rule =  rewriteRules.entrySet().iterator().next();
             }
+            StringBuilder redirectUriBuilder = new StringBuilder(url.getProtocol());
+            redirectUriBuilder.append("://").append(url.getAuthority());
+            if (rule != null) {
+                redirectUriBuilder.append(url.getPath().replaceFirst(rule.getKey(), rule.getValue()));
+            } else {
+                redirectUriBuilder.append(url.getPath());
+            }
+            return redirectUriBuilder.toString();
+        } catch (MalformedURLException ex) {
+            log.error("Not a valid request url");
+            throw new RuntimeException(ex);
         }
-        return originalUri;
     }
 
     private static String addOidcScopeIfNeeded(String scope) {


### PR DESCRIPTION
[ELY-2242] Changed OidcRequestAuthenticator.rewrittenRedirectUri to behave consistently when a redirect rewrite rule is specified vs when none is. Exposed redirect rewrite rules when OidcClientConfiguration is delegated by OidcClientContext.

https://issues.redhat.com/browse/ELY-2242