### PR TITLE
[ELY-2284] Wildfly OIDC secured App generates a lot of keycloak requests

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
@@ -167,28 +167,37 @@ public class OidcClientConfiguration {
 
     public void setProviderUrl(String providerUrl) {
         this.providerUrl = providerUrl;
+        resetUrls();
     }
 
 
     public void setAuthServerBaseUrl(OidcJsonConfiguration config) {
         this.authServerBaseUrl = config.getAuthServerUrl();
-        if (authServerBaseUrl == null) return;
+        resetUrls();
+    }
+
+    /**
+     * Resets all calculated urls to null and sets the relativeUrls field
+     * depending the value of the current discovery URL in the configuration.
+     * If it is relative is set to ALWAYS and if absolute is set to NEVER.
+     */
+    protected void resetUrls() {
         authUrl = null;
-        providerUrl = null;
         tokenUrl = null;
         logoutUrl = null;
         accountUrl = null;
         registerNodeUrl = null;
         unregisterNodeUrl = null;
         jwksUrl = null;
-
-        URI authServerUri = URI.create(authServerBaseUrl);
-
-        if (authServerUri.getHost() == null) {
-            relativeUrls = RelativeUrlsUsed.ALWAYS;
-        } else {
-            // We have absolute URI in config
-            relativeUrls = RelativeUrlsUsed.NEVER;
+        relativeUrls = null;
+        if (providerUrl != null || authServerBaseUrl != null) {
+            URI uri = URI.create(providerUrl != null? providerUrl : authServerBaseUrl);
+            if (uri.getHost() == null) {
+                relativeUrls = RelativeUrlsUsed.ALWAYS;
+            } else {
+                // We have absolute URI in config
+                relativeUrls = RelativeUrlsUsed.NEVER;
+            }
         }
     }
 

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -216,6 +216,8 @@ public class OidcTest extends AbstractBaseHttpTest {
         try {
             Map<String, Object> props = new HashMap<>();
             OidcClientConfiguration oidcClientConfiguration = OidcClientConfigurationBuilder.build(oidcConfig);
+            assertEquals(OidcClientConfiguration.RelativeUrlsUsed.NEVER, oidcClientConfiguration.getRelativeUrls());
+
             OidcClientContext oidcClientContext = new OidcClientContext(oidcClientConfiguration);
             oidcFactory = new OidcMechanismFactory(oidcClientContext);
             HttpServerAuthenticationMechanism mechanism = oidcFactory.createAuthenticationMechanism(OIDC_NAME, props, getCallbackHandler());


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2284

Setting `providerUrl` instead of `authServerBaseUrl` in the OIDC configuration did not calculate the `relativeUrls` and [the implementation refreshed the context](https://github.com/wildfly-security/wildfly-elytron/blob/1.18.1.Final/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientContext.java#L91-L102) in every request. Now both setters reset the calculated URLs and the relative field. The OIDC test is modified to check that the relative field is correctly set to NEVER with a normal configuration that uses an absolute URL.

@fjuma If you need the PR in another branch different to 1.x just let me know.