### PR TITLE
[ELY-2067] Elytron tool should log a warning that mask password command is not FIPS compliant

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -502,4 +502,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Invalid \"%s\" parameter. Generated value \"%s\" will be used.")
     String invalidParameterGeneratedWillBeUsed(String parameter, String value);
+
+    @Message(id = NONE, value = "Mask password operation is not allowed in FIPS mode.")
+    String fipsModeNotAllowed();
 }

--- a/tool/src/main/java/org/wildfly/security/tool/MaskCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/MaskCommand.java
@@ -18,6 +18,7 @@
 package org.wildfly.security.tool;
 
 import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -71,6 +72,10 @@ class MaskCommand extends Command {
 
     @Override
     public void execute(String[] args) throws Exception {
+        if (new SecureRandom().getProvider().getName().toLowerCase().contains("fips")) {
+            System.out.println(ElytronToolMessages.msg.fipsModeNotAllowed());
+            return;
+        }
         setStatus(GENERAL_CONFIGURATION_ERROR);
         cmdLine = parser.parse(options, args, false);
         setEnableDebug(cmdLine.hasOption(DEBUG_PARAM));


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2067