### PR TITLE
[ELY-2286] make the interfaces OidcHttpFacade.Request/Response and PublicKeyResolver public

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcHttpFacade.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcHttpFacade.java
@@ -495,7 +495,7 @@ public class OidcHttpFacade {
         return this.securityIdentity != null;
     }
 
-    interface Request {
+    public interface Request {
 
         String getMethod();
         /**
@@ -538,7 +538,7 @@ public class OidcHttpFacade {
         void setError(LogoutError error);
     }
 
-    interface Response {
+    public interface Response {
         void setStatus(int status);
         void addHeader(String name, String value);
         void setHeader(String name, String value);

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/PublicKeyLocator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/PublicKeyLocator.java
@@ -26,7 +26,7 @@ import java.security.PublicKey;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-interface PublicKeyLocator {
+public interface PublicKeyLocator {
 
     /**
      * @param kid the key id


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2286

The Interfaces OidcHttpFacade.Request must be public to allow implementing OidcClientConfigurationResolver.

I assume that's okay since the methods getRequest/getResponse in OidcHttpFacace are public anyway, but not really usable without the type.

It would be nice to have the PublicKeyResolver-Interface public as well, so that we can implement our own.