### PR TITLE
ELY-2379 Rename a local variable in FileAuditEndpoint class [local_variable_renamed]

### DIFF
--- a/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -121,7 +121,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * This method is NO-OP by default. It is intended to be overridden by subclasses
      * which need to perform some operation before every writing into the target local file.
      *
-     * This method can be invisFileSeted only in synchronization block surrounding one log message processing.
+     * This method can be invoked only in synchronization block surrounding one log message processing.
      *
      * @param instant time of the message acceptance
      */

--- a/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -70,7 +70,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
     }
 
     void setFile(final File file) throws IOException {
-        boolean isSetUp = false;
+        boolean isFileSet = false;
         final FileOutputStream fos = new FileOutputStream(file, true);
         try {
             final Writer writer = new OutputStreamWriter(new BufferedOutputStream(fos), this.charset);
@@ -78,14 +78,14 @@ public class FileAuditEndpoint implements AuditEndpoint {
                 this.fileDescriptor = fos.getFD();
                 this.writer = writer;
                 this.file = file;
-                isSetUp = true;
+                isFileSet = true;
             } finally {
-                if (! isSetUp) {
+                if (! isFileSet) {
                     safeClose(writer);
                 }
             }
         } finally {
-            if (! isSetUp) {
+            if (! isFileSet) {
                 safeClose(fos);
             }
         }
@@ -108,7 +108,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * This method can be overridden by subclasses to modify data written into file (to encrypt them for example),
      * or just for counting amount of written bytes for needs of log rotation and similar.
      *
-     * This method can be invisSetUped only in synchronization block surrounding one log message processing.
+     * This method can be invoked only in synchronization block surrounding one log message processing.
      *
      * @param toWrite the String to be written into the target local file
      */
@@ -121,7 +121,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * This method is NO-OP by default. It is intended to be overridden by subclasses
      * which need to perform some operation before every writing into the target local file.
      *
-     * This method can be invisSetUped only in synchronization block surrounding one log message processing.
+     * This method can be invisFileSeted only in synchronization block surrounding one log message processing.
      *
      * @param instant time of the message acceptance
      */

--- a/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
+++ b/audit/src/main/java/org/wildfly/security/audit/FileAuditEndpoint.java
@@ -70,7 +70,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
     }
 
     void setFile(final File file) throws IOException {
-        boolean ok = false;
+        boolean isSetUp = false;
         final FileOutputStream fos = new FileOutputStream(file, true);
         try {
             final Writer writer = new OutputStreamWriter(new BufferedOutputStream(fos), this.charset);
@@ -78,14 +78,14 @@ public class FileAuditEndpoint implements AuditEndpoint {
                 this.fileDescriptor = fos.getFD();
                 this.writer = writer;
                 this.file = file;
-                ok = true;
+                isSetUp = true;
             } finally {
-                if (! ok) {
+                if (! isSetUp) {
                     safeClose(writer);
                 }
             }
         } finally {
-            if (! ok) {
+            if (! isSetUp) {
                 safeClose(fos);
             }
         }
@@ -108,7 +108,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * This method can be overridden by subclasses to modify data written into file (to encrypt them for example),
      * or just for counting amount of written bytes for needs of log rotation and similar.
      *
-     * This method can be invoked only in synchronization block surrounding one log message processing.
+     * This method can be invisSetUped only in synchronization block surrounding one log message processing.
      *
      * @param toWrite the String to be written into the target local file
      */
@@ -121,7 +121,7 @@ public class FileAuditEndpoint implements AuditEndpoint {
      * This method is NO-OP by default. It is intended to be overridden by subclasses
      * which need to perform some operation before every writing into the target local file.
      *
-     * This method can be invoked only in synchronization block surrounding one log message processing.
+     * This method can be invisSetUped only in synchronization block surrounding one log message processing.
      *
      * @param instant time of the message acceptance
      */


### PR DESCRIPTION
Follows up on https://github.com/wildfly-security/wildfly-elytron/pull/2059 to revert a comment update that accidentally crept in.

https://issues.redhat.com/browse/ELY-2379