### PR TITLE
[ELY-2487] Misplaced invocation of isAutodetectedBearerOnly()

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/RequestAuthenticator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/RequestAuthenticator.java
@@ -152,11 +152,6 @@ public class RequestAuthenticator {
             log.debug("NOT_ATTEMPTED: bearer only");
             return AuthOutcome.NOT_ATTEMPTED;
         }
-        if (isAutodetectedBearerOnly()) {
-            challenge = bearer.getChallenge();
-            log.debug("NOT_ATTEMPTED: Treating as bearer only");
-            return AuthOutcome.NOT_ATTEMPTED;
-        }
 
         if (log.isTraceEnabled()) {
             log.trace("try oidc");
@@ -166,6 +161,12 @@ public class RequestAuthenticator {
             if (verifySSL()) return AuthOutcome.FAILED;
             log.debug("AUTHENTICATED: was cached");
             return AuthOutcome.AUTHENTICATED;
+        }
+
+        if (isAutodetectedBearerOnly()) {
+            challenge = bearer.getChallenge();
+            log.debug("NOT_ATTEMPTED: Treating as bearer only");
+            return AuthOutcome.NOT_ATTEMPTED;
         }
 
         OidcRequestAuthenticator oidc = createOidcAuthenticator();


### PR DESCRIPTION
Method isAutodetectedBearerOnly() should be invoked after checking cached token.

Invoking isAutodetectedBearerOnly() early will break every AJAX request that relies on HTTP session. A clear example is JSF Partial Request, it will never send the header "Authorization" neither the query parameter "auth". During the initial load of view the user was authenticated, then the token was stored in HTTP session, so, JSF Partial Request relies on HTTP session onwards.

https://issues.redhat.com/browse/ELY-2487