### PR TITLE
[ELY-2695] Update the import statement in CommandCredentialSourceTest…

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/credential/source/impl/CommandCredentialSourceTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/credential/source/impl/CommandCredentialSourceTest.java
@@ -18,7 +18,8 @@
 
 package org.wildfly.security.credential.source.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
… for the Assert class objects to import them explicitly

[https://issues.redhat.com/browse/ELY-2695](https://issues.redhat.com/browse/ELY-2695)