### PR TITLE
[ELY-2589] Make sure the delegate#setAuthorized call happens before the super#setAuthorized call for SSO to ensure the session cache has the correct information after a session ID change

### DIFF
--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -276,16 +276,16 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                             callbacks[i] = new CachedIdentityAuthorizeCallback(principal, singleSignOnSession) {
                                 @Override
                                 public void setAuthorized(SecurityIdentity securityIdentity) {
-                                    super.setAuthorized(securityIdentity);
                                     delegate.setAuthorized(securityIdentity);
+                                    super.setAuthorized(securityIdentity);
                                 }
                             };
                         } else {
                             callbacks[i] = new CachedIdentityAuthorizeCallback(singleSignOnSession, delegate.isLocalCache()) {
                                 @Override
                                 public void setAuthorized(SecurityIdentity securityIdentity) {
-                                    super.setAuthorized(securityIdentity);
                                     delegate.setAuthorized(securityIdentity);
+                                    super.setAuthorized(securityIdentity);
                                 }
                             };
                         }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2589
https://issues.redhat.com/browse/JBEAP-25796

**Description of the fix**

The changes for [ELY-1945](https://issues.redhat.com/browse/ELY-1945) ensure that if we are associating an identity with the session for the first time then we need to change the ID of the session.

However, when the ID of the session is changed, the SSO session cache doesn't get updated accordingly. This means that the corresponding logout handling for the session won't get registered.

This PR changes the order in which `setAuthorized` gets called in [CachedIdentityAuthorizationCallback#setAuthorized](https://github.com/wildfly-security/wildfly-elytron/blob/2.x/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java#L276-L293) to ensure that the entry that gets added to the SSO session cache has the correct session ID.

More details about this fix can be found [here](https://issues.redhat.com/browse/ELY-2589?focusedId=23734934&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-23734934).

**Tests**

Note that a new test case for this fix has been added to the Elytron Web test suite, see https://github.com/wildfly-security/elytron-web/pull/245.

