### PR TITLE
[ELY-2457] Swallowed exception in KeyStoreCredentialStore.flush

### DIFF
--- a/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -800,6 +800,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                             e.addSuppressed(t);
                             throw e;
                         }
+                        throw log.cannotFlushCredentialStore(t);
                     }
                 }
             } catch (IOException e) {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2457

Just a minor issue. If there is a exception saving the credential store the exception can be swallowed and no error is reported. It drove me crazy this morning. :smile: 

As always if you want in any other branch better than 1.x just let me know.