### PR TITLE
[ELY-2665] update org apache.httpcomponents.httpcore from 4.4.15 to 4.4.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.org.bouncycastle>1.67</version.org.bouncycastle>
         <version.org.apache.sshd.common>2.10.0</version.org.apache.sshd.common>
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
-        <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpcore>4.4.16</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss>


### PR DESCRIPTION
[ELY-2665] update apache.httpcomponents.httpcore from 4.4.15 to 4.4.16
https://issues.redhat.com/browse/ELY-2665?filter=12364234