### PR TITLE
[ELY-2493] Upgrade jackson-databind to 2.13.4 to address CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,8 @@
 
     <properties>
         <jdk.min.version>11</jdk.min.version>
-        <version.com.fasterxml.jackson>2.11.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}.2</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.4</version.commons-cli>
         <version.io.smallrye.jwt>3.0.0</version.io.smallrye.jwt>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
@@ -1009,7 +1010,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
+                <version>${version.com.fasterxml.jackson.databind}</version>
             </dependency>
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-25182
Upstream issue: https://issues.redhat.com/browse/ELY-2493
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/1847