### PR TITLE
ELY-2166: Added javadoc for org.wildfly.security.sasl.util.SaslMechanismInformation.Names class.

### DIFF
--- a/sasl/base/src/main/java/org/wildfly/security/sasl/util/SaslMechanismInformation.java
+++ b/sasl/base/src/main/java/org/wildfly/security/sasl/util/SaslMechanismInformation.java
@@ -55,6 +55,9 @@ import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
  */
 public final class SaslMechanismInformation {
 
+    /**
+     * The class providing Sasl Mechanism Names.
+     */
     public static final class Names {
         public static final String CRAM_MD5 = "CRAM-MD5";
         public static final String DIGEST_MD5 = "DIGEST-MD5";


### PR DESCRIPTION
https://issues.redhat.com/projects/ELY/issues/ELY-2166