### PR TITLE
ELY-2628 : Move the method LongNameSetPermissionCollection

### DIFF
--- a/permission/src/main/java/org/wildfly/security/permission/LongNameSetPermissionCollection.java
+++ b/permission/src/main/java/org/wildfly/security/permission/LongNameSetPermissionCollection.java
@@ -33,10 +33,6 @@ final class LongNameSetPermissionCollection extends NameSetPermissionCollection 
         super(sourcePermission, nameEnumeration);
     }
 
-    private Permission permissionFor(int id) {
-        return ((AbstractNamedPermission<?>)getSourcePermission()).withName(getNameEnumeration().nameOf(id));
-    }
-
     protected void doAdd(final AbstractPermission<?> permission) {
         long setBits = getBitsForName(permission);
         final AtomicLong bitSet = this.bitSet;
@@ -112,6 +108,10 @@ final class LongNameSetPermissionCollection extends NameSetPermissionCollection 
 
         public Permission next() {
             return nextElement();
+        }
+
+        private Permission permissionFor(int id) {
+            return ((AbstractNamedPermission<?>)getSourcePermission()).withName(getNameEnumeration().nameOf(id));
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2628