### PR TITLE
[ELY-2694] Update assertEquals calls in CommandCredentialSourceTest s…

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/credential/source/impl/CommandCredentialSourceTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/credential/source/impl/CommandCredentialSourceTest.java
@@ -43,7 +43,7 @@ public class CommandCredentialSourceTest {
         assertNotNull(password);
         final ClearPassword clearPassword = password.castAs(ClearPassword.class, ClearPassword.ALGORITHM_CLEAR);
         assertNotNull(clearPassword);
-        assertEquals(new String(clearPassword.getPassword()), "secret_key_THREE");
+        assertEquals("secret_key_THREE", new String(clearPassword.getPassword()));
     }
 
     private static CommandCredentialSource.Builder getBuilder() {


### PR DESCRIPTION
…o that the expected value and actual value are passed in the correct order

[https://issues.redhat.com/browse/ELY-2694](https://issues.redhat.com/browse/ELY-2694)