### PR TITLE
[ELY-2580] Add new CVE Reporting page to the Elytron website

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,3 +12,5 @@
   link: /blog/
 - name: GitHub
   link: https://github.com/wildfly-security/wildfly-elytron
+- name: CVE Reporting
+  link: /security/

--- a/_layouts/security.html
+++ b/_layouts/security.html
@@ -1,0 +1,43 @@
+---
+layout: default
+---
+
+<div class="guides-page grid-wrapper">
+    <div class="grid__item width-12-12">
+        <h1>Reporting of CVEs and Security Issues</h1>
+        <h2 class="page-subtitle">The Wild<strong>Fly</strong> Elytron community and our sponsor, Red Hat, take security bugs very
+            seriously
+        </h2>
+        <p>We aim to take immediate action to address serious security-related problems that involve our projects.
+            Note that we will only fix such issues in the most recent minor release of Wild<strong>Fly</strong> Elytron.</p>
+    </div>
+    <div class="grid__item width-12-12">
+        <h2>Reporting of Security Issues</h2>
+        <p>When reporting a security vulnerability it is important to not accidentally broadcast to the world that the
+            issue exists, as this makes it easier for people to exploit it. The software industry uses the term
+            <a href="https://www.redhat.com/en/blog/security-embargoes-red-hat">embargo</a> to describe the time a security
+            issue is known internally until it is public knowledge.
+        </p>
+        <p>
+            Our preferred way of reporting security issues in Wild<strong>Fly</strong> Elytron and its related projects is listed below.
+        </p>
+    </div>
+    <div class="grid__item width-12-12">
+        <h2>Email the mailing list</h2>
+        <p>The list at <a href="mailto:security@wildfly.org">security@wildfly.org</a> is the preferred mechanism for outside users
+            to report security issues. A member of the Wild<strong>Fly</strong> Elytron team will open the required issues.</p>
+    </div>
+    <div class="grid__item width-12-12">
+        <h2>Other considerations</h2>
+        <p>
+            If you would like to work with us on a fix for the security vulnerability, please include your GitHub username
+            in the above email, and we will provide you access to a temporary private fork where we can collaborate on a
+            fix without it being disclosed publicly, <strong>including in your own publicly visible git repository</strong>.
+        </p>
+        <p>
+            Do not open a public issue, send a pull request, or disclose any information about the suspected vulnerability
+            publicly, <strong>including in your own publicly visible git repository</strong>. If you discover any publicly disclosed security vulnerabilities, please notify us immediately through
+            <a href="mailto:security@wildfly.org">security@wildfly.org</a>
+        </p>
+    </div>
+</div>

--- a/security.md
+++ b/security.md
@@ -1,0 +1,5 @@
+---
+layout: security
+title: Reporting of CVEs and Security Issues
+permalink: /security/
+---


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2580