### PR TITLE
[ELY-2385] RawSecretKeyFactoryTest uses deprecated Assert.assertThat method

### DIFF
--- a/credential/base/src/test/java/org/wildfly/security/key/RawSecretKeyFactoryTest.java
+++ b/credential/base/src/test/java/org/wildfly/security/key/RawSecretKeyFactoryTest.java
@@ -28,7 +28,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.junit.Test;
 
 import static org.hamcrest.core.IsSame.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RawSecretKeyFactoryTest {
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2385