### PR TITLE
[ELY-2548] BasicAuthenticationMechanism should return FORBIDDEN instead of UNAUTHORIZED

### DIFF
--- a/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
+++ b/http/basic/src/main/java/org/wildfly/security/http/basic/BasicAuthenticationMechanism.java
@@ -42,6 +42,7 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import org.wildfly.common.iteration.ByteIterator;
 import org.wildfly.security.auth.callback.AvailableRealmsCallback;
 import org.wildfly.security.http.HttpAuthenticationException;
+import org.wildfly.security.http.HttpConstants;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.mechanism.http.UsernamePasswordAuthenticationMechanism;
@@ -170,7 +171,7 @@ final class BasicAuthenticationMechanism extends UsernamePasswordAuthenticationM
                                 httpBasic.debugf("User %s authorization failed.", username);
                                 fail();
 
-                                request.authenticationFailed(httpBasic.authorizationFailed(username), response -> prepareResponse(request, displayRealmName, response));
+                                request.authenticationFailed(httpBasic.authorizationFailed(username), response -> response.setStatusCode(HttpConstants.FORBIDDEN));
                                 return;
                             }
 

--- a/tests/base/src/test/java/org/wildfly/security/http/basic/BasicAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/basic/BasicAuthenticationMechanismTest.java
@@ -99,4 +99,15 @@ public class BasicAuthenticationMechanismTest extends AbstractBaseHttpTest {
         testStatefulBasic("Aladdin", "WallyWorld", "open sesame", "basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
         testStatefulBasic("test", "foo", "123\u00A3", "BASIC dGVzdDoxMjPCow==");
     }
+
+    @Test
+    public void testBasicUnauthorizedUser() throws Exception {
+       HttpServerAuthenticationMechanism mechanism = basicFactory.createAuthenticationMechanism(HttpConstants.BASIC_NAME,
+                Collections.singletonMap(HttpConstants.CONFIG_REALM, "test-realm"), getCallbackHandler("unauthorizedUser", "test-realm", "password"));
+        TestingHttpServerRequest request = new TestingHttpServerRequest(new String[] {"Basic dW5hdXRob3JpemVkVXNlcjpwYXNzd29yZA=="});
+        mechanism.evaluateRequest(request);
+        Assert.assertEquals(Status.FAILED, request.getResult());
+        TestingHttpServerResponse response = request.getResponse();
+        Assert.assertEquals(HttpConstants.FORBIDDEN, response.getStatusCode());
+    }
 }

--- a/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -471,7 +471,10 @@ public class AbstractBaseHttpTest {
                     Assert.assertNotNull(clearPwdCredential);
                     Assert.assertArrayEquals(password.toCharArray(), clearPwdCredential.getPassword());
                 } else if (callback instanceof AuthorizeCallback) {
-                    if(username.equals(((AuthorizeCallback) callback).getAuthenticationID()) &&
+                    if(username.equalsIgnoreCase("unauthorizedUser")){
+                        ((AuthorizeCallback) callback).setAuthorized(false);
+                    }
+                    else if(username.equals(((AuthorizeCallback) callback).getAuthenticationID()) &&
                        username.equals(((AuthorizeCallback) callback).getAuthorizationID())) {
                         ((AuthorizeCallback) callback).setAuthorized(true);
                     } else {


### PR DESCRIPTION
This is a resubmission of https://github.com/wildfly-security/wildfly-elytron/pull/1899 to address the merge conflict.

https://issues.redhat.com/browse/ELY-2548

@Skyllarr FYI you had approved the original submission of this PR.

