### PR TITLE
[ELY-2307] Update the OIDC tests so that they can run with Keycloak 17.0.0 and later

### DIFF
--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/KeycloakContainer.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/KeycloakContainer.java
@@ -29,7 +29,6 @@ import org.testcontainers.containers.wait.strategy.Wait;
 public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public static final String KEYCLOAK_ADMIN_USER = "admin";
     public static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
-    private static final String KEYCLOAK_AUTH_PATH = "/auth";
 
     private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:latest";
     private static final int KEYCLOAK_PORT_HTTP = 8080;
@@ -50,12 +49,13 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     @Override
     protected void configure() {
         withExposedPorts(KEYCLOAK_PORT_HTTP, KEYCLOAK_PORT_HTTPS);
-        waitingFor(Wait.forHttp("/auth").forPort(8080));
-        withEnv("KEYCLOAK_USER", KEYCLOAK_ADMIN_USER);
-        withEnv("KEYCLOAK_PASSWORD", KEYCLOAK_ADMIN_PASSWORD);
+        waitingFor(Wait.forHttp("/").forPort(8080));
+        withEnv("KEYCLOAK_ADMIN", KEYCLOAK_ADMIN_USER);
+        withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_ADMIN_PASSWORD);
+        withCommand("start-dev");
     }
 
     public String getAuthServerUrl() {
-        return String.format("http://%s:%s%s", getContainerIpAddress(), useHttps ? getMappedPort(KEYCLOAK_PORT_HTTPS) : getMappedPort(KEYCLOAK_PORT_HTTP), KEYCLOAK_AUTH_PATH);
+        return String.format("http://%s:%s", getContainerIpAddress(), useHttps ? getMappedPort(KEYCLOAK_PORT_HTTPS) : getMappedPort(KEYCLOAK_PORT_HTTP));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
         <version.org.bitbucket.b_c.jose4j>0.7.5</version.org.bitbucket.b_c.jose4j>
         <version.org.testcontainers.testcontainers>1.15.3</version.org.testcontainers.testcontainers>
-        <version.org.keycloak>15.0.2</version.org.keycloak>
+        <version.org.keycloak>17.0.0</version.org.keycloak>
         <version.io.rest-assured>4.3.3</version.io.rest-assured>
         <version.net.sourceforge.htmlunit.htmlunit>2.40.0</version.net.sourceforge.htmlunit.htmlunit>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2307

Upstream: https://github.com/wildfly-security/wildfly-elytron/pull/1673

This is needed to get CI for 1.15.x passing again.