### PR TITLE
[ELY-2398] Fix FileSystemEncryptRealmCommand.java so it uses logical OR instead of bitwise OR

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/FileSystemEncryptRealmCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/FileSystemEncryptRealmCommand.java
@@ -393,9 +393,9 @@ class FileSystemEncryptRealmCommand extends Command {
             }
             descriptors.add(descriptor);
             checkDescriptorFields(descriptor);
-        } else if (inputRealmLocationOption != null | outputRealmLocationOption != null | secretKeyAliasOption != null |
-                realmNameOption != null | credentialStoreOption != null | createCredentialStore != null |
-                hashEncodingOption != null | encodedOption != null | levelsOption != null | populateOption != null) {
+        } else if (inputRealmLocationOption != null || outputRealmLocationOption != null || secretKeyAliasOption != null ||
+                realmNameOption != null || credentialStoreOption != null || createCredentialStore != null ||
+                hashEncodingOption != null || encodedOption != null || levelsOption != null || populateOption != null) {
             throw ElytronToolMessages.msg.mutuallyExclusiveOptionsEncryptSpecified();
         } else {
             if (summaryMode) {


### PR DESCRIPTION
issue : [ELY-2398](https://issues.redhat.com/browse/ELY-2398)