### PR TITLE
[ELY-2670] Upgrade org.jboss.slf4j:slf4j-jboss-logmanager from 1.0.4.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <version.org.jboss.logmanager.log4j-jboss>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss>
         <version.org.jboss.logging.tools>2.2.1.Final</version.org.jboss.logging.tools>
         <version.org.jboss.modules>1.9.2.Final</version.org.jboss.modules>
-        <version.org.jboss.slf4j>1.0.4.GA</version.org.jboss.slf4j>
+        <version.org.jboss.slf4j>1.2.0.Final</version.org.jboss.slf4j>
         <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
         <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.org.jboss.threads>3.5.1.Final</version.org.jboss.threads>


### PR DESCRIPTION
…GA to 1.2.0.Final

[https://issues.redhat.com/browse/ELY-2670](https://issues.redhat.com/browse/ELY-2670)