### PR TITLE
ELY-2420: Update MaskedPasswordImpl to make use of MessageDigest#isEq…

### DIFF
--- a/password/impl/src/main/java/org/wildfly/security/password/impl/MaskedPasswordImpl.java
+++ b/password/impl/src/main/java/org/wildfly/security/password/impl/MaskedPasswordImpl.java
@@ -25,6 +25,7 @@ import java.io.ObjectInputStream;
 import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
@@ -216,7 +217,9 @@ final class MaskedPasswordImpl extends AbstractPasswordImpl implements MaskedPas
             return false;
         }
         MaskedPasswordImpl other = (MaskedPasswordImpl) obj;
-        return iterationCount == other.iterationCount && Arrays.equals(initialKeyMaterial, other.initialKeyMaterial) && Arrays.equals(salt, other.salt) && Arrays.equals(maskedPasswordBytes, other.maskedPasswordBytes) && Arrays.equals(initializationVector, other.initializationVector) && algorithm.equals(other.algorithm);
+        return iterationCount == other.iterationCount && Arrays.equals(initialKeyMaterial, other.initialKeyMaterial)
+                && MessageDigest.isEqual(salt, other.salt) && MessageDigest.isEqual(maskedPasswordBytes, other.maskedPasswordBytes)
+                && MessageDigest.isEqual(initializationVector, other.initializationVector) && algorithm.equals(other.algorithm);
     }
 
     Object writeReplace() {


### PR DESCRIPTION
…ual to avoid a potential timing attack

Refer issue : https://issues.redhat.com/browse/ELY-2420

Note: there are references to Array.equals comparing char[] which are unchanged in the PR.