### PR TITLE
[ELY-2502] SASL authentication configured by the security command denies CLI connection

### DIFF
--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/KeyStoreBackedSecurityRealm.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/KeyStoreBackedSecurityRealm.java
@@ -79,36 +79,34 @@ public class KeyStoreBackedSecurityRealm implements SecurityRealm {
 
     @Override
     public RealmIdentity getRealmIdentity(final Principal principal) throws RealmUnavailableException {
-        if (NamePrincipal.isConvertibleTo(principal)) {
+        final X500Principal x500Principal = X500PrincipalUtil.asX500Principal(principal);
+        if (x500Principal != null) {
+            log.tracef("KeyStoreRealm: obtaining certificate by X500Principal [%s]", x500Principal);
+            final KeyStore keyStore = this.keyStore;
+            try {
+                final Enumeration<String> aliases = keyStore.aliases();
+                while (aliases.hasMoreElements()) {
+                    final String alias = aliases.nextElement();
+                    if (keyStore.isCertificateEntry(alias)) {
+                        final Certificate certificate = keyStore.getCertificate(alias);
+                        if (certificate instanceof X509Certificate && x500Principal.equals(X500PrincipalUtil.asX500Principal(((X509Certificate) certificate).getSubjectX500Principal()))) {
+                            log.tracef("KeyStoreRealm: certificate found by X500Principal in alias [%s]", alias);
+                            return new KeyStoreRealmIdentity(alias);
+                        }
+                    }
+                }
+            } catch (KeyStoreException e) {
+                throw log.failedToReadKeyStore(e);
+            }
+            log.tracef("KeyStoreRealm: certificate not found by X500Principal");
+            return RealmIdentity.NON_EXISTENT;
+        } else if (NamePrincipal.isConvertibleTo(principal)) {
             String name = principal.getName();
             log.tracef("KeyStoreRealm: obtaining certificate by alias [%s]", name);
             return new KeyStoreRealmIdentity(name);
         } else {
-            final X500Principal x500Principal = X500PrincipalUtil.asX500Principal(principal);
-            if (x500Principal == null) {
-                log.tracef("KeyStoreRealm: conversion of principal [%s] to X500Principal failed", principal);
-                return RealmIdentity.NON_EXISTENT;
-            } else {
-                log.tracef("KeyStoreRealm: obtaining certificate by X500Principal [%s]", x500Principal);
-                final KeyStore keyStore = this.keyStore;
-                try {
-                    final Enumeration<String> aliases = keyStore.aliases();
-                    while (aliases.hasMoreElements()) {
-                        final String alias = aliases.nextElement();
-                        if (keyStore.isCertificateEntry(alias)) {
-                            final Certificate certificate = keyStore.getCertificate(alias);
-                            if (certificate instanceof X509Certificate && x500Principal.equals(X500PrincipalUtil.asX500Principal(((X509Certificate) certificate).getSubjectX500Principal()))) {
-                                log.tracef("KeyStoreRealm: certificate found by X500Principal in alias [%s]", alias);
-                                return new KeyStoreRealmIdentity(alias);
-                            }
-                        }
-                    }
-                } catch (KeyStoreException e) {
-                    throw log.failedToReadKeyStore(e);
-                }
-                log.tracef("KeyStoreRealm: certificate not found by X500Principal");
-                return RealmIdentity.NON_EXISTENT;
-            }
+            log.tracef("KeyStoreRealm: conversion of principal [%s] to X500Principal failed", principal);
+            return RealmIdentity.NON_EXISTENT;
         }
     }
 

--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -189,16 +189,22 @@ public class SSLAuthenticationTest {
     }
 
     private static SecurityDomain getKeyStoreBackedSecurityDomain(String keyStorePath) throws Exception {
+        return getKeyStoreBackedSecurityDomain(keyStorePath, true);
+    }
+
+    private static SecurityDomain getKeyStoreBackedSecurityDomain(String keyStorePath, boolean decoder) throws Exception {
         SecurityRealm securityRealm = new KeyStoreBackedSecurityRealm(createKeyStore(keyStorePath));
 
-        return SecurityDomain.builder()
+        SecurityDomain.Builder builder = SecurityDomain.builder()
                 .addRealm("KeystoreRealm", securityRealm)
                 .build()
                 .setDefaultRealmName("KeystoreRealm")
-                .setPrincipalDecoder(new X500AttributePrincipalDecoder("2.5.4.3", 1))
                 .setPreRealmRewriter((String s) -> s.toLowerCase(Locale.ENGLISH))
-                .setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL)
-                .build();
+                .setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL);
+        if (decoder) {
+            builder.setPrincipalDecoder(new X500AttributePrincipalDecoder("2.5.4.3", 1));
+        }
+        return builder.build();
     }
 
     @BeforeClass
@@ -464,6 +470,19 @@ public class SSLAuthenticationTest {
     public void testTwoWay() throws Throwable {
         SSLContext serverContext = new SSLContextBuilder()
                 .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
+                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
+                .setTrustManager(getCATrustManager())
+                .setNeedClientAuth(true)
+                .build().create();
+
+        performConnectionTest(serverContext, "protocol://test-two-way.org", true, "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Scarab",
+                "OU=Elytron,O=Elytron,C=UK,ST=Elytron,CN=Ladybird", false);
+    }
+
+    @Test
+    public void testTwoWayNoDecoder() throws Throwable {
+        SSLContext serverContext = new SSLContextBuilder()
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore", false))
                 .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .setTrustManager(getCATrustManager())
                 .setNeedClientAuth(true)


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2502

Just changing the order of the ifs for `[KeyStoreBackedSecurityRealm.java`. First the X500Principal is tried if non null, if null the alias is tried if the principal is convertible to name, finally an error is thrown if none is possible. Little test added without decoder to pass a X500Principal.