### PR TITLE
ELY-2308: Fix digest authentication for requests with encoded path parameters

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -280,9 +280,9 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             String relativeRequestUri;
             String query = requestURI.getQuery();
             if (query == null || query.isEmpty()) {
-                relativeRequestUri = requestURI.getPath();
+                relativeRequestUri = requestURI.getRawPath();
             } else {
-                relativeRequestUri = requestURI.getPath() + "?" + requestURI.getRawQuery();
+                relativeRequestUri = requestURI.getRawPath() + "?" + requestURI.getRawQuery();
             }
 
             return relativeRequestUri.equals(digestUriStr);


### PR DESCRIPTION
As for the query part, for the path part also use the raw representation.

Fixes #1675 (https://issues.redhat.com/browse/ELY-2308)