### PR TITLE
refactor: changes to close ELY-2595,2596,2597,2603,2605,2606,2607

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -714,13 +714,10 @@ public final class ElytronXmlParser {
         while (reader.hasNext()) {
             final int tag = reader.nextTag();
             if (tag == START_ELEMENT) {
-                switch (reader.getLocalName()) {
-                    case "certificate-revocation-list": {
-                        parseCertificateRevocationList(reader, builder, xmlVersion, true);
-                        break;
-                    }
-                    default:
-                        throw reader.unexpectedElement();
+                if (reader.getLocalName().equals("certificate-revocation-list")) {
+                    parseCertificateRevocationList(reader, builder, xmlVersion, true);
+                } else {
+                    throw reader.unexpectedElement();
                 }
             } else if (tag != END_ELEMENT) {
                 throw reader.unexpectedContent();

--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -1099,6 +1099,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             streamWriter.writeEndDocument();
         }
 
+        @Override
         public void dispose() {
             // Release the lock for this realm identity
             IdentityLock identityLock = lock;

--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FileSystemSecurityRealm.java
@@ -1000,7 +1000,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             }
         }
 
-        private Version requiredVersion(final LoadedIdentity identityToWrite) {
+        private Version requiredVersion() {
             // As new functionality is added we will identify if we need to use a later version
             // if new functionality is used then use the required schema version otherwise fallback
             // to an older version.
@@ -1018,7 +1018,7 @@ public final class FileSystemSecurityRealm implements ModifiableSecurityRealm, C
             streamWriter.writeStartDocument();
             streamWriter.writeCharacters("\n");
             streamWriter.writeStartElement("identity");
-            streamWriter.writeDefaultNamespace(requiredVersion(newIdentity).getNamespace());
+            streamWriter.writeDefaultNamespace(requiredVersion().getNamespace());
 
             if (integrityEnabled) {
                 streamWriter.writeCharacters("\n    ");

--- a/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
+++ b/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
@@ -176,10 +176,8 @@ class X509EvidenceVerifier implements EvidenceVerifier {
 
                 for (int i = 0; i < size; i++) {
                     Object attrDigest = attribute.get(i);
-                    if (attrDigest != null){
-                        if (digest.equalsIgnoreCase((String) attrDigest)) {
-                            return true;
-                        }
+                    if (attrDigest != null && digest.equalsIgnoreCase((String) attrDigest)){
+                        return true;
                     }
                 }
             } catch (NoSuchAlgorithmException | CertificateEncodingException e) {

--- a/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/CredentialStoreCommand.java
@@ -92,8 +92,8 @@ import static org.wildfly.security.tool.Params.SUMMARY_PARAM;
  */
 class CredentialStoreCommand extends Command {
 
-    public static int ACTION_NOT_DEFINED = 5;
-    public static int ALIAS_NOT_FOUND = 6;
+    public static final int ACTION_NOT_DEFINED = 5;
+    public static final int ALIAS_NOT_FOUND = 6;
 
     public static final String RSA_ALGORITHM = "RSA";
     public static final String DSA_ALGORITHM = "DSA";

--- a/tool/src/main/java/org/wildfly/security/tool/ElytronTool.java
+++ b/tool/src/main/java/org/wildfly/security/tool/ElytronTool.java
@@ -36,11 +36,11 @@ public class ElytronTool {
     /**
      * status code for unrecognized command
      */
-    public static int ElytronToolExitStatus_unrecognizedCommand = 1;
+    public static final int ElytronToolExitStatus_unrecognizedCommand = 1;
     /**
      * status code for no problems
      */
-    public static int ElytronToolExitStatus_OK = 0;
+    public static final int ElytronToolExitStatus_OK = 0;
 
     private Map<String, Command> commandRegistry = new HashMap<>();
     /**

--- a/tool/src/main/java/org/wildfly/security/tool/VaultCommand.java
+++ b/tool/src/main/java/org/wildfly/security/tool/VaultCommand.java
@@ -446,7 +446,7 @@ public class VaultCommand extends Command {
         if (keystorePassword != null) {
             password = keystorePassword;
             if (salt != null && iterationCount > -1) {
-                password = keystorePassword.startsWith(MASK_PREFIX) ? keystorePassword + ";" + salt + ";" + String.valueOf(iterationCount)
+                password = keystorePassword.startsWith(MASK_PREFIX) ? keystorePassword + ";" + salt + ";" + iterationCount
                         : MaskCommand.computeMasked(keystorePassword, salt, iterationCount);
             }
         }


### PR DESCRIPTION
This makes some refactoring changes to close the following tickets: 

- https://issues.redhat.com/browse/ELY-2595 - Remove unused method parameter in FileSystemSecurityRealm#requiredVersion
- https://issues.redhat.com/browse/ELY-2596 - Add missing @OverRide annotation to the FileSystemSecurityRealm#Identity class dispose method
- https://issues.redhat.com/browse/ELY-2597 - Merge an if statement in verifyCertificate in X509EvidenceVerifier with its enclosing if statement
- https://issues.redhat.com/browse/ELY-2603 - Replace a switch statement in ElytronXmlParser#parseCertificateRevocationLists to improve readability
- https://issues.redhat.com/browse/ELY-2605 - Make two fields in the CredentialStoreCommand class final
- https://issues.redhat.com/browse/ELY-2606 - Make two fields in the ElytronTool class final
- https://issues.redhat.com/browse/ELY-2607 - Directly append iterationCount instead of using String.valueOf()