### PR TITLE
ELY-2641 : Simplify assersions in MaskCommandTest#testMissingSaltAnd iteration method

### DIFF
--- a/tool/src/test/java/org/wildfly/security/tool/MaskCommandTest.java
+++ b/tool/src/test/java/org/wildfly/security/tool/MaskCommandTest.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.security.tool;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.security.tool.Params.LINE_SEPARATOR;
 
@@ -64,7 +65,7 @@ public class MaskCommandTest extends AbstractCommandTest {
         String[] retValLines = retVal.split(LINE_SEPARATOR);
 
         assertTrue("Message about invalid salt parameter must be present", retValLines[0].contains("Invalid \"salt\" parameter. Generated value"));
-        assertTrue("Message about invalid iteration parameter must be present", ("Invalid \"iteration\" parameter. Default value \"" + defaultIteration + "\" will be used.").equals(retValLines[1]));
+        assertEquals("Message about invalid iteration parameter must be present", "Invalid \"iteration\" parameter. Default value \"" + defaultIteration + "\" will be used.", retValLines[1]);
         assertTrue("Message about invalid salt parameter must be present", retValLines[2].contains("MASK-"));
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2641

Simplify assersions in MaskCommandTest#testMissingSaltAndIteration method