### PR TITLE
[ELY-2662] Upgrade jakarta.json:jakarta.json-api from 2.0.0 to 2.1.2

### DIFF
--- a/auth/realm/token/pom.xml
+++ b/auth/realm/token/pom.xml
@@ -85,7 +85,7 @@
 
         <!--Test scope-->
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>

--- a/http/oidc/pom.xml
+++ b/http/oidc/pom.xml
@@ -164,7 +164,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,14 @@
         <version.org.jboss.logging.tools>2.2.1.Final</version.org.jboss.logging.tools>
         <version.org.jboss.modules>1.9.2.Final</version.org.jboss.modules>
         <version.org.jboss.slf4j>1.0.4.GA</version.org.jboss.slf4j>
-        <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
+        <version.jakarta.json.jakarta-json-api>2.1.2</version.jakarta.json.jakarta-json-api>
         <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.org.jboss.threads>2.4.0.Final</version.org.jboss.threads>
         <version.org.kohsuke.metainf-services.metainf-services>1.7</version.org.kohsuke.metainf-services.metainf-services>
         <version.junit.junit>4.13.1</version.junit.junit>
         <version.jmockit>1.34</version.jmockit>
         <version.hsqldb>2.4.0</version.hsqldb>
-        <version.org.glassfish.jakarta.json>2.0.0</version.org.glassfish.jakarta.json>
+        <version.org.eclipse.parsson.jakarta.json>1.1.5</version.org.eclipse.parsson.jakarta.json>
         <version.net.minidev.json-smart>2.4.9</version.net.minidev.json-smart>
         <version.com.nimbusds.nimbus-jose-jwt>8.2.1</version.com.nimbusds.nimbus-jose-jwt>
         <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
@@ -1156,9 +1156,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish</groupId>
+                <groupId>org.eclipse.parsson</groupId>
                 <artifactId>jakarta.json</artifactId>
-                <version>${version.org.glassfish.jakarta.json}</version>
+                <version>${version.org.eclipse.parsson.jakarta.json}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -713,7 +713,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>

--- a/x500/cert/acme/pom.xml
+++ b/x500/cert/acme/pom.xml
@@ -105,7 +105,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ELY-2662