### PR TITLE
[ELY-2352] UpRev Jackson to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 
     <properties>
         <jdk.min.version>11</jdk.min.version>
-        <version.com.fasterxml.jackson>2.13.1</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.3</version.com.fasterxml.jackson>
         <version.commons-cli>1.4</version.commons-cli>
         <version.io.smallrye.jwt>3.1.1</version.io.smallrye.jwt>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2352

Addresses CVE-2020-36518
https://github.com/FasterXML/jackson-databind/issues/2816
https://github.com/advisories/GHSA-57j2-w4cx-62h2

This fix improves on the Dependabot PR (https://github.com/wildfly-security/wildfly-elytron/pull/1699) which incorrectly bumps the version for the whole of Jackson to 2.13.2.1, which caused an error (because 2.13.2.1 only applied to jackson-databind). This PR bumps to the later (2.13.3) version, which also satisfies the CVE.