### PR TITLE
[JBEAP-23123] [ELY-2298] [ELY-303] Verify compatibility with RFC2617 Digest Access Authentica…

### DIFF
--- a/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
+++ b/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
@@ -136,7 +136,7 @@ final class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationM
         List<String> authorizationValues = request.getRequestHeaderValues(AUTHORIZATION);
         if (authorizationValues != null) {
             for (String current : authorizationValues) {
-                if (current.startsWith(CHALLENGE_PREFIX)) {
+                if (current.regionMatches(true, 0, CHALLENGE_PREFIX, 0, PREFIX_LENGTH)) {
                     byte[] decodedValue = ByteIterator.ofBytes(current.substring(PREFIX_LENGTH).getBytes(UTF_8)).asUtf8String().base64Decode().drain();
 
                     // Note: A ':' can not be present in the username but it can be present in the password so the first ':' is the delimiter.

--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -119,7 +119,7 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
 
         if (authorizationValues != null) {
             for (String current : authorizationValues) {
-                if (current.startsWith(CHALLENGE_PREFIX)) {
+                if (current.regionMatches(true, 0, CHALLENGE_PREFIX, 0, CHALLENGE_PREFIX.length())) {
                     byte[] rawHeader = current.substring(CHALLENGE_PREFIX.length()).getBytes(UTF_8);
                     try {
                         HashMap<String, byte[]> responseTokens = parseResponse(rawHeader, UTF_8, false, httpDigest);

--- a/http/stateful-basic/src/main/java/org/wildfly/security/http/sfbasic/BasicAuthenticationMechanism.java
+++ b/http/stateful-basic/src/main/java/org/wildfly/security/http/sfbasic/BasicAuthenticationMechanism.java
@@ -151,7 +151,7 @@ final class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationM
         List<String> authorizationValues = request.getRequestHeaderValues(AUTHORIZATION);
         if (authorizationValues != null) {
             for (String current : authorizationValues) {
-                if (current.startsWith(CHALLENGE_PREFIX)) {
+                if (current.regionMatches(true, 0, CHALLENGE_PREFIX, 0, PREFIX_LENGTH)) {
                     byte[] decodedValue = ByteIterator.ofBytes(current.substring(PREFIX_LENGTH).getBytes(UTF_8)).asUtf8String().base64Decode().drain();
 
                     // Note: A ':' can not be present in the username but it can be present in the password so the first ':' is the delimiter.

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -389,6 +389,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-http-stateful-basic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http-digest</artifactId>
         </dependency>
         <dependency>

--- a/tests/base/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/HttpAuthenticatorTest.java
@@ -54,9 +54,9 @@ import static org.wildfly.security.http.HttpConstants.OK;
 @RunWith(JMockit.class)
 public class HttpAuthenticatorTest extends AbstractBaseHttpTest {
 
-    private TestingHttpExchangeSpi exchangeSpi = new TestingHttpExchangeSpi();
+    private final TestingHttpExchangeSpi exchangeSpi = new TestingHttpExchangeSpi();
     private HttpAuthenticator authenticator;
-    private String digestHeader = "Digest username=\"Mufasa\",\n" +
+    private final String digestHeader = "Digest username=\"Mufasa\",\n" +
             "       realm=\"http-auth@example.org\",\n" +
             "       uri=\"/dir/index.html\",\n" +
             "       algorithm=MD5,\n" +
@@ -66,6 +66,16 @@ public class HttpAuthenticatorTest extends AbstractBaseHttpTest {
             "       qop=auth,\n" +
             "       response=\"8ca523f5e9506fed4657c9700eebdbec\",\n" +
             "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\"";
+    private final String digestSha256Header  = "Digest username=\"Mufasa\",\n"
+            + "       realm=\"http-auth@example.org\",\n"
+            + "       uri=\"/dir/index.html\",\n"
+            + "       algorithm=SHA-256,\n"
+            + "       nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\",\n"
+            + "       nc=00000001,\n"
+            + "       cnonce=\"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ\",\n"
+            + "       qop=auth,\n"
+            + "       response=\"753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\",\n"
+            + "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\"";
 
     private CallbackHandler callbackHandler() {
         return getCallbackHandler("Mufasa", "http-auth@example.org", "Circle of Life");
@@ -137,21 +147,32 @@ public class HttpAuthenticatorTest extends AbstractBaseHttpTest {
     }
 
     @Test
-    public void testDigestSha256() throws Exception {
+    public void testBasicCaseInsensitive() throws Exception {
         testOneOfThree();
 
         exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList(
-                "Digest username=\"Mufasa\",\n" +
-                        "       realm=\"http-auth@example.org\",\n" +
-                        "       uri=\"/dir/index.html\",\n" +
-                        "       algorithm=SHA-256,\n" +
-                        "       nonce=\"7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v\",\n" +
-                        "       nc=00000001,\n" +
-                        "       cnonce=\"f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ\",\n" +
-                        "       qop=auth,\n" +
-                        "       response=\"753927fa0e85d155564e2e272a28d1802ca10daf4496794697cf8db5856cb6c1\",\n" +
-                        "       opaque=\"FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS\""
+                "BASIC TXVmYXNhOkNpcmNsZSBvZiBMaWZl"
         ));
+        Assert.assertTrue("Basic successful", authenticator.authenticate());
+        Assert.assertEquals(0, exchangeSpi.getStatusCode());
+        Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());
+    }
+
+    @Test
+    public void testDigestSha256() throws Exception {
+        testOneOfThree();
+
+        exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList(digestSha256Header));
+        Assert.assertTrue("Digest-SHA-256 successful", authenticator.authenticate());
+        Assert.assertEquals(0, exchangeSpi.getStatusCode());
+        Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());
+    }
+
+    @Test
+    public void testDigestSha256CaseInsensitive() throws Exception {
+        testOneOfThree();
+
+        exchangeSpi.setRequestAuthorizationHeaders(Collections.singletonList("DIGEST " + digestSha256Header.substring(7)));
         Assert.assertTrue("Digest-SHA-256 successful", authenticator.authenticate());
         Assert.assertEquals(0, exchangeSpi.getStatusCode());
         Assert.assertEquals(Status.COMPLETE, exchangeSpi.getResult());

--- a/tests/base/src/test/java/org/wildfly/security/http/basic/BasicAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/basic/BasicAuthenticationMechanismTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.http.basic;
+
+import java.util.Collections;
+import java.util.List;
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.http.HttpConstants;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+import org.wildfly.security.http.sfbasic.BasicMechanismFactory;
+
+/**
+ * Test for the Basic and stateful Basic HTTP mechanisms. Using the examples
+ * from the <a href="https://datatracker.ietf.org/doc/html/rfc7617">rfc7617</a>.
+ *
+ * @author rmartinc
+ */
+@RunWith(JMockit.class)
+public class BasicAuthenticationMechanismTest extends AbstractBaseHttpTest {
+
+    public void testBasic(String username, String realm, String password, String authorization) throws Exception {
+        HttpServerAuthenticationMechanism mechanism = basicFactory.createAuthenticationMechanism(HttpConstants.BASIC_NAME,
+                Collections.singletonMap(HttpConstants.CONFIG_REALM, realm), getCallbackHandler(username, realm, password));
+
+        // request without authorization, it should be 401 and response added
+        TestingHttpServerRequest request = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(Status.NO_AUTH, request.getResult());
+        TestingHttpServerResponse response = request.getResponse();
+        Assert.assertEquals(HttpConstants.UNAUTHORIZED, response.getStatusCode());
+        Assert.assertEquals("Basic realm=\"" + realm + "\"", response.getAuthenticateHeader());
+
+        // send the authorization header and check everything OK
+        request = new TestingHttpServerRequest(new String[] {authorization});
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(AbstractBaseHttpTest.Status.COMPLETE, request.getResult());
+    }
+
+    @Test
+    public void testBasicRFC7617Examples() throws Exception {
+        testBasic("Aladdin", "WallyWorld", "open sesame", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        testBasic("test", "foo", "123\u00A3", "Basic dGVzdDoxMjPCow==");
+        // test case insensitive
+        testBasic("Aladdin", "WallyWorld", "open sesame", "basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        testBasic("test", "foo", "123\u00A3", "BASIC dGVzdDoxMjPCow==");
+    }
+
+    public void testStatefulBasic(String username, String realm, String password, String authorization) throws Exception {
+        HttpServerAuthenticationMechanism mechanism = statefulBasicFactory.createAuthenticationMechanism(BasicMechanismFactory.STATEFUL_BASIC_NAME,
+                Collections.singletonMap(HttpConstants.CONFIG_REALM, realm), getCallbackHandler(username, realm, password));
+
+        // request without authorization, it should be 401 and response added
+        TestingHttpServerRequest request = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(Status.NO_AUTH, request.getResult());
+        TestingHttpServerResponse response = request.getResponse();
+        Assert.assertEquals(HttpConstants.UNAUTHORIZED, response.getStatusCode());
+        Assert.assertEquals("Basic realm=\"" + realm + "\"", response.getAuthenticateHeader());
+
+        // send the authorization header and check everything OK
+        request = new TestingHttpServerRequest(new String[] {authorization});
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(AbstractBaseHttpTest.Status.COMPLETE, request.getResult());
+        response = request.getResponse();
+        List<HttpServerCookie> cookies =  response.getCookies();
+        Assert.assertNotNull(cookies);
+        Assert.assertEquals(1, cookies.size());
+        Assert.assertEquals(BasicMechanismFactory.COOKIE_NAME, cookies.get(0).getName());
+
+        // send just the cookie and it should work again
+        request = new TestingHttpServerRequest(null, null, cookies);
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(AbstractBaseHttpTest.Status.COMPLETE, request.getResult());
+    }
+
+    @Test
+    public void testStatefulBasicRFC7617Examples() throws Exception {
+        testStatefulBasic("Aladdin", "WallyWorld", "open sesame", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        testStatefulBasic("test", "foo", "123\u00A3", "Basic dGVzdDoxMjPCow==");
+        // test case insensitive
+        testStatefulBasic("Aladdin", "WallyWorld", "open sesame", "basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        testStatefulBasic("test", "foo", "123\u00A3", "BASIC dGVzdDoxMjPCow==");
+    }
+}


### PR DESCRIPTION
[ELY-2298] Verify compatibility with RFC2617 Digest Access Authentication
[ELY-303] Verify compatibility with RFC7617 "The 'Basic' HTTP Authentication Scheme"

Issue: https://issues.redhat.com/browse/JBEAP-23123

Fix for JBEAP-23123 in the maintenance branch 1.15.x. It combines ELY-2298 and ELY-303. Changes:

* Digest and Basic mechs now use `regionMatches` with insensitive case to fix the main issue.
* Specific test `BasicAuthenticationMechanismTest` for basic using the examples show in RFC2617 (ELY-303). Added `sfbasic` dependency for the `test` project.
* Two more tests in `HttpAuthenticatorTest` to check that the mech token can be sent by the client in any case.

Just a warning for doing the forward port to 1.x. There is a little conflict in [this section](https://github.com/rmartinc/wildfly-elytron/blob/12cbc43817a6a70a964560c9562f3b827c088e37/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java#L89-L92), just add the new line needed for the stateful basic factory and maintain the previous three lines as they are in master.

Regards!