### PR TITLE
[ELY-2313] Update the OIDC tests to use the 19.0.1 version of quay.io/keycloak/keycloak

### DIFF
--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/KeycloakContainer.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/KeycloakContainer.java
@@ -30,7 +30,7 @@ public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
     public static final String KEYCLOAK_ADMIN_USER = "admin";
     public static final String KEYCLOAK_ADMIN_PASSWORD = "admin";
 
-    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:latest";
+    private static final String KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:19.0.1";
     private static final int KEYCLOAK_PORT_HTTP = 8080;
     private static final int KEYCLOAK_PORT_HTTPS = 8443;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2313
