### PR TITLE
Update GitHub token instructions, use libffi8 in build-and-deploy-site

### DIFF
--- a/.github/actions/build-and-deploy-site/Dockerfile
+++ b/.github/actions/build-and-deploy-site/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
         build-essential \
         ca-certificates \
         curl \
-        libffi7 \
+        libffi8 \
         make \
         shellcheck \
         git-all \

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ To write a blog post:
     - The file name should be `yyyy-mm-dd-slug.adoc`
 - Your blog post should be in asciidoc format (take a look at other blogs posts in the _posts directory to see examples)
     - To view your blog post without needing to build locally, the following steps can be used:
-        - If you haven't done so already, generate a GitHub token following the instructions
-          [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token)
-          (in step 7, you only need to select "public_repo"). Use this value to add a `PUSH_GITHUB_TOKEN` secret to your
-          repository settings (i.e., https://github.com/<YOUR_GITHUB_USERNAME>/wildfly-elytron/settings).
+        - If you haven't done so already, generate a fine-grained GitHub token following the instructions
+          [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token). Use this value to add a `PUSH_GITHUB_TOKEN` secret to your
+          repository secrets (i.e., https://github.com/<YOUR_GITHUB_USERNAME>/wildfly-elytron/settings/secrets/actions).
+          - You should set the **Resource owner** to your user account, and **Repository access** to "Only select repositories", and then your fork of `wildfly-elytron`. The only repository permissions needed are **Read and write access to _Contents_** (this also enables **Read access to _Metadata_**, which is required).
         - Simply push your changes to the `develop` branch on your `wildfly-elytron` fork. This will trigger a website
           build that will get pushed to the `gh-pages` branch on your fork. Then browse to
           http://<YOUR_GITHUB_USERNAME>.github.io/wildfly-elytron/blog and click on your post.


### PR DESCRIPTION
Rewrites the instructions for generating a fine-grained GitHub token. Also updates libffi in the build-and-deploy-site action to "8" (?), since `ruby-3:slim` updated to use  `debian:bookworm`.

Test site: https://cam-rod.github.io/wildfly-elytron/