### PR TITLE
[ELY-2469] Update deprecated assertThat method in JACC, credential store and sasl test cases

### DIFF
--- a/credential/store/src/test/java/org/wildfly/security/credential/store/impl/VaultObjectInputStreamTest.java
+++ b/credential/store/src/test/java/org/wildfly/security/credential/store/impl/VaultObjectInputStreamTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.junit.Test;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VaultObjectInputStreamTest {
 

--- a/jacc/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
+++ b/jacc/src/test/java/org/wildfly/security/authz/jacc/LinkPolicyConfigurationTest.java
@@ -50,8 +50,8 @@ import java.security.Security;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/jacc/src/test/java/org/wildfly/security/authz/jacc/PolicyConfigurationTest.java
+++ b/jacc/src/test/java/org/wildfly/security/authz/jacc/PolicyConfigurationTest.java
@@ -19,7 +19,6 @@ package org.wildfly.security.authz.jacc;
 
 import org.hamcrest.core.IsInstanceOf;
 import org.hamcrest.core.IsSame;
-import org.junit.Assert;
 import org.junit.Test;
 import org.wildfly.security.auth.principal.NamePrincipal;
 
@@ -32,8 +31,8 @@ import java.security.Policy;
 import java.security.PrivilegedAction;
 
 import static java.security.AccessController.doPrivileged;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -48,11 +47,11 @@ public class PolicyConfigurationTest extends AbstractAuthorizationTestCase {
     public void testCreateElytronPolicyConfigurationFactory() throws Exception {
         PolicyConfigurationFactory policyConfigurationFactory = PolicyConfigurationFactory.getPolicyConfigurationFactory();
 
-        Assert.assertThat(policyConfigurationFactory, new IsInstanceOf(ElytronPolicyConfigurationFactory.class));
+        assertThat(policyConfigurationFactory, new IsInstanceOf(ElytronPolicyConfigurationFactory.class));
 
         PolicyConfigurationFactory sameInstance = PolicyConfigurationFactory.getPolicyConfigurationFactory();
 
-        Assert.assertThat(policyConfigurationFactory, new IsSame<>(sameInstance));
+        assertThat(policyConfigurationFactory, new IsSame<>(sameInstance));
     }
 
     @Test

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslFactoriesApiTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslFactoriesApiTest.java
@@ -20,7 +20,7 @@ package org.wildfly.security.sasl.test;
 
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2469