### PR TITLE
[ELY-2294] Failures in the WFCORE test-suite with branch 1.x

### DIFF
--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -138,6 +138,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
      * @param encoded whether identity names should be BASE32 encoded before using as filename
      * @param hashCharset the character set to use when converting password strings to a byte array. Uses UTF-8 by default.
      * @param hashEncoding the string format for the hashed passwords. Uses Base64 by default.
+     * @param providers The providers supplier
      */
     public FileSystemSecurityRealm(final Path root, final NameRewriter nameRewriter, final int levels, final boolean encoded, final Encoding hashEncoding, final Charset hashCharset, Supplier<Provider[]> providers) {
         final SecurityManager sm = System.getSecurityManager();
@@ -151,6 +152,22 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
         this.hashCharset = hashCharset != null ? hashCharset : StandardCharsets.UTF_8;
         this.hashEncoding = hashEncoding != null ? hashEncoding : Encoding.BASE64;
         this.providers = providers;
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * Construction with enabled security manager requires {@code createSecurityRealm} {@link ElytronPermission}.
+     *
+     * @param root the root path of the identity store
+     * @param nameRewriter the name rewriter to apply to looked up names
+     * @param levels the number of levels of directory hashing to apply
+     * @param encoded whether identity names should be BASE32 encoded before using as filename
+     * @param hashCharset the character set to use when converting password strings to a byte array. Uses UTF-8 by default.
+     * @param hashEncoding the string format for the hashed passwords. Uses Base64 by default.
+     */
+    public FileSystemSecurityRealm(final Path root, final NameRewriter nameRewriter, final int levels, final boolean encoded, final Encoding hashEncoding, final Charset hashCharset) {
+        this(root, nameRewriter, levels, encoded, hashEncoding, hashCharset, INSTALLED_PROVIDERS);
     }
 
     /**

--- a/http/basic/src/main/java/org/wildfly/security/http/basic/BasicMechanismFactory.java
+++ b/http/basic/src/main/java/org/wildfly/security/http/basic/BasicMechanismFactory.java
@@ -45,6 +45,9 @@ public class BasicMechanismFactory implements HttpServerAuthenticationMechanismF
     public BasicMechanismFactory() {
     }
 
+    public BasicMechanismFactory(final Provider provider) {
+    }
+
     public BasicMechanismFactory(final Provider... providers) {
     }
 

--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestMechanismFactory.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestMechanismFactory.java
@@ -57,6 +57,10 @@ public class DigestMechanismFactory implements HttpServerAuthenticationMechanism
         providers = INSTALLED_PROVIDERS;
     }
 
+    public DigestMechanismFactory(final Provider provider) {
+        this(new Provider[] { provider });
+    }
+
     public DigestMechanismFactory(final Provider... providers) {
         this.providers = () -> providers;
     }

--- a/http/external/src/main/java/org/wildfly/security/http/external/ExternalMechanismFactory.java
+++ b/http/external/src/main/java/org/wildfly/security/http/external/ExternalMechanismFactory.java
@@ -42,6 +42,9 @@ public class ExternalMechanismFactory implements HttpServerAuthenticationMechani
     public ExternalMechanismFactory() {
     }
 
+    public ExternalMechanismFactory(final Provider provider) {
+    }
+
     public ExternalMechanismFactory(final Provider... providers) {
     }
 

--- a/tests/base/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
@@ -37,7 +37,10 @@ import javax.security.auth.callback.CallbackHandler;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.wildfly.security.http.digest.WildFlyElytronHttpDigestProvider;
 import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+import org.wildfly.security.http.util.SecurityProviderServerMechanismFactory;
 
 import mockit.integration.junit4.JMockit;
 
@@ -198,6 +201,37 @@ public class HttpAuthenticatorTest extends AbstractBaseHttpTest {
     public void testBasicSilentWithDigest() throws Exception{
         // authenticate using only DIGEST mechanism
         prepareSilentBasicWithDigestMechanisms();
+        authenticateWithDigestMD5();
+    }
+
+    public void prepareSecurityProviderServerMechanismWithDigestMD5() throws Exception {
+        mockDigestNonce("7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v");
+
+        final List<HttpServerAuthenticationMechanism> mechanisms = new LinkedList<>();
+        Map<String, Object> digestProps = new HashMap<>();
+        digestProps.put(CONFIG_REALM, "http-auth@example.org");
+        digestProps.put("org.wildfly.security.http.validate-digest-uri", "false");
+        HttpServerAuthenticationMechanismFactory fact = new SecurityProviderServerMechanismFactory(WildFlyElytronHttpDigestProvider.getInstance());
+        mechanisms.add(fact.createAuthenticationMechanism(DIGEST_NAME, digestProps, callbackHandler()));
+
+        authenticator = HttpAuthenticator.builder()
+                .setMechanismSupplier(() -> mechanisms)
+                .setHttpExchangeSpi(exchangeSpi)
+                .setRequired(true)
+                .build();
+    }
+
+    @Test
+    public void testUsingSecurityProviderServerMechanismWithDigestMD5() throws Exception {
+        prepareSecurityProviderServerMechanismWithDigestMD5();
+
+        Assert.assertFalse(authenticator.authenticate());
+        List<String> responses = exchangeSpi.getResponseAuthenticateHeaders();
+        assertEquals("DIGEST response is received", 1, responses.size());
+        Assert.assertEquals(UNAUTHORIZED, exchangeSpi.getStatusCode());
+        Assert.assertEquals(null, exchangeSpi.getResult());
+        exchangeSpi.setStatusCode(0);
+
         authenticateWithDigestMD5();
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2294

Two issues related to [ELY-2271](https://issues.redhat.com/browse/ELY-2271) that make wfcore test-suite fail several times. One constructor was renamed in `FileSystemSecurityRealm` (it was used in core and core doesn't compile). Implementations of the interface `HttpServerAuthenticationMechanismFactory` need a constructor with a single `Provider` argument (it is used by the `SecurityProviderServerMechanismFactory` via reflection). I decided to restore back the constructor in the three modified classes (I think this solution is simpler than adding the new constructor in all the others classes). If you think different just let me know.

A little test was also added to create a digest mech through the failing `SecurityProviderServerMechanismFactory`.