### PR TITLE
[ELY-2392] Fix invalid tags on the Elytron Blogs page

### DIFF
--- a/_posts/2022-04-19-improving-readability-of-alias-commands.adoc
+++ b/_posts/2022-04-19-improving-readability-of-alias-commands.adoc
@@ -2,7 +2,7 @@
 layout: post
 title: 'Improving readability of certificate read commands'
 date: 2022-04-19
-tags: ux, certificate, cli
+tags: ux certificate cli
 synopsis: Improving user experience and reducing console clutter.
 author: baranowb
 ---


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2392