### PR TITLE
[ELY-2551] Upgrade jose4j to 0.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.commons-io.commons-io>2.6</version.commons-io.commons-io>
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
-        <version.org.bitbucket.b_c.jose4j>0.7.5</version.org.bitbucket.b_c.jose4j>
+        <version.org.bitbucket.b_c.jose4j>0.9.3</version.org.bitbucket.b_c.jose4j>
         <version.org.testcontainers.testcontainers>1.15.3</version.org.testcontainers.testcontainers>
         <version.org.keycloak>17.0.0</version.org.keycloak>
         <version.io.rest-assured>4.3.3</version.io.rest-assured>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24925
Upstream issue: (1.x) https://issues.redhat.com/browse/ELY-2561 / (2.x) https://issues.redhat.com/browse/ELY-2551
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1904