### PR TITLE
[ELY-2234] Add use-realm-role-mappings OIDC configuration setting

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
@@ -98,6 +98,7 @@ public class OidcClientConfiguration {
     protected String oidcStateCookiePath = "";
     protected String stateCookieName = "OAuth_Token_Request_State";
     protected boolean useResourceRoleMappings;
+    protected boolean useRealmRoleMappings;
     protected boolean cors;
     protected int corsMaxAge = -1;
     protected String corsAllowedHeaders;
@@ -445,6 +446,14 @@ public class OidcClientConfiguration {
 
     public void setUseResourceRoleMappings(boolean useResourceRoleMappings) {
         this.useResourceRoleMappings = useResourceRoleMappings;
+    }
+
+    public boolean isUseRealmRoleMappings() {
+        return useRealmRoleMappings;
+    }
+
+    public void setUseRealmRoleMappings(boolean useRealmRoleMappings) {
+        this.useRealmRoleMappings = useRealmRoleMappings;
     }
 
     public boolean isCors() {

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfigurationBuilder.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfigurationBuilder.java
@@ -108,6 +108,7 @@ public class OidcClientConfigurationBuilder {
 
         oidcClientConfiguration.setPublicClient(oidcJsonConfiguration.isPublicClient());
         oidcClientConfiguration.setUseResourceRoleMappings(oidcJsonConfiguration.isUseResourceRoleMappings());
+        oidcClientConfiguration.setUseRealmRoleMappings(oidcJsonConfiguration.isUseRealmRoleMappings());
 
         oidcClientConfiguration.setExposeToken(oidcJsonConfiguration.isExposeToken());
 

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientContext.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientContext.java
@@ -346,6 +346,16 @@ public class OidcClientContext {
         }
 
         @Override
+        public boolean isUseRealmRoleMappings() {
+            return delegate.isUseRealmRoleMappings();
+        }
+
+        @Override
+        public void setUseRealmRoleMappings(boolean useRealmRoleMappings) {
+            delegate.setUseRealmRoleMappings(useRealmRoleMappings);
+        }
+
+        @Override
         public boolean isCors() {
             return delegate.isCors();
         }

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  */
 @JsonPropertyOrder({"realm", "realm-public-key", "auth-server-url", "ssl-required",
         "resource", "public-client", "credentials",
-        "use-resource-role-mappings",
+        "use-resource-role-mappings", "use-realm-role-mappings",
         "enable-cors", "cors-max-age", "cors-allowed-methods", "cors-exposed-headers",
         "expose-token", "bearer-only", "autodetect-bearer-only",
         "connection-pool-size",
@@ -99,6 +99,8 @@ public class OidcJsonConfiguration {
     protected String resource;
     @JsonProperty("use-resource-role-mappings")
     protected boolean useResourceRoleMappings;
+    @JsonProperty("use-realm-role-mappings")
+    protected boolean useRealmRoleMappings = true;
     @JsonProperty("enable-cors")
     protected boolean cors;
     @JsonProperty("cors-max-age")
@@ -395,6 +397,14 @@ public class OidcJsonConfiguration {
 
     public void setUseResourceRoleMappings(boolean useResourceRoleMappings) {
         this.useResourceRoleMappings = useResourceRoleMappings;
+    }
+
+    public boolean isUseRealmRoleMappings() {
+        return useRealmRoleMappings;
+    }
+
+    public void setUseRealmRoleMappings(boolean useRealmRoleMappings) {
+        this.useRealmRoleMappings = useRealmRoleMappings;
     }
 
     public boolean isCors() {

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcSecurityRealm.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcSecurityRealm.java
@@ -111,7 +111,8 @@ public class OidcSecurityRealm implements SecurityRealm {
             if (resourceAccessClaim != null) {
                 roles = resourceAccessClaim.getRoles().stream().collect(Collectors.toSet());
             }
-        } else {
+        }
+        if (session.getOidcClientConfiguration().isUseRealmRoleMappings()) {
             if (log.isTraceEnabled()) {
                 log.trace("use realm role mappings");
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2234

Add a new OIDC settings key named 'use-realm-role-mappings' to permit more control over role mappings behavior. This key defaults to 'true'.