### PR TITLE
[ELY-2295] Algorithm alias "Data" generates errors in WFCORE test-suite with jdk-18

### DIFF
--- a/base/src/main/java/org/wildfly/security/WildFlyElytronBaseProvider.java
+++ b/base/src/main/java/org/wildfly/security/WildFlyElytronBaseProvider.java
@@ -61,7 +61,6 @@ public abstract class WildFlyElytronBaseProvider extends VersionedProvider {
 
     protected WildFlyElytronBaseProvider(final String name, final String version, final String info) {
         super(name, version, info);
-        put("Alg.Alias.Data.OID.1.2.840.113549.1.7.1", "Data");
     }
 
     protected void putPasswordImplementations() {

--- a/base/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
+++ b/base/src/main/java/org/wildfly/security/WildFlyElytronProvider.java
@@ -67,7 +67,6 @@ public class WildFlyElytronProvider extends VersionedProvider {
         putSaslMechanismImplementations();
         putCredentialStoreProviderImplementations();
         putAlgorithmParametersImplementations();
-        put("Alg.Alias.Data.OID.1.2.840.113549.1.7.1", "Data");
         putService(new Service(this, "SecretKeyFactory", "1.2.840.113549.1.7.1", "org.wildfly.security.key.RawSecretKeyFactory", Collections.emptyList(), Collections.emptyMap()));
         putService(new Service(this, "MessageDigest", "SHA-512-256", "org.wildfly.security.digest.SHA512_256MessageDigest", Collections.emptyList(), Collections.emptyMap()));
     }

--- a/credential/store/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
+++ b/credential/store/src/test/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStoreTest.java
@@ -81,12 +81,12 @@ public class KeyStoreCredentialStoreTest {
     @Parameters(name = "format={0}")
     public static Iterable<Object[]> keystoreFormats() {
         final String vendor = System.getProperty("java.vendor");
-        if ("Oracle Corporation".equals(vendor)) {
-            return Arrays.asList(new Object[] { "JCEKS" }, new Object[] { "PKCS12" });
-        } else {
+        if (vendor.contains("IBM") || vendor.toLowerCase().contains("hewlett")) {
             // IBM PKCS12 does not allow storing PasswordCredential (and requires singed JAR)
             // HP requires signed JAR
             return Collections.singletonList(new Object[] { "JCEKS" });
+        } else {
+            return Arrays.asList(new Object[] { "JCEKS" }, new Object[] { "PKCS12" });
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2295

Just removing the alias `Data` that was added using the legacy method. It is discarded by the jdk now (no real legacy service associated), so it is invalid and useless. With jdk-18 build 28 the alias generates failures in the wfcore test-suite.

The test `KeyStoreCredentialStoreTest` is also modified to test the PKCS12 credential key store with more jdk implementations (in version 11 it works for all of them, openjdk, zulu, openj9, ibm,... So better discard the ones we know that fail instead of only allowing the oracle vendor).