### PR TITLE
[ELY-2451] Correct a typo in ServerAuthenticationContext.

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1525,7 +1525,7 @@ public final class ServerAuthenticationContext implements AutoCloseable {
             boolean ok = false;
             try {
                 if (! realmIdentity.exists()) {
-                    ElytronMessages.log.tracef("Authorization failed - identity does not exists");
+                    ElytronMessages.log.tracef("Authorization failed - identity does not exist");
                     return false;
                 }
                 // check the run-as permission on the old identity


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2451