### PR TITLE
ELY-2286: interface OidcHttpFacade.Request must be public to allow implementing OidcClientConfigurationResolver.

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcHttpFacade.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcHttpFacade.java
@@ -495,7 +495,7 @@ public class OidcHttpFacade {
         return this.securityIdentity != null;
     }
 
-    interface Request {
+    public interface Request {
 
         String getMethod();
         /**
@@ -538,7 +538,7 @@ public class OidcHttpFacade {
         void setError(LogoutError error);
     }
 
-    interface Response {
+    public interface Response {
         void setStatus(int status);
         void addHeader(String name, String value);
         void setHeader(String name, String value);

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/PublicKeyLocator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/PublicKeyLocator.java
@@ -26,7 +26,7 @@ import java.security.PublicKey;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
  */
-interface PublicKeyLocator {
+public interface PublicKeyLocator {
 
     /**
      * @param kid the key id


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-23106
Upstream issue: https://issues.redhat.com/browse/ELY-2286
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1653