### PR TITLE
[ELY-2668] Upgrade org.jboss.logmanager:jboss-logmanager from 2.1.18.Final to 2.1.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.org.apache.httpcomponents.httpclient>4.5.14</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.15</version.org.apache.httpcomponents.httpcore>
         <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
-        <version.org.jboss.logmanager>2.1.18.Final</version.org.jboss.logmanager>
+        <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
         <version.org.jboss.logmanager.log4j-jboss>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.2.1.Final</version.org.jboss.logging.tools>
         <version.org.jboss.modules>1.12.2.Final</version.org.jboss.modules>


### PR DESCRIPTION
[ELY-2668] Upgrade org.jboss.logmanager:jboss-logmanager from 2.1.18.Final to 2.1.19.Final
https://issues.redhat.com/browse/ELY-2668?filter=-1