### PR TITLE
[ELY-2377] RealmFailedAuthenticationEvent triggered during successful http programmatic login

### DIFF
--- a/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
+++ b/http/base/src/main/java/org/wildfly/security/http/HttpAuthenticator.java
@@ -139,9 +139,12 @@ public class HttpAuthenticator {
 
                     IdentityCache identityCache = getOrCreateIdentityCache();
                     identityCache.put(authorizedIdentity);
-                    logoutHandlerConsumer.accept(identityCache::remove);
+                    if (logoutHandlerConsumer != null) {
+                        logoutHandlerConsumer.accept(identityCache::remove);
+                    }
 
                     httpExchangeSpi.authenticationComplete(authorizedIdentity, mechanismName);
+                    authenticationContext.succeed();
 
                     return authorizedIdentity;
                 } else {
@@ -192,7 +195,9 @@ public class HttpAuthenticator {
                     securityIdentity = authenticationContext.getAuthorizedIdentity();
 
                     httpExchangeSpi.authenticationComplete(securityIdentity, cachedIdentity.getMechanismName());
-                    logoutHandlerConsumer.accept(identityCache::remove);
+                    if (logoutHandlerConsumer != null) {
+                        logoutHandlerConsumer.accept(identityCache::remove);
+                    }
 
                     if (cache) {
                         log.tracef("Replacing cached identity for '%s' against session scope.", cachedIdentity.getName());

--- a/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -601,7 +601,7 @@ public class AbstractBaseHttpTest {
         }
 
         public HttpScope getScope(Scope scope) {
-            throw new IllegalStateException();
+            return null;
         }
 
         public Collection<String> getScopeIds(Scope scope) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2377

Adding the missing `succeed` call and checking for null when accessing the `logoutHandlerConsumer`. A new test added to the `HttpAuthenticatorTest` class that handles a successful and failed programmatic login using a security domain (domain listeners are checked instead of realm because it's easier, the same issue was also there).