### PR TITLE
[ELY-2358] Option extract-rdn selects the rightmost matching RDN instead of the leftmost one

### DIFF
--- a/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -717,7 +717,9 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
         private String extractRdn(AttributeMapping mapping, final String dn) {
             String valueRdn = mapping.getRdn();
             try {
-                for (Rdn rdn : new LdapName(dn).getRdns()) {
+                LdapName dnName = new LdapName(dn);
+                for (int i = dnName.size() - 1; i >= 0; i--) {
+                    Rdn rdn = dnName.getRdn(i);
                     if (rdn.getType().equalsIgnoreCase(valueRdn)) {
                         return rdn.getValue().toString();
                     }

--- a/tests/base/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
@@ -32,7 +32,15 @@ public class GroupMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
     public void testMultipleGroupsWithUniqueMember() throws Exception {
         assertAttributes(attributes -> {
             assertEquals("Expected a single attribute.", 1, attributes.size());
-            assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree");
+            assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree", "GroupOneInGroupThree");
         }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={1}))").from("CN").to("Groups").build());
+    }
+
+    @Test
+    public void testMultipleGroupsWithUniqueMemberExtractRdn() throws Exception {
+        assertAttributes(attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree", "GroupOneInGroupThree");
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={1}))").to("Groups").extractRdn("CN").build());
     }
 }

--- a/tests/base/src/test/resources/ldap/elytron-group-mapping-tests.ldif
+++ b/tests/base/src/test/resources/ldap/elytron-group-mapping-tests.ldif
@@ -23,4 +23,8 @@ objectClass: groupOfUniqueNames
 cn: GroupThree
 uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org
 
-
+dn: cn=GroupOneInGroupThree,cn=GroupThree,ou=Groups,dc=elytron,dc=wildfly,dc=org
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: GroupOneInGroupThree
+uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-23779

Changing the `extractRdn` method to return the leftmost RDN that matches the mapping name. Little test added.