### PR TITLE
[ELY-2455]: Add a "FAQ for New Contributors" section to the CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,4 +148,4 @@ Remember, we value your contributions and are here to support you throughout the
 A: If you encounter any issues or have questions, feel free to reach out to the community on our [communication channels](https://wildfly-security.github.io/wildfly-elytron/community/). We are here to help!
 
 ## Community
-For more information on how to get involved with WildFly Elytron, check out our [community](https://wildfly-security.github.io/wildfly-elytron/community/) page.6
+For more information on how to get involved with WildFly Elytron, check out our [community](https://wildfly-security.github.io/wildfly-elytron/community/) page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ Welcome to the WildFly Elytron project! We welcome contributions from the commun
   - [Good First Issues](#good-first-issues)
 - [Setting up your Developer Environment](#setting-up-your-developer-environment)
 - [Contributing Guidelines](#contributing-guidelines)
-  - [Code Style and Conventions](#code-style-and-conventions)
   - [Testing](#testing)
   - [Pull Request Process](#pull-request-process)
   - [Documentation](#documentation)
+- [FAQ for New Contributors](#faq-for-new-contributors)
 - [Community](#community)
 
 
@@ -92,16 +92,6 @@ For more information, including details on how WildFly Elytron is integrated in 
 
 ## Contributing Guidelines
 
-
-### Code Style and Conventions
-
-We follow a specific set of code style and conventions in our project. Please adhere to the following guidelines:
-
-- **Indentation:** Use four spaces for indentation.
-- **Naming Conventions:** Follow camelCase for variable and method names.
-
-Before submitting your pull request, make sure your code aligns with these conventions.
-
 ### Testing
 
 Ensure that your changes are thoroughly tested before submitting a pull request. Follow these testing guidelines:
@@ -112,13 +102,11 @@ Ensure that your changes are thoroughly tested before submitting a pull request.
 If applicable, provide instructions on how to run integration tests or any additional testing procedures.
 
 ### Documentation
-
 Contributors are encouraged to keep documentation up-to-date along with code changes. If your changes impact user-facing features, update the relevant documentation files in directory.
 
 If there are specific guidelines for documentation changes, please follow them closely.
 
 ### Pull Request Guidelines
-
 When submitting a PR, please keep the following guidelines in mind:
 
 1. In general, it's good practice to squash all of your commits into a single commit. For larger changes, it's ok to have multiple meaningful commits. If you need help with squashing your commits, feel free to ask us how to do this on your pull request. We're more than happy to help!
@@ -129,6 +117,35 @@ When submitting a PR, please keep the following guidelines in mind:
 
 For an example of a properly formatted PR, take a look at https://github.com/wildfly-security/wildfly-elytron/pull/1532
 
-## Community
+## FAQ for New Contributors
 
-For more information on how to get involved with WildFly Elytron, check out our [community](https://wildfly-security.github.io/wildfly-elytron/community/) page.
+### Q: How do I find good first issues to work on?
+A: You can find issues labeled as `good-first-issue` in our [JIRA project](https://issues.redhat.com/browse/WFLY-18776?filter=12364234). These are specifically curated for new contributors to get started.
+
+### Q: What is the process for assigning an issue to myself?
+A: To assign an issue to yourself, navigate to the issue on our [JIRA](https://issues.redhat.com/projects/ELY) and click on "Start Progress." This will automatically assign the issue to you.
+
+### Q: How should I name my feature branch?
+A: It is recommended to use a branch name that includes the JIRA issue number. For example, if you are working on [ELY-1234](https://issues.redhat.com/browse/ELY-1234), your branch name could be `ELY-1234-feature-description`.
+
+### Q: Can I work on multiple issues simultaneously?
+A: Yes, you can work on multiple issues simultaneously by creating separate feature branches for each issue. This allows you to have multiple pull requests open for different issues.
+
+### Q: I find the existing codebase complex. How can I understand it better?
+A: Take your time to explore the code gradually. Start by focusing on specific modules or components. Don't hesitate to ask questions on [communication channels](https://wildfly-security.github.io/wildfly-elytron/community/) if something is unclear.
+
+### Q: What should I do if I encounter build or test failures?
+A: Run 'mvn clean test' to identify and address build or test failures. If needed, seek help on community channels, and include details about the issue you're facing.
+
+### Q: How do I run tests before submitting a pull request?
+A: To run tests, use the following Maven command: `mvn clean test`. Additionally, include new unit tests for your code changes.
+
+### Q: How should I handle feedback on my contributions?
+A: Embrace feedback as a learning opportunity. Review and address comments provided by maintainers or community members, and consider it a collaborative effort to improve your contributions.
+Remember, we value your contributions and are here to support you throughout the process. Don't hesitate to seek assistance and enjoy your journey as a contributor!
+
+### Q: What should I do if I encounter issues during the contribution process?
+A: If you encounter any issues or have questions, feel free to reach out to the community on our [communication channels](https://wildfly-security.github.io/wildfly-elytron/community/). We are here to help!
+
+## Community
+For more information on how to get involved with WildFly Elytron, check out our [community](https://wildfly-security.github.io/wildfly-elytron/community/) page.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,33 @@ Note: Some tests will fail if `localhost` is not listed first in `/etc/hosts` fi
 
 For more information, including details on how WildFly Elytron is integrated in WildFly Core and WildFly, check out our [developer guide](https://wildfly-security.github.io/wildfly-elytron/getting-started-for-developers/).
 
+## Code Style and Conventions
+
+We follow a specific set of code style and conventions in our project. Please adhere to the following guidelines:
+
+- **Indentation:** Use four spaces for indentation.
+- **Naming Conventions:** Follow camelCase for variable and method names.
+- ...
+
+Before submitting your pull request, make sure your code aligns with these conventions.
+
+## Testing
+
+Ensure that your changes are thoroughly tested before submitting a pull request. Follow these testing guidelines:
+
+- Run the existing unit tests using Maven: `mvn clean test`
+- Include new unit tests for your code changes.
+- ...
+
+If applicable, provide instructions on how to run integration tests or any additional testing procedures.
+
+## Documentation
+
+Contributors are encouraged to keep documentation up-to-date along with code changes. If your changes impact user-facing features, update the relevant documentation files in the `docs/` directory.
+
+If there are specific guidelines for documentation changes, please follow them closely.
+
+
 ## Contributing Guidelines
 
 When submitting a PR, please keep the following guidelines in mind:
@@ -98,4 +125,5 @@ When submitting a PR, please keep the following guidelines in mind:
 For an example of a properly formatted PR, take a look at https://github.com/wildfly-security/wildfly-elytron/pull/1532
 
 ## Community
+
 For more information on how to get involved with WildFly Elytron, check out our [community](https://wildfly-security.github.io/wildfly-elytron/community/) page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Welcome to the WildFly Elytron project! We welcome contributions from the commun
   - [Good First Issues](#good-first-issues)
 - [Setting up your Developer Environment](#setting-up-your-developer-environment)
 - [Contributing Guidelines](#contributing-guidelines)
+  - [Code Style and Conventions](#code-style-and-conventions)
+  - [Testing](#testing)
+  - [Pull Request Process](#pull-request-process)
+  - [Documentation](#documentation)
 - [Community](#community)
 
 
@@ -85,34 +89,35 @@ Note: Some tests will fail if `localhost` is not listed first in `/etc/hosts` fi
 
 For more information, including details on how WildFly Elytron is integrated in WildFly Core and WildFly, check out our [developer guide](https://wildfly-security.github.io/wildfly-elytron/getting-started-for-developers/).
 
-## Code Style and Conventions
+
+## Contributing Guidelines
+
+
+### Code Style and Conventions
 
 We follow a specific set of code style and conventions in our project. Please adhere to the following guidelines:
 
 - **Indentation:** Use four spaces for indentation.
 - **Naming Conventions:** Follow camelCase for variable and method names.
-- ...
 
 Before submitting your pull request, make sure your code aligns with these conventions.
 
-## Testing
+### Testing
 
 Ensure that your changes are thoroughly tested before submitting a pull request. Follow these testing guidelines:
 
 - Run the existing unit tests using Maven: `mvn clean test`
 - Include new unit tests for your code changes.
-- ...
 
 If applicable, provide instructions on how to run integration tests or any additional testing procedures.
 
-## Documentation
+### Documentation
 
-Contributors are encouraged to keep documentation up-to-date along with code changes. If your changes impact user-facing features, update the relevant documentation files in the `docs/` directory.
+Contributors are encouraged to keep documentation up-to-date along with code changes. If your changes impact user-facing features, update the relevant documentation files in directory.
 
 If there are specific guidelines for documentation changes, please follow them closely.
 
-
-## Contributing Guidelines
+### Pull Request Guidelines
 
 When submitting a PR, please keep the following guidelines in mind:
 


### PR DESCRIPTION
[ELY-2455]: Add a "FAQ for New Contributors" section to the CONTRIBUTING.md file

Issue: https://issues.redhat.com/browse/ELY-2455

-Added FAQ's section for New contributors.
-Updated the CONTRUBITING.md file.
  -Pull Request section added for more clarity.
  -Testing and Documentations guidelines added for new contributors to understand the importance of documentation and 
    testing their fixes.