### PR TITLE
[ELY-2661] Upgrade jakarta.enterprise:jakarta.enterprise.cdi-api from 2.0.2 to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <version.com.fasterxml.jackson>2.15.3</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.5.0</version.commons-cli>
-        <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
+        <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
         <version.org.apache.commons>3.8.1</version.org.apache.commons>
         <version.org.apache.directory.server>2.0.0-M24</version.org.apache.directory.server>
         <version.org.apache.directory.api>1.0.0</version.org.apache.directory.api>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2661