### PR TITLE
[ELY-2613] Update an assertEquals call in ScramServerCompatibilityTest#testAllowedAuthorizationId so that the expected value and actual value are passed in the correct order

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -215,7 +215,7 @@ public class ScramServerCompatibilityTest {
         assertEquals("v=xzTfS758LckdRoQKN/ZFY/Bauxo=", new String(message, StandardCharsets.UTF_8));
 
         assertTrue(saslServer.isComplete());
-        assertEquals(saslServer.getAuthorizationID(), "user");
+        assertEquals("user", saslServer.getAuthorizationID());
     }
 
     /**


### PR DESCRIPTION
[ELY-2613] Update an assertEquals call in ScramServerCompatibilityTest#testAllowedAuthorizationId so that the expected value and actual value are passed in the correct order
https://issues.redhat.com/browse/ELY-2613