### PR TITLE
ELY-2449:Remove unneeded null check in OidcCookieTokenStore#logout

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcCookieTokenStore.java
@@ -137,7 +137,7 @@ public class OidcCookieTokenStore implements OidcTokenStore {
                 return;
             }
             OidcClientConfiguration deployment = httpFacade.getOidcClientConfiguration();
-            if (! deployment.isBearerOnly() && securityContext != null && securityContext instanceof RefreshableOidcSecurityContext) {
+            if (! deployment.isBearerOnly() && securityContext instanceof RefreshableOidcSecurityContext) {
                 ((RefreshableOidcSecurityContext) securityContext).logout(deployment);
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2449