### PR TITLE
[ELY-2602] Update assertEquals calls in ElytronXmlParserTest so that the

### DIFF
--- a/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
+++ b/auth/client/src/test/java/org/wildfly/security/auth/client/ElytronXmlParserTest.java
@@ -167,8 +167,8 @@ public class ElytronXmlParserTest {
         Assert.assertNotNull(node);
         String wsHttpMechanism  = node.getConfiguration().getWsHttpMechanism();
         String wsSecurityType = node.getConfiguration().getWsSecurityType();
-        Assert.assertEquals(wsHttpMechanism, "BASIC");
-        Assert.assertEquals(wsSecurityType, "UsernameToken");
+        Assert.assertEquals("BASIC", wsHttpMechanism);
+        Assert.assertEquals("UsernameToken", wsSecurityType);
     }
 
     @Test


### PR DESCRIPTION
expected value and actual value are passed in the correct order

Issue: https://issues.redhat.com/browse/ELY-2602