### PR TITLE
[ELY-2381] LdapSecurityRealm can return duplicated values for filtered attributes

### DIFF
--- a/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
+++ b/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/LdapSecurityRealm.java
@@ -771,7 +771,7 @@ class LdapSecurityRealm implements ModifiableSecurityRealm, CacheableSecurityRea
 
         private Map<String, Collection<String>> extractFilteredAttributes(SearchResult identityEntry, DirContext context, DirContext identityContext) {
             return extractAttributes(AttributeMapping::isFilteredOrReference, mapping -> {
-                Collection<String> values = mapping.getRoleRecursionDepth() == 0 ? new ArrayList<>() : new HashSet<>();
+                Collection<String> values = new HashSet<>();
                 final String searchDn = mapping.getSearchDn() != null ? mapping.getSearchDn() : identityMapping.searchDn;
 
                 List<SearchResult> toSearch = new LinkedList<>();

--- a/tests/base/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/AbstractAttributeMappingSuiteChild.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.ldap;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -40,6 +41,7 @@ public abstract class AbstractAttributeMappingSuiteChild {
 
     protected void assertAttributeValue(Attributes.Entry values, String... expectedValues) {
         assertNotNull("Attribute values are null.", values);
+        assertEquals("Different number of attributes values", expectedValues.length, values.size());
 
         for (String expectedValue : expectedValues) {
             assertTrue("Value [" + expectedValue + "] for attribute [" + values.getKey() + "] not found in " + Arrays.toString(values.toArray()), values.contains(expectedValue));

--- a/tests/base/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
+++ b/tests/base/src/test/java/org/wildfly/security/ldap/GroupMappingSuiteChild.java
@@ -43,4 +43,12 @@ public class GroupMappingSuiteChild extends AbstractAttributeMappingSuiteChild {
             assertAttributeValue(attributes.get("Groups"), "GroupOne", "GroupTwo", "GroupThree", "GroupOneInGroupThree");
         }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={1}))").to("Groups").extractRdn("CN").build());
     }
+
+    @Test
+    public void testDuplicateValuesMultipleGroupsWithUniqueMember() throws Exception {
+        assertAttributes(attributes -> {
+            assertEquals("Expected a single attribute.", 1, attributes.size());
+            assertAttributeValue(attributes.get("categories"), "oneAndTwo", "three");
+        }, AttributeMapping.fromFilter("(&(objectClass=groupOfUniqueNames)(uniqueMember={1}))").from("businessCategory").to("categories").build());
+    }
 }

--- a/tests/base/src/test/resources/ldap/elytron-group-mapping-tests.ldif
+++ b/tests/base/src/test/resources/ldap/elytron-group-mapping-tests.ldif
@@ -9,22 +9,26 @@ dn: cn=GroupOne,ou=Groups,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: groupOfUniqueNames
 cn: GroupOne
+businessCategory: oneAndTwo
 uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org
 
 dn: cn=GroupTwo,ou=Groups,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: groupOfUniqueNames
 cn: GroupTwo
+businessCategory: oneAndTwo
 uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org
 
 dn: cn=GroupThree,ou=Groups,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: groupOfUniqueNames
 cn: GroupThree
+businessCategory: three
 uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org
 
 dn: cn=GroupOneInGroupThree,cn=GroupThree,ou=Groups,dc=elytron,dc=wildfly,dc=org
 objectClass: top
 objectClass: groupOfUniqueNames
 cn: GroupOneInGroupThree
+businessCategory: three
 uniqueMember: uid=plainUser,dc=elytron,dc=wildfly,dc=org


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2381

Using a Set always in the method `extractFilteredAttributes`, that avoids returning duplicated entries.

The test uses the easiest approach to return duplicated entries, just collecting an attribute that is repeated inside the groups (`businessCategory` which is a kind of group type attribute). And now the test also checks for different sizes between expected and returned attribute value lists (previously it just checked that all values in one list were in the other and vice-versa, so duplicated entries were no detected).