### PR TITLE
[ELY-2663] Upgrade org.apache.commons:commons-lang3 from 3.8.1 to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.5.0</version.commons-cli>
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>
-        <version.org.apache.commons>3.8.1</version.org.apache.commons>
+        <version.org.apache.commons>3.13.0</version.org.apache.commons>
         <version.org.apache.directory.server>2.0.0-M24</version.org.apache.directory.server>
         <version.org.apache.directory.api>1.0.0</version.org.apache.directory.api>
         <version.org.apache.directory.jdbm>2.0.0-M3</version.org.apache.directory.jdbm>


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/ELY-2663