### PR TITLE
Update 3 tests in SunUnixMD5Crypt to call a common method in order to…

### DIFF
--- a/password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java
@@ -43,40 +43,44 @@ import org.wildfly.security.password.util.ModularCrypt;
 public class SunUnixMD5CryptTest {
 
     @Test
-    public void testParseCryptStringWithoutRounds() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String cryptString = "$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01";
-
-        // Get the spec by parsing the crypt string
-        SunUnixMD5CryptPassword password = (SunUnixMD5CryptPassword) ModularCrypt.decode(cryptString);
-        assertEquals(0, password.getIterationCount());
-
-        // Use the spec to build a new crypt string and compare it to the original
-        assertEquals(cryptString, ModularCrypt.encodeAsString(password));
+    public void testParseCryptStringWithoutRounds() throws NoSuchAlgorithmException, InvalidKeySpecException { 
+        testParseCryptString("$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01");
     }
 
     @Test
-    public void testParseCryptStringWithRounds() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String cryptString = "$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1";
-
-        // Get the spec by parsing the crypt string
-        SunUnixMD5CryptPassword password = (SunUnixMD5CryptPassword) ModularCrypt.decode(cryptString);
-        assertEquals(1_000, password.getIterationCount());
-
-        // Use the spec to build a new crypt string and compare it to the original
-        assertEquals(cryptString, ModularCrypt.encodeAsString(password));
+    public void testParseCryptStringWithRounds() throws NoSuchAlgorithmException, InvalidKeySpecException { 
+        testParseCryptString("$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1");
     }
 
     @Test
-    public void testParseCryptStringWithBareSalt() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        String cryptString = "$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.";
+    public void testParseCryptStringWithBareSalt() throws NoSuchAlgorithmException, InvalidKeySpecException { 
+        testParseCryptString("$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.");
+    }
 
-        // Get the spec by parsing the crypt string
+    
+    public void testParseCryptString(String cryptString) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        int assertionValue = 0;
+
+        if (cryptString.equals("$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01")) {
+            assertionValue = 0;
+        }
+
+        else if (cryptString.equals("$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1")) {
+            assertionValue = 1_000;
+        }
+
+        else if (cryptString.equals("$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.")) {
+            assertionValue = 1_500;
+        }
+
         SunUnixMD5CryptPassword password = (SunUnixMD5CryptPassword) ModularCrypt.decode(cryptString);
-        assertEquals(1_500, password.getIterationCount());
+        assertEquals(assertionValue, password.getIterationCount());
 
         // Use the spec to build a new crypt string and compare it to the original
         assertEquals(cryptString, ModularCrypt.encodeAsString(password));
+
     }
+
 
     private void generateAndVerify(String cryptString, String correctPassword) throws NoSuchAlgorithmException,  InvalidKeyException, InvalidKeySpecException {
         final PasswordFactorySpiImpl spi = new PasswordFactorySpiImpl();

--- a/password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java
@@ -44,37 +44,23 @@ public class SunUnixMD5CryptTest {
 
     @Test
     public void testParseCryptStringWithoutRounds() throws NoSuchAlgorithmException, InvalidKeySpecException { 
-        testParseCryptString("$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01");
+        testParseCryptString("$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01", 0);
     }
 
     @Test
     public void testParseCryptStringWithRounds() throws NoSuchAlgorithmException, InvalidKeySpecException { 
-        testParseCryptString("$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1");
+        testParseCryptString("$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1", 1_000);
     }
 
     @Test
     public void testParseCryptStringWithBareSalt() throws NoSuchAlgorithmException, InvalidKeySpecException { 
-        testParseCryptString("$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.");
+        testParseCryptString("$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.", 1_500);
     }
 
     
-    public void testParseCryptString(String cryptString) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        int assertionValue = 0;
-
-        if (cryptString.equals("$md5$zrdhpMlZ$$wBvMOEqbSjU.hu5T2VEP01")) {
-            assertionValue = 0;
-        }
-
-        else if (cryptString.equals("$md5,rounds=1000$saltstring$$1wGsmnKgDGdu03LxKu0VI1")) {
-            assertionValue = 1_000;
-        }
-
-        else if (cryptString.equals("$md5,rounds=1500$saltstring$F9DNxgHVXWaeLS9zUaWXd.")) {
-            assertionValue = 1_500;
-        }
-
+    public void testParseCryptString(String cryptString, int iterCount) throws NoSuchAlgorithmException, InvalidKeySpecException {
         SunUnixMD5CryptPassword password = (SunUnixMD5CryptPassword) ModularCrypt.decode(cryptString);
-        assertEquals(assertionValue, password.getIterationCount());
+        assertEquals(iterCount, password.getIterationCount());
 
         // Use the spec to build a new crypt string and compare it to the original
         assertEquals(cryptString, ModularCrypt.encodeAsString(password));


### PR DESCRIPTION
JIRA issue number: [ELY-2689](https://issues.redhat.com/browse/ELY-2689)

## Description
Provide a more detailed description of the changes. It might include:
Three tests in SunUnixMD5CryptTest.java [(password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java)](https://github.com/shreya-pramod/wildfly-elytron/blob/wildfly-feature/password/impl/src/test/java/org/wildfly/security/password/impl/SunUnixMD5CryptTest.java) had to be optimized. The tests had repeated lines of code. 

## Context
This change is to avoid code repetition. 

## Testing
All tests ran successfully. 

## Changes
- A common method created testParseCryptString(String cryptString) [Line 61] which is called from each test that is used to run the tests. 

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.
