### PR TITLE
[ELY-2666] Upgrade org.apache.sshd:sshd-common from 2.9.2 to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.org.apache.directory.jdbm>2.0.0-M3</version.org.apache.directory.jdbm>
         <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
-        <version.org.apache.sshd.common>2.9.2</version.org.apache.sshd.common>
+        <version.org.apache.sshd.common>2.10.0</version.org.apache.sshd.common>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ELY-2666