### PR TITLE
[ELY-2347] parseKeyStoreType crashes if type and wrap attributes not set

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -3576,8 +3576,9 @@ public final class ElytronXmlParser {
                 }
                 keyStore = KeyStoreUtil.loadKeyStore(providers, providerName, fin, fileName, passwordFactory.get());
             } catch (Exception e) {
-                safeClose(fin);
                 throw xmlLog.xmlFailedToCreateKeyStore(location, e);
+            } finally {
+                safeClose(fin);
             }
             return keyStore;
         }

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -2007,7 +2007,7 @@ public final class ElytronXmlParser {
                 ExceptionSupplier<KeyStore, ConfigXMLParseException> keyStoreFactory = null;
                 if (type == null || type.equalsIgnoreCase("automatic")) {
                     keyStoreFactory = new UnknownTypeFileKeyStoreFactory(providers, provider, passwordFactory, fileSource, resourceSource, uriSource, location);
-                    if (wrap) {
+                    if (wrap == Boolean.TRUE) {
                         keyStoreFactory = new PasswordKeyStoreFactory(keyStoreFactory);
                     }
                 } else {

--- a/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
@@ -129,6 +129,13 @@ public class ElytronXmlParserTest {
     }
 
     @Test
+    public void testKeyStoreEmptyType() throws ConfigXMLParseException, URISyntaxException {
+        URL config = getClass().getResource("test-wildfly-config-v1_4.xml");
+        SecurityFactory<AuthenticationContext> authContext = ElytronXmlParser.parseAuthenticationClientConfiguration(config.toURI());
+        Assert.assertNotNull(authContext);
+    }
+
+    @Test
     public void testClearCredential() throws Exception {
         URL config = getClass().getResource("test-wildfly-config-v1_4.xml");
         SecurityFactory<AuthenticationContext> authContext = ElytronXmlParser.parseAuthenticationClientConfiguration(config.toURI());

--- a/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-v1_4.xml
+++ b/auth/client/src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-v1_4.xml
@@ -37,6 +37,10 @@
                 <file name="./target/keystore/client.keystore"/>
                 <key-store-masked-password algorithm="masked-HMAC-SHA1-AES-128" key-material="testingKeyMaterial" iteration-count="12" salt="12345678" masked-password="9EQZkSe7w+VHasVXbNxuJA==" initialization-vector="QXRFBhXc7Z8dkQaFn1yRzQ=="/>
             </key-store>
+            <key-store name="empty-type-keystore">
+                <file name="./target/keystore/client.keystore"/>
+                <key-store-clear-password password="password"/>
+            </key-store>
         </key-stores>
         <ssl-contexts>
             <ssl-context name="client-ssl-context-clear">
@@ -47,6 +51,11 @@
             <ssl-context name="client-ssl-context-masked">
                 <key-store-ssl-certificate key-store-name="masked-keystore" alias="testclient1">
                     <key-store-masked-password algorithm="masked-HMAC-SHA1-AES-128" key-material="testingKeyMaterial" iteration-count="12" salt="12345678" masked-password="9EQZkSe7w+VHasVXbNxuJA==" initialization-vector="QXRFBhXc7Z8dkQaFn1yRzQ=="/>
+                </key-store-ssl-certificate>
+            </ssl-context>
+            <ssl-context name="client-ssl-context-empty-type">
+                <key-store-ssl-certificate key-store-name="empty-type-keystore" alias="testclient1">
+                    <key-store-clear-password password="password"/>
                 </key-store-ssl-certificate>
             </ssl-context>
         </ssl-contexts>
@@ -64,6 +73,9 @@
             </rule>
             <rule use-ssl-context="client-ssl-context-masked">
                 <match-host name="masked"/>
+            </rule>
+            <rule use-ssl-context="client-ssl-context-empty-type">
+                <match-host name="empty"/>
             </rule>
         </ssl-context-rules>
     </authentication-client>


### PR DESCRIPTION
[https://issues.redhat.com/browse/ELY-2347](https://issues.redhat.com/browse/ELY-2347)