### PR TITLE
ELY-2308: Fix digest authentication for requests with encoded query parameters

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -282,7 +282,7 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             if (query == null || query.isEmpty()) {
                 relativeRequestUri = requestURI.getPath();
             } else {
-                relativeRequestUri = requestURI.getPath() + "?" + requestURI.getQuery();
+                relativeRequestUri = requestURI.getPath() + "?" + requestURI.getRawQuery();
             }
 
             return relativeRequestUri.equals(digestUriStr);

--- a/tests/base/src/test/java/org/wildfly/security/http/digest/DigestAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/digest/DigestAuthenticationMechanismTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 import org.wildfly.security.http.impl.AbstractBaseHttpTest;
 
+import java.net.URI;
 import java.security.Provider;
 import java.security.Security;
 import java.util.HashMap;
@@ -86,6 +87,32 @@ public class DigestAuthenticationMechanismTest extends AbstractBaseHttpTest {
                 "                 opaque=\"00000000000000000000000000000000\",\n" +
                 "                 algorithm=MD5"
         });
+        mechanism.evaluateRequest(request2);
+        Assert.assertEquals(Status.COMPLETE, request2.getResult());
+    }
+
+    @Test
+    public void testRfc2617EncodedQuery() throws Exception {
+        mockDigestNonce("AAAAAQABsxiWa25/kpFxsPCrpDCFsjkTzs/Xr7RPsi/VVN6faYp21Hia3h4=");
+        Map<String, Object> props = new HashMap<>();
+        props.put(CONFIG_REALM, "testrealm@host.com");
+        props.put("org.wildfly.security.http.validate-digest-uri", "true");
+        HttpServerAuthenticationMechanism mechanism = digestFactory.createAuthenticationMechanism(DIGEST_NAME, props, getCallbackHandler("Mufasa", "testrealm@host.com", "Circle Of Life"));
+
+        String path = "/dir/index.html?foo=b%2Fr";
+        String uri = "http://localhost" + path;
+        TestingHttpServerRequest request2 = new TestingHttpServerRequest(new String[] {
+                "Digest username=\"Mufasa\",\n" +
+                        "                 realm=\"testrealm@host.com\",\n" +
+                        "                 nonce=\"dcd98b7102dd2f0e8b11d0f600bfb0c093\",\n" +
+                        "                 uri=\"" + path + "\",\n" +
+                        "                 qop=auth,\n" +
+                        "                 nc=00000001,\n" +
+                        "                 cnonce=\"0a4f113b\",\n" +
+                        "                 response=\"9f4c595c275c13d41d65043d3a509abe\",\n" +
+                        "                 opaque=\"00000000000000000000000000000000\",\n" +
+                        "                 algorithm=MD5"
+        }, new URI(uri));
         mechanism.evaluateRequest(request2);
         Assert.assertEquals(Status.COMPLETE, request2.getResult());
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2308