### PR TITLE
[ELY-2664] Upgrade org.apache.httpcomponents:httpclient from 4.5.13 to 4.5.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.org.apache.directory.mavibot>1.0.0-M8</version.org.apache.directory.mavibot>
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
         <version.org.apache.sshd.common>2.10.0</version.org.apache.sshd.common>
-        <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>


### PR DESCRIPTION
[ELY-2664] Upgrade org.apache.httpcomponents:httpclient from 4.5.13 to 4.5.14
https://issues.redhat.com/browse/ELY-2664?filter=12364234