### PR TITLE
[ELY-2557] Add an afterclass method to do clean-up after the FileSystemEncryptRealmCommandTest testBulkWithoutNames test

### DIFF
--- a/tool/src/test/java/org/wildfly/security/tool/FileSystemEncryptRealmCommandTest.java
+++ b/tool/src/test/java/org/wildfly/security/tool/FileSystemEncryptRealmCommandTest.java
@@ -23,13 +23,17 @@ import static org.wildfly.security.tool.Command.ELYTRON_KS_PASS_PROVIDERS;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.crypto.SecretKey;
 
 import org.apache.commons.cli.MissingArgumentException;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.wildfly.security.auth.principal.NamePrincipal;
 import org.wildfly.security.auth.realm.FileSystemSecurityRealm;
@@ -227,6 +231,18 @@ public class FileSystemEncryptRealmCommandTest extends AbstractCommandTest {
         assertTrue(existingIdentity.exists());
         assertTrue(existingIdentity.verifyEvidence(new PasswordGuessEvidence("password!4".toCharArray())));
         existingIdentity.dispose();
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        //cleanup after testBulkWithoutNames test
+        Path bulkWithoutNamesFolderPath = Paths.get(RELATIVE_BASE_DIR + "fs-encrypted-realms/bulk-encryption-conversion-desc-without-names");
+        if (bulkWithoutNamesFolderPath.toFile().exists()) {
+            Files.walk(bulkWithoutNamesFolderPath)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
     }
 
     private boolean fileExists(String path) {

--- a/tool/src/test/resources/bulk-encryption-conversion-desc-without-names
+++ b/tool/src/test/resources/bulk-encryption-conversion-desc-without-names
@@ -1,22 +1,22 @@
 input-location:target/test-classes/filesystem-encrypt/fs-unencrypted-realms/multiple-credential-types
-output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms
+output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms/bulk-encryption-conversion-desc-without-names
 credential-store:target/test-classes/filesystem-encrypt/mycredstore.cs
 create:true
 levels:1
 
 input-location:target/test-classes/filesystem-encrypt/fs-unencrypted-realms/level-4
-output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms
+output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms/bulk-encryption-conversion-desc-without-names
 credential-store:target/test-classes/filesystem-encrypt/mycredstore.cs
 create:true
 levels:4
 
 input-location:target/test-classes/filesystem-encrypt/fs-unencrypted-realms/fsRealmCharset
-output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms
+output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms/bulk-encryption-conversion-desc-without-names
 credential-store:target/test-classes/filesystem-encrypt/mycredstore.cs
 create:true
 
 input-location:target/test-classes/filesystem-encrypt/fs-unencrypted-realms/hashencoding
-output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms
+output-location:target/test-classes/filesystem-encrypt/fs-encrypted-realms/bulk-encryption-conversion-desc-without-names
 hash-encoding:hex
 credential-store:target/test-classes/filesystem-encrypt/mycredstore.cs
 create:true


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2557
follow up to: https://github.com/wildfly-security/wildfly-elytron/pull/1892