### PR TITLE
[ELY-2312] Support encrypting an existing PasswordCredential from the credential store.

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -65,6 +65,7 @@ import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.credential.store.impl.PropertiesCredentialStore;
 import org.wildfly.security.encryption.CipherUtil;
 import org.wildfly.security.encryption.SecretKeyUtil;
+import org.wildfly.security.password.Password;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.pem.Pem;
 
@@ -124,6 +125,7 @@ class CredentialStoreCommand extends Command {
     public static final String KEY_PARAM = "key";
     public static final String ENCRYPT = "encrypt";
     public static final String CLEAR_TEXT = "clear-text";
+    public static final String ENTRY = "entry";
 
     private static final List<String> filebasedKeystoreTypes = Collections.unmodifiableList(Arrays.asList("JKS", "JCEKS", "PKCS12"));
 
@@ -196,11 +198,19 @@ class CredentialStoreCommand extends Command {
                 .argName("key")
                 .desc(ElytronToolMessages.msg.key())
                 .build());
+
+        // This pair (clear-text and entry) are mutually exclusive but we will check later.
         options.addOption(Option.builder()
                 .longOpt(CLEAR_TEXT)
                 .hasArg()
                 .argName("clear text")
                 .desc(ElytronToolMessages.msg.clearText())
+                .build());
+        options.addOption(Option.builder()
+                .longOpt(ENTRY)
+                .hasArg()
+                .argName(ALIAS_ARGUMENT)
+                .desc(ElytronToolMessages.msg.cmdLineEntryDesc())
                 .build());
 
         OptionGroup og = new OptionGroup(); // Mutually Exclusive Options (Actions)
@@ -475,7 +485,7 @@ class CredentialStoreCommand extends Command {
 
             } else if (cmdLine.hasOption(ALIASES_PARAM) || cmdLine.hasOption(CHECK_ALIAS_PARAM) ) {
                 com.append("/subsystem=elytron/credential-store=test:read-aliases()");
-            } else if (cmdLine.hasOption(ENCRYPT)) {
+            } else if (cmdLine.hasOption(ENCRYPT) && cipherTextToken != null) {
                 getUseExpressionExample(com, cipherTextToken);
             } else if (cmdLine.hasOption(CREATE_CREDENTIAL_STORE_PARAM)){
                 if (PropertiesCredentialStore.NAME.equals(csType)) {
@@ -794,7 +804,27 @@ class CredentialStoreCommand extends Command {
             final SecretKey secretKey = credentialStore.retrieve(alias, SecretKeyCredential.class).getSecretKey();
 
             String clearText = cmdLine.getOptionValue(CLEAR_TEXT);
-            if (clearText == null) {
+            String entry = cmdLine.getOptionValue(ENTRY);
+            if (clearText != null && entry != null) {
+                throw ElytronToolMessages.msg.mutuallyExclusiveOptions(CLEAR_TEXT, ENTRY);
+            }
+
+            if (entry != null) {
+                if (credentialStore.exists(entry, PasswordCredential.class)) {
+                    final Password password = credentialStore.retrieve(entry, PasswordCredential.class).getPassword();
+                    if (password instanceof ClearPassword) {
+                        clearText = new String(((ClearPassword) password).getPassword());
+                    } else {
+                        setStatus(ALIAS_NOT_FOUND);
+                        System.out.println(ElytronToolMessages.msg.passwordCredentialNotClearText());
+                        return null;
+                    }
+                } else {
+                    setStatus(ALIAS_NOT_FOUND);
+                    System.out.println(ElytronToolMessages.msg.aliasDoesNotExist(alias));
+                    return null;
+                }
+            } else if (clearText == null) {
                 clearText = prompt(false, ElytronToolMessages.msg.clearTextToImport(), true, ElytronToolMessages.msg.clearTextToImportAgain());
             }
 

--- a/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -85,6 +85,9 @@ public interface ElytronToolMessages extends BasicLogger {
     @Message(id = NONE, value = "Password credential value")
     String cmdLinePasswordCredentialValueDesc();
 
+    @Message(id = NONE, value = "The alias of the existing password entry to encrypt")
+    String cmdLineEntryDesc();
+
     @Message(id = NONE, value = "Type of entry in credential store")
     String cmdLineEntryTypeDesc();
 
@@ -203,6 +206,9 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "Confirm secret to store: ")
     String secretToStorePromptConfirm();
+
+    @Message(id = NONE, value = "The retrieved PasswordCredential does not contain a ClearTextPassword")
+    String passwordCredentialNotClearText();
 
     // mask command
     @Message(id = NONE, value = "\"mask\" command is used to get MASK- string encrypted using PBEWithMD5AndDES in PicketBox compatible way.")
@@ -596,4 +602,9 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "No Credential Store location or Secret Key Alias specified.")
     MissingOptionException missingCredentialStoreSecretKey();
+    
+    // Numeric Errors
+    @Message(id = 35, value = "Only one of '%s' and '%s' can be specified at the same time")
+    IllegalArgumentException mutuallyExclusiveOptions(String first, String second);
+
 }

--- a/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
+++ b/tool/src/main/java/org/wildfly/security/tool/ElytronToolMessages.java
@@ -602,7 +602,7 @@ public interface ElytronToolMessages extends BasicLogger {
 
     @Message(id = NONE, value = "No Credential Store location or Secret Key Alias specified.")
     MissingOptionException missingCredentialStoreSecretKey();
-    
+
     // Numeric Errors
     @Message(id = 35, value = "Only one of '%s' and '%s' can be specified at the same time")
     IllegalArgumentException mutuallyExclusiveOptions(String first, String second);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2312

This change is to make it easier for those migrating from a PicketBox vault to an Elytron credential store.  

Some entries stored in the vault may be referenced in non password attributes in WildFly's management model, in that case an encrypted expression will be needed.