### PR TITLE
[ELY-2576] Make it possible to use DigestPasswords when using the DIGEST-SHA-256 and DIGEST-SHA-512-256 HTTP Digest authentication mechanisms

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -49,6 +49,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 import javax.security.auth.callback.Callback;
@@ -68,7 +69,6 @@ import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.mechanism.AuthenticationMechanismException;
 import org.wildfly.security.mechanism.digest.DigestQuote;
 import org.wildfly.security.mechanism.digest.PasswordDigestObtainer;
-import org.wildfly.security.password.interfaces.DigestPassword;
 
 /**
  * Implementation of the HTTP DIGEST authentication mechanism as defined in RFC 7616.
@@ -326,7 +326,7 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
     }
 
     private byte[] getH_A1(final MessageDigest messageDigest, final String username, final String messageRealm) throws AuthenticationMechanismException {
-        PasswordDigestObtainer obtainer = new PasswordDigestObtainer(callbackHandler, username, messageRealm, httpDigest, DigestPassword.ALGORITHM_DIGEST_MD5, messageDigest, providers, null, true, false);
+        PasswordDigestObtainer obtainer = new PasswordDigestObtainer(callbackHandler, username, messageRealm, httpDigest, getMechanismName().toLowerCase(Locale.ROOT), messageDigest, providers, null, true, false);
         return obtainer.handleUserRealmPasswordCallbacks();
     }
 

--- a/tests/base/src/test/java/org/wildfly/security/http/digest/DigestAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/digest/DigestAuthenticationMechanismTest.java
@@ -227,6 +227,38 @@ public class DigestAuthenticationMechanismTest extends AbstractBaseHttpTest {
         },mechanism);
     }
 
+    @Test
+    public void testSha256WithDigestPassword() throws Exception {
+        mockDigestNonce("5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK");
+        Map<String, Object> props = new HashMap<>();
+        props.put(CONFIG_REALM, "api@example.org");
+        props.put("org.wildfly.security.http.validate-digest-uri", "false");
+        HttpServerAuthenticationMechanism mechanism = digestFactory.createAuthenticationMechanism(DIGEST_NAME + "-" + SHA256, props, getCallbackHandler("J\u00E4s\u00F8n Doe", "api@example.org", "Secret, or not?", true));
+
+        TestingHttpServerRequest request1 = new TestingHttpServerRequest(null);
+        mechanism.evaluateRequest(request1);
+        Assert.assertEquals(Status.NO_AUTH, request1.getResult());
+        TestingHttpServerResponse response = request1.getResponse();
+        Assert.assertEquals(UNAUTHORIZED, response.getStatusCode());
+        Assert.assertEquals("Digest realm=\"api@example.org\", nonce=\"5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK\", opaque=\"00000000000000000000000000000000\", algorithm=SHA-256, qop=auth", response.getAuthenticateHeader());
+
+        TestingHttpServerRequest request2 = new TestingHttpServerRequest(new String[] {
+                "Digest username*=UTF-8''J%C3%A4s%C3%B8n%20Doe,\n" +
+                        "       realm=\"api@example.org\",\n" +
+                        "       uri=\"/doe.json\",\n" +
+                        "       algorithm=SHA-256,\n" +
+                        "       nonce=\"5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK\",\n" +
+                        "       nc=00000001,\n" +
+                        "       cnonce=\"NTg6RKcb9boFIAS3KrFK9BGeh+iDa/sm6jUMp2wds69v\",\n" +
+                        "       qop=auth,\n" +
+                        "       response=\"" + computeDigest("/doe.json", "5TsQWLVdgBdmrQ0XsxbDODV+57QdFR34I9HAbC/RVvkK", "NTg6RKcb9boFIAS3KrFK9BGeh+iDa/sm6jUMp2wds69v", "00000001", "J\u00E4s\u00F8n Doe", "Secret, or not?", "SHA-256", "api@example.org", "auth", "GET") + "\",\n" +
+                        "       opaque=\"00000000000000000000000000000000\",\n" +
+                        "       userhash=false"
+        });
+        mechanism.evaluateRequest(request2);
+        Assert.assertEquals(Status.COMPLETE, request2.getResult());
+    }
+
     private String computeDigest(String uri, String nonce, String cnonce, String nc, String username, String password, String algorithm, String realm, String qop, String method) throws NoSuchAlgorithmException {
         String A1, HashA1, A2, HashA2;
         MessageDigest md = MessageDigest.getInstance(algorithm);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2576

When using the `DIGEST-SHA-256` or `DIGEST-SHA-512-256` HTTP Digest authentication mechanisms, it's not possible to make use of `DigestPasswords`. Only clear passwords can be used with these mechanisms.

The underlying issue is that [DigestAuthenticationMechanism#getH_A1](https://github.com/wildfly-security/wildfly-elytron/blob/2.x/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java#L329) erroneously sets the credential algorithm for the `PasswordDigestObtainer` to `digest-md5` in all cases. The algorithm that should be used depends on the mechanism name.