### PR TITLE
[ELY-2540] Elytron Tool filesystem-realm-encrypt checks incorrect script location for overwrite

### DIFF
--- a/tool/src/main/java/org/wildfly/security/tool/FileSystemEncryptRealmCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/FileSystemEncryptRealmCommand.java
@@ -742,12 +742,15 @@ class FileSystemEncryptRealmCommand extends Command {
                 secretKeyAlias = "key";
             }
             String createScriptCheck = "";
-            if (Paths.get(String.format("%s.cli", fileSystemRealmName)).toFile().exists()) {
+
+            Path scriptPath = Paths.get(String.format("%s/%s.cli", outputRealmLocation, fileSystemRealmName));
+
+            if (scriptPath.toFile().exists()) {
                 createScriptCheck = prompt(
+                        true,
+                        ElytronToolMessages.msg.shouldFileBeOverwritten(scriptPath.toString()),
                         false,
-                        null,
-                        false,
-                        ElytronToolMessages.msg.shouldFileBeOverwritten(String.format("%s.cli", fileSystemRealmName))
+                        null
                 );
             }
             String fullOutputPath;
@@ -758,7 +761,7 @@ class FileSystemEncryptRealmCommand extends Command {
             }
 
             if (summaryMode) {
-                summaryString.append(String.format("Configured script for WildFly named %s.cli at %s.", fileSystemRealmName, fullOutputPath));
+                summaryString.append(String.format("Configured script for WildFly at %s", scriptPath));
                 summaryString.append(System.getProperty("line.separator"));
                 summaryString.append("The script is using the following names:");
                 summaryString.append(System.getProperty("line.separator"));
@@ -767,14 +770,14 @@ class FileSystemEncryptRealmCommand extends Command {
             }
 
             List<String> scriptLines = Arrays.asList(
-                String.format("/subsystem=elytron/secret-key-credential-store=%s:add(path=%s)", "mycredstore"+counter, credentialStore),
-                String.format("/subsystem=elytron/filesystem-realm=%s:add(path=%s, levels=%s, credential-store=%s, secret-key=%s)", fileSystemRealmName, fullOutputPath+'/'+fileSystemRealmName, levels, "mycredstore"+counter, secretKeyAlias)
+                    String.format("/subsystem=elytron/secret-key-credential-store=%s:add(path=%s)", "mycredstore"+counter, credentialStore),
+                    String.format("/subsystem=elytron/filesystem-realm=%s:add(path=%s, levels=%s, credential-store=%s, secret-key=%s)", fileSystemRealmName, fullOutputPath+'/'+fileSystemRealmName, levels, "mycredstore"+counter, secretKeyAlias)
             );
 
             if (!createScriptCheck.equals("y") && !createScriptCheck.equals("yes")) {
-                Files.write(Paths.get(String.format("%s/%s.cli", outputRealmLocation, fileSystemRealmName)), scriptLines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+                Files.write(scriptPath, scriptLines, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
             } else {
-                Files.write(Paths.get(String.format("%s/%s.cli", outputRealmLocation, fileSystemRealmName)), scriptLines, StandardOpenOption.APPEND);
+                Files.write(scriptPath, scriptLines, StandardOpenOption.APPEND);
             }
             counter++;
         }


### PR DESCRIPTION
This pr contains the same changes as [this pr](https://github.com/wildfly-security/wildfly-elytron/pull/1889/files#diff-ebe53241afd70e1e5743d6db5b39150461c335abce6c083cafbf6aae4b4c1e2dR764), but rebased for branch 2.x