### PR TITLE
[ELY-2604] Make the constructor for FailoverRealmIdentity to “protected”

### DIFF
--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FailoverSecurityRealm.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/FailoverSecurityRealm.java
@@ -134,7 +134,7 @@ public class FailoverSecurityRealm implements SecurityRealm {
         protected RealmIdentity delegate;
         protected boolean failed = false;
 
-        public FailoverRealmIdentity(final RealmIdentity identity) {
+        protected FailoverRealmIdentity(final RealmIdentity identity) {
             this.delegate = identity;
         }
 


### PR DESCRIPTION
since it is an abstract class

Issue: https://issues.redhat.com/browse/ELY-2604