### PR TITLE
[ELY-2561] Upgrade jose4j to version 0.9.3 or higher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <version.commons-io.commons-io>2.7</version.commons-io.commons-io>
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
-        <version.org.bitbucket.b_c.jose4j>0.7.11</version.org.bitbucket.b_c.jose4j>
+        <version.org.bitbucket.b_c.jose4j>0.9.3</version.org.bitbucket.b_c.jose4j>
         <version.org.testcontainers.testcontainers>1.15.3</version.org.testcontainers.testcontainers>
         <version.org.keycloak>18.0.2</version.org.keycloak>
         <version.io.rest-assured>4.3.3</version.io.rest-assured>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2561

Upstream PR for 2.x: https://github.com/wildfly-security/wildfly-elytron/pull/1904