### PR TITLE
[ELY-2728] Upgrade japicmp-maven-plugin to 0.20.0 so we can build with JDK 21

### DIFF
--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -821,7 +821,7 @@
                     <plugin>
                         <groupId>com.github.siom79.japicmp</groupId>
                         <artifactId>japicmp-maven-plugin</artifactId>
-                        <version>0.13.0</version>
+                        <version>0.20.0</version>
                         <configuration>
                             <oldVersion>
                                 <dependency>

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -546,7 +546,7 @@
                     <plugin>
                         <groupId>com.github.siom79.japicmp</groupId>
                         <artifactId>japicmp-maven-plugin</artifactId>
-                        <version>0.13.0</version>
+                        <version>0.20.0</version>
                         <inherited>false</inherited>
                         <configuration>
                             <oldVersion>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2728