### PR TITLE
[ELY-2582] Upgrade Jackson FasterXML to version 2.15.2 - resolves CVE PRISMA-2023-0067

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 
     <properties>
         <jdk.min.version>11</jdk.min.version>
-        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}.2</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson>2.15.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.4</version.commons-cli>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.org.apache.commons>3.8.1</version.org.apache.commons>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2582