### PR TITLE
[ELY-2717] Ensure that the credential algorithm for the DIGEST mechanism is set to digest-md5

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -23,6 +23,7 @@ import static org.wildfly.security.http.HttpConstants.AUTH;
 import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
 import static org.wildfly.security.http.HttpConstants.BAD_REQUEST;
 import static org.wildfly.security.http.HttpConstants.CNONCE;
+import static org.wildfly.security.http.HttpConstants.DIGEST_NAME;
 import static org.wildfly.security.http.HttpConstants.NC;
 import static org.wildfly.security.http.HttpConstants.QOP;
 import static org.wildfly.security.http.HttpConstants.URI;
@@ -69,6 +70,7 @@ import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.mechanism.AuthenticationMechanismException;
 import org.wildfly.security.mechanism.digest.DigestQuote;
 import org.wildfly.security.mechanism.digest.PasswordDigestObtainer;
+import org.wildfly.security.password.interfaces.DigestPassword;
 
 /**
  * Implementation of the HTTP DIGEST authentication mechanism as defined in RFC 7616.
@@ -326,8 +328,17 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
     }
 
     private byte[] getH_A1(final MessageDigest messageDigest, final String username, final String messageRealm) throws AuthenticationMechanismException {
-        PasswordDigestObtainer obtainer = new PasswordDigestObtainer(callbackHandler, username, messageRealm, httpDigest, getMechanismName().toLowerCase(Locale.ROOT), messageDigest, providers, null, true, false);
+        PasswordDigestObtainer obtainer = new PasswordDigestObtainer(callbackHandler, username, messageRealm, httpDigest, getCredentialAlgorithm(getMechanismName()), messageDigest, providers, null, true, false);
         return obtainer.handleUserRealmPasswordCallbacks();
+    }
+
+    private String getCredentialAlgorithm(String mechanismName) {
+        switch (mechanismName) {
+            case DIGEST_NAME:
+                return DigestPassword.ALGORITHM_DIGEST_MD5;
+            default:
+                return mechanismName.toLowerCase(Locale.ROOT);
+        }
     }
 
     private String convertToken(final String name, final byte[] value) throws AuthenticationMechanismException {

--- a/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -430,11 +430,13 @@ public class AbstractBaseHttpTest {
                     Assert.assertEquals(username, ((NameCallback) callback).getDefaultName());
                 } else if (callback instanceof CredentialCallback) {
                     if (useDigestPassword) {
-                        if (! DigestPassword.ALGORITHM_DIGEST_SHA_256.equals(((CredentialCallback) callback).getAlgorithm())) {
+                        String credentialAlgorithm = ((CredentialCallback) callback).getAlgorithm();
+                        if (! DigestPassword.ALGORITHM_DIGEST_SHA_256.equals(credentialAlgorithm) &&
+                                ! DigestPassword.ALGORITHM_DIGEST_MD5.equals(credentialAlgorithm)) {
                             throw new UnsupportedCallbackException(callback);
                         }
                         try {
-                            PasswordFactory factory = PasswordFactory.getInstance(DigestPassword.ALGORITHM_DIGEST_SHA_256, ELYTRON_PASSWORD_PROVIDERS);
+                            PasswordFactory factory = PasswordFactory.getInstance(credentialAlgorithm, ELYTRON_PASSWORD_PROVIDERS);
                             DigestPasswordAlgorithmSpec algorithmSpec = new DigestPasswordAlgorithmSpec(username, realm);
                             EncryptablePasswordSpec encryptableSpec = new EncryptablePasswordSpec(password.toCharArray(), algorithmSpec);
                             DigestPassword digestPassword = (DigestPassword) factory.generatePassword(encryptableSpec);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2717

Follows up on https://github.com/wildfly-security/wildfly-elytron/pull/1927 to ensure that the correct credential algorithm gets set for the DIGEST mechanism.

More details can be found [here](https://issues.redhat.com/browse/ELY-2717).