### PR TITLE
[ELY-2599] Update assertEquals calls in RegexRoleMapperTest so that t…

### DIFF
--- a/auth/server/base/src/test/java/org/wildfly/security/authz/RegexRoleMapperTest.java
+++ b/auth/server/base/src/test/java/org/wildfly/security/authz/RegexRoleMapperTest.java
@@ -48,7 +48,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 3);
+        assertEquals(3, count);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 2);
+        assertEquals(2,count);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 2);
+        assertEquals(2,count);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 3);
+        assertEquals(3,count);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 3);
+        assertEquals(3,count);
     }
 
     @Test
@@ -153,7 +153,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 2);
+        assertEquals( 2,count);
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 2);
+        assertEquals( 2,count);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -238,7 +238,7 @@ public class RegexRoleMapperTest {
             iterator.next();
             count++;
         }
-        assertEquals(count, 2);
+        assertEquals(2,count);
     }
 
     private Set<String> createSet(String... values) {


### PR DESCRIPTION
[ELY-2599](https://issues.redhat.com/browse/ELY-2599) updated  assertEquals calls in RegexRoleMapperTest so that the expected value and actual value are passed in the correct order