### PR TITLE
[ELY-2374] Add support domain_hint query parameter

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
@@ -60,6 +60,7 @@ public class Oidc {
     public static final String ERROR = "error";
     public static final String GRANT_TYPE = "grant_type";
     public static final String LOGIN_HINT = "login_hint";
+    public static final String DOMAIN_HINT = "domain_hint";
     public static final String MAX_AGE = "max_age";
     public static final String PROMPT = "prompt";
     public static final String SCOPE = "scope";

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
@@ -21,6 +21,7 @@ package org.wildfly.security.http.oidc;
 import static org.wildfly.security.http.oidc.ElytronMessages.log;
 import static org.wildfly.security.http.oidc.Oidc.CLIENT_ID;
 import static org.wildfly.security.http.oidc.Oidc.CODE;
+import static org.wildfly.security.http.oidc.Oidc.DOMAIN_HINT;
 import static org.wildfly.security.http.oidc.Oidc.ERROR;
 import static org.wildfly.security.http.oidc.Oidc.KC_IDP_HINT;
 import static org.wildfly.security.http.oidc.Oidc.LOGIN_HINT;
@@ -163,7 +164,7 @@ public class OidcRequestAuthenticator {
                 url = uriBuilder.build().toString();
             }
 
-            List<String> forwardableQueryParams = Arrays.asList(LOGIN_HINT, KC_IDP_HINT, PROMPT, MAX_AGE, UI_LOCALES, SCOPE);
+            List<String> forwardableQueryParams = Arrays.asList(LOGIN_HINT, DOMAIN_HINT, KC_IDP_HINT, PROMPT, MAX_AGE, UI_LOCALES, SCOPE);
             List<NameValuePair> forwardedQueryParams = new ArrayList<>(forwardableQueryParams.size());
             for (String paramName : forwardableQueryParams) {
                 String paramValue = getQueryParamValue(facade, paramName);


### PR DESCRIPTION
Azure AD allows to pass the domain_hint parameter to the /authorize
endpoint which helps user account selection (see [Microsoft's documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code))
This pull requests adds support for appending this parameter to the redirect
uri. Additionally it refactors the code for forwarding the query parameters to the 
redirect uri to make it easier to add support for additional parameters.

https://issues.redhat.com/browse/ELY-2374