### PR TITLE
[ELY-2495] ConfiguredSSL(Server)SocketFactory method getDefaultCipherSuites returns incorrect list of ciphers

### DIFF
--- a/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLServerSocketFactory.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLServerSocketFactory.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 
@@ -39,6 +40,12 @@ final class ConfiguredSSLServerSocketFactory extends AbstractDelegatingSSLServer
         this.sslContext = sslContext;
         this.sslConfigurator = sslConfigurator;
         this.wrap = wrap;
+    }
+
+    public String[] getDefaultCipherSuites() {
+        SSLParameters params = sslContext.getSupportedSSLParameters​();
+        params = sslConfigurator.getDefaultSSLParameters(sslContext, params);
+        return params.getCipherSuites();
     }
 
     public ServerSocket createServerSocket() throws IOException {

--- a/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLSocketFactory.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/ConfiguredSSLSocketFactory.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -41,6 +42,12 @@ final class ConfiguredSSLSocketFactory extends AbstractDelegatingSSLSocketFactor
         this.sslContext = sslContext;
         this.sslConfigurator = sslConfigurator;
         this.wrap = wrap;
+    }
+
+    public String[] getDefaultCipherSuites() {
+        SSLParameters params = sslContext.getSupportedSSLParameters​();
+        params = sslConfigurator.getDefaultSSLParameters(sslContext, params);
+        return params.getCipherSuites();
     }
 
     public Socket createSocket(final Socket s, final String host, final int port, final boolean autoClose) throws IOException {

--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLConfiguratorImplTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLConfiguratorImplTest.java
@@ -25,7 +25,10 @@ import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 import java.io.IOException;
 import java.security.AlgorithmConstraints;
@@ -38,6 +41,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -117,4 +121,19 @@ public class SSLConfiguratorImplTest {
         assertEquals("HTTPS", copiedSSLParams.getEndpointIdentificationAlgorithm());
     }
 
+    @Test
+    public void testCipherSuites() throws GeneralSecurityException, IOException {
+        SSLContext sslContext = new SSLContextBuilder().setCipherSuiteSelector(CipherSuiteSelector.fromString("AES256-SHA256")).build().create();
+        SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+        SSLSocket sslSocket = (SSLSocket) sslSocketFactory.createSocket();
+        assertArrayEquals(new String[]{"TLS_RSA_WITH_AES_256_CBC_SHA256"}, sslSocket.getEnabledCipherSuites());
+        assertArrayEquals(new String[]{"TLS_RSA_WITH_AES_256_CBC_SHA256"}, sslSocketFactory.getDefaultCipherSuites());
+        assertArrayEquals(sslSocket.getSupportedCipherSuites(), sslSocketFactory.getSupportedCipherSuites());
+
+        SSLServerSocketFactory sslServerSocketFactory = sslContext.getServerSocketFactory();
+        SSLServerSocket sslServerSocket = (SSLServerSocket) sslServerSocketFactory.createServerSocket();
+        assertArrayEquals(new String[]{"TLS_RSA_WITH_AES_256_CBC_SHA256"}, sslServerSocket.getEnabledCipherSuites());
+        assertArrayEquals(new String[]{"TLS_RSA_WITH_AES_256_CBC_SHA256"}, sslServerSocketFactory.getDefaultCipherSuites());
+        assertArrayEquals(sslServerSocket.getSupportedCipherSuites(), sslServerSocketFactory.getSupportedCipherSuites());
+    }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2495

Method `getDefaultCipherSuites` in the `ConfiguredSSL(Server)SocketFactory` classes is not filtering the default ciphers using the configurator. This generated a weird issue with CXF and IBM JDK-8 in [JBEAP-24221](https://issues.redhat.com/browse/JBEAP-24221). The fix is also filtering the ciphers using the configurator in those methods for the factories.

@Skyllarr @fjuma PR sent to maintenance branch 1.15.x as it's usually  requested for these issues. If you need something more please just let me know.