### PR TITLE
[ELY-2128] Upgrade Apache DS to version AM26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,7 @@
         <version.io.smallrye.jwt>3.1.1</version.io.smallrye.jwt>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.org.apache.commons>3.8.1</version.org.apache.commons>
-        <version.org.apache.directory.server>2.0.0-M24</version.org.apache.directory.server>
-        <version.org.apache.directory.api>1.0.0</version.org.apache.directory.api>
-        <version.org.apache.directory.jdbm>2.0.0-M3</version.org.apache.directory.jdbm>
-        <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
+        <version.org.apache.directory.server>2.0.0.AM26</version.org.apache.directory.server>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
         <version.org.eclipse.microprofile.jwt.api>1.2.2</version.org.eclipse.microprofile.jwt.api>
         <version.org.apache.sshd.common>2.7.0</version.org.apache.sshd.common>
@@ -1053,63 +1050,14 @@
                   Test Scope Only
              -->
             <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-asn1-api</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-asn1-ber</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-ldap-codec-core</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-ldap-codec-standalone</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-ldap-extras-codec-api</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.api</groupId>
-                <artifactId>api-ldap-model</artifactId>
-                <version>${version.org.apache.directory.api}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.jdbm</groupId>
-                <artifactId>apacheds-jdbm1</artifactId>
-                <version>${version.org.apache.directory.jdbm}</version>
-                <type>jar</type>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-core-api</artifactId>
-                <version>${version.org.apache.directory.server}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-core-annotations</artifactId>
+                <artifactId>apacheds-test-framework</artifactId>
                 <version>${version.org.apache.directory.server}</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.apache.directory.jdbm</groupId>
-                        <artifactId>apacheds-jdbm1</artifactId>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1118,50 +1066,6 @@
                 <artifactId>apacheds-interceptor-kerberos</artifactId>
                 <version>${version.org.apache.directory.server}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-kerberos-codec</artifactId>
-                <version>${version.org.apache.directory.server}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-protocol-kerberos</artifactId>
-                <version>${version.org.apache.directory.server}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-protocol-ldap</artifactId>
-                <version>${version.org.apache.directory.server}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.directory.jdbm</groupId>
-                        <artifactId>apacheds-jdbm1</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.directory.mavibot</groupId>
-                <artifactId>mavibot</artifactId>
-                <version>${version.org.apache.directory.mavibot}</version>
-                <scope>test</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -583,97 +583,14 @@
               Test Scope Only
          -->
         <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-asn1-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-asn1-ber</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-ldap-codec-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-ldap-codec-standalone</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-ldap-extras-codec-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.api</groupId>
-            <artifactId>api-ldap-model</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.jdbm</groupId>
-            <artifactId>apacheds-jdbm1</artifactId>
-            <type>jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-core-api</artifactId>
+            <artifactId>apacheds-test-framework</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-core-annotations</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.directory.jdbm</groupId>
-                    <artifactId>apacheds-jdbm1</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-interceptor-kerberos</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-kerberos-codec</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-protocol-kerberos</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-protocol-ldap</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.directory.jdbm</groupId>
-                    <artifactId>apacheds-jdbm1</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.directory.mavibot</groupId>
-            <artifactId>mavibot</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/tests/base/src/test/java/org/wildfly/security/apacheds/LdapService.java
+++ b/tests/base/src/test/java/org/wildfly/security/apacheds/LdapService.java
@@ -143,7 +143,6 @@ public class LdapService implements Closeable {
             for (String current : indexes) {
                 partitionFactory.addIndex(partition, current, indexSize);
             }
-            partition.setCacheService(directoryService.getCacheService());
             partition.initialize();
             directoryService.addPartition(partition);
 

--- a/tests/base/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/credential/store/KeystorePasswordStoreTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Supplier;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/tests/base/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/DirContextFactoryRule.java
@@ -94,7 +94,6 @@ public class DirContextFactoryRule implements TestRule {
                 .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
                 .build();
         X509Certificate issuerCertificate = issuerSelfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
-        localhostKeyStore.setCertificateEntry("ca", issuerCertificate);
         trustStore.setCertificateEntry("mykey", issuerCertificate);
 
         // Generates certificate and keystore for Localhost

--- a/tests/base/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/ModifiabilitySuiteChild.java
@@ -72,7 +72,7 @@ public class ModifiabilitySuiteChild {
                      AttributeMapping.fromIdentity().from("sn").to("lastName").build(),
                      AttributeMapping.fromIdentity().from("description").to("description").build(),
                      AttributeMapping.fromIdentity().from("telephoneNumber").to("phones").build(),
-                     AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={0}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build())
+                     AttributeMapping.fromFilter("(&(objectClass=groupOfNames)(member={1}))").searchDn("ou=Finance,dc=elytron,dc=wildfly,dc=org").extractRdn("OU").to("businessArea").build())
                 .setNewIdentityParent(new LdapName("dc=elytron,dc=wildfly,dc=org"))
                 .setNewIdentityAttributes(attributes)
                 .setIteratorFilter("(uid=*)")

--- a/tests/base/src/test/java/org/wildfly/security/sasl/gssapi/TestKDC.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/gssapi/TestKDC.java
@@ -117,7 +117,6 @@ public class TestKDC {
         for (String current : indexAttributes) {
             pf.addIndex(p, current, 10);
         }
-        p.setCacheService(directoryService.getCacheService());
         p.initialize();
         directoryService.addPartition(p);
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2128

Trying again to upgrade `apache-ds` from M24 to AM26. Previously it was reverted because there was an issue with IBM JDK-8. But neither elytron nor wildfly-core use jdk-8 anymore so we are free to upgrade in upstream now. This PR contains more or less the same changes that were sent before by Sonia but I'm simplifying the dependencies. I'm just using two (`apacheds-test-framework`, which includes all the other dependencies, and `apacheds-interceptor-kerberos`, that should be added for kerberos testing). I think it's much easier this way, `apache-ds` is just a test dependency, and only one version is managed now (`2.0.0.AM26` in the upgrade).