### PR TITLE
[ELY-2667] Upgrade org.jboss.logging:jboss-logging from 3.4.3.Final to 3.5.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.org.apache.sshd.common>2.10.0</version.org.apache.sshd.common>
         <version.org.apache.httpcomponents.httpclient>4.5.13</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
-        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
+        <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.2.1.Final</version.org.jboss.logging.tools>


### PR DESCRIPTION
[ELY-2667] Upgrade org.jboss.logging:jboss-logging from 3.4.3.Final to 3.5.3.Final
https://issues.redhat.com/browse/ELY-2667?filter=12364234