### PR TITLE
[ELY-2304] Location is required even for non-filebased type e.g. PKCS11

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -497,7 +497,10 @@ class CredentialStoreCommand extends Command {
         }
 
         // Get the original attributes of the credential store
-        Map<String, Object> locationAttributes = readAttributesForPreservation(Paths.get(location));
+        Map<String, Object> locationAttributes = null;
+        if (location != null) {
+            locationAttributes = readAttributesForPreservation(Paths.get(location));
+        }
 
         credentialStore.store(alias, createCredential(secret, entryType));
         credentialStore.flush();
@@ -509,7 +512,9 @@ class CredentialStoreCommand extends Command {
         setStatus(ElytronTool.ElytronToolExitStatus_OK);
 
         // Restore the original attributes of the credential store
-        setAttributesForPreservation(Paths.get(location), locationAttributes);
+        if (location != null) {
+            setAttributesForPreservation(Paths.get(location), locationAttributes);
+        }
     }
 
     private void removeAlias(CredentialStore credentialStore, String entryType, String storeType) throws Exception {

--- a/tool/src/test/java/org/wildfly/security/tool/CredentialStoreCommandTest.java
+++ b/tool/src/test/java/org/wildfly/security/tool/CredentialStoreCommandTest.java
@@ -221,6 +221,24 @@ public class CredentialStoreCommandTest extends AbstractCommandTest {
     }
 
     @Test
+    public void testAddAliasCustomWithoutLocation() throws Exception {
+        String storagePassword = "cspassword";
+        String aliasName = "testalias";
+        String aliasValue = "secret";
+
+        // just create the alias with no location, it should work on memory
+        String[] argsCreate = {
+            "--create",
+            "--credential-store-provider=" + CustomPropertiesProvider.CUSTOM_PROPERTIES_PROVIDER,
+            "--type=" + CustomPropertiesCredentialStore.CUSTOM_PROPERTIES_CREDENTIAL_STORE,
+            "--add", aliasName,
+            "--secret", aliasValue,
+            "--summary",
+            "--password", storagePassword};
+        executeCommandAndCheckStatus(argsCreate);
+    }
+
+    @Test
     public void testAliasesList() {
         String storageLocation = getStoragePathForNewFile();
         String storagePassword = "cspassword";


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2304

Little check for the `location` before saving/restoring its file permissions. JCEKS, PKCS12 or JKS types require a location and that condition is checked previously. So
at this point `location` can happen to be `null` if the type does not require it (PKCS11 is an example).