### PR TITLE
[ELY-2658] Remove the unassigned call to the constructor in X500Attri…

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/x500/X500AttributePrincipalDecoderTest.java
@@ -63,7 +63,7 @@ public class X500AttributePrincipalDecoderTest {
 
     @Test
     public void testDecodeWithConcatenation() {
-        X500Principal principal; new X500Principal("cn=bob.smith,cn=bob,ou=people,dc=example,dc=redhat,dc=com");
+        X500Principal principal;
         PrincipalDecoder dcDecoder, dcDecoder1,  cnDecoder, ouDecoder, concatenatingDecoder;
         principal = new X500Principal("cn=bob.smith,cn=bob,ou=people,dc=example,dc=redhat,dc=com");
         dcDecoder = new X500AttributePrincipalDecoder(X500.OID_DC);


### PR DESCRIPTION
…butePrincipalDecoderTest#testDecodeWithConcatenation
https://issues.redhat.com/browse/ELY-2658?filter=12383825