### PR TITLE
[ELY-2360] Change OIDC_STATE delimiter

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
@@ -36,7 +36,7 @@ import org.wildfly.security.http.Scope;
 public class OidcCookieTokenStore implements OidcTokenStore {
 
     private final OidcHttpFacade httpFacade;
-    private static final String DELIM = "___";
+    private static final String DELIM = "###";
     private static final int EXPECTED_NUM_TOKENS = 3;
     private static final int ACCESS_TOKEN_INDEX = 0;
     private static final int ID_TOKEN_INDEX = 1;
@@ -206,7 +206,8 @@ public class OidcCookieTokenStore implements OidcTokenStore {
         String cookieVal = cookie.getValue();
         String[] tokens = cookieVal.split(DELIM);
         if (tokens.length != EXPECTED_NUM_TOKENS) {
-            log.warnf("Invalid format of %s cookie. Count of tokens: %s, expected 3", OIDC_STATE_COOKIE, tokens.length);
+            log.warnf("Invalid format of %s cookie. Count of tokens: %s, expected %s", OIDC_STATE_COOKIE, tokens.length, EXPECTED_NUM_TOKENS);
+            log.debugf("Value of %s cookie is: %s", OIDC_STATE_COOKIE, cookieVal);
             return null;
         }
         String accessTokenString = tokens[ACCESS_TOKEN_INDEX];

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
@@ -37,6 +37,7 @@ public class OidcCookieTokenStore implements OidcTokenStore {
 
     private final OidcHttpFacade httpFacade;
     private static final String DELIM = "###";
+    private static final String LEGACY_DELIM = "___";
     private static final int EXPECTED_NUM_TOKENS = 3;
     private static final int ACCESS_TOKEN_INDEX = 0;
     private static final int ID_TOKEN_INDEX = 1;
@@ -205,6 +206,11 @@ public class OidcCookieTokenStore implements OidcTokenStore {
         }
         String cookieVal = cookie.getValue();
         String[] tokens = cookieVal.split(DELIM);
+        if (tokens.length != EXPECTED_NUM_TOKENS) {
+            // Cookies set by older versions of wildfly-elytron use a different token delimiter. Since clients may
+            // still send such cookies we fall back to the old delimiter to avoid discarding valid tokens:
+            tokens = cookieVal.split(LEGACY_DELIM);
+        }
         if (tokens.length != EXPECTED_NUM_TOKENS) {
             log.warnf("Invalid format of %s cookie. Count of tokens: %s, expected %s", OIDC_STATE_COOKIE, tokens.length, EXPECTED_NUM_TOKENS);
             log.debugf("Value of %s cookie is: %s", OIDC_STATE_COOKIE, cookieVal);


### PR DESCRIPTION
Change the delimiter character sequence used in the OIDC_STATE cookie
to avoid clashes when the same character sequence appears in the encoded
tokens stored in the cookie.

Additionally, a debug log message is added to print the value of the
OIDC_STATE cookie if the value could not be split into its components.

https://issues.redhat.com/browse/ELY-2360