### PR TITLE
[ELY-2578] Upgrade nimbus-jose-jwt from 8.2.1 to 9.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.hsqldb>2.4.0</version.hsqldb>
         <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
         <version.net.minidev.json-smart>2.4.9</version.net.minidev.json-smart>
-        <version.com.nimbusds.nimbus-jose-jwt>8.2.1</version.com.nimbusds.nimbus-jose-jwt>
+        <version.com.nimbusds.nimbus-jose-jwt>9.31</version.com.nimbusds.nimbus-jose-jwt>
         <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2578

Diff: https://bitbucket.org/connect2id/nimbus-jose-jwt/branch/release-9.31?dest=release-8.2.1