### PR TITLE
[ELY-2259] Fix version of wildfly-elytron-http-stateful-basic to be compatible with parent pom

### DIFF
--- a/http/stateful-basic/pom.xml
+++ b/http/stateful-basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron-parent</artifactId>
-        <version>1.15.9.CR1-SNAPSHOT</version>
+        <version>1.17.3.CR1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2259