### PR TITLE
[ELY-2723] Fix failures in SSLAuthenticationTestCase with SE 21

### DIFF
--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -54,6 +54,7 @@
 
     <properties>
         <version.org.codehaus.mojo.xml.plugin>1.0.2</version.org.codehaus.mojo.xml.plugin>
+        <version.org.glassfish.jaxb.jaxb-runtime>2.4.0-b180830.0438</version.org.glassfish.jaxb.jaxb-runtime>
     </properties>
 
     <build>
@@ -770,15 +771,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${version.org.glassfish.jaxb.jaxb-runtime}</version>
             <scope>test</scope>
         </dependency>
 

--- a/tests/base/src/test/java/org/wildfly/security/ssl/TestingOcspServer.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/TestingOcspServer.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.ssl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -42,6 +43,7 @@ import org.junit.Assert;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.Times;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.NottableString;
 import org.wildfly.common.iteration.ByteIterator;
@@ -126,32 +128,13 @@ public class TestingOcspServer {
                         .withMethod("POST")
                         .withPath("/ocsp"),
                 Times.unlimited())
-                .respond(request -> {
-                    ByteBuf buffer = Unpooled.wrappedBuffer(request.getBody().getRawBytes());
-                    FullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.POST, request.getPath().getValue(), buffer);
-                    for (Header header : request.getHeaderList()) {
-                        for (NottableString value : header.getValues()) {
-                            nettyRequest.headers().add(header.getName().getValue(), value.getValue());
-                        }
-                    }
-
-                    FullHttpResponse nettyResponse;
-                    try {
-                        nettyResponse = servlet.service(nettyRequest, new ServletURI(request.getPath().getValue()), null, SslReverseProxyMode.NONE);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-
-                    HttpResponse response = response()
-                            .withStatusCode(nettyResponse.status().code())
-                            .withBody(nettyResponse.content().array());
-
-                    for (Map.Entry<String, String> header : nettyResponse.headers()) {
-                        response.withHeader(header.getKey(), header.getValue());
-                    }
-
-                    return response;
-                });
+                .respond(request -> getHttpResponse(request, servlet));
+        server.when(
+                        request()
+                                .withMethod("GET")
+                                .withPath("/ocsp/.*"),
+                        Times.unlimited())
+                .respond(request -> getHttpResponse(request, servlet));
     }
 
     public void stop() throws SQLException {
@@ -198,4 +181,40 @@ public class TestingOcspServer {
         statement.execute();
     }
 
+
+
+    public HttpResponse getHttpResponse(HttpRequest request, HttpOcspServlet servlet){
+        byte[] body;
+        HttpMethod method;
+        if (request.getBody() == null) {
+            method = HttpMethod.GET;
+            body = request.getPath().getValue().split("/ocsp/", 2)[1].getBytes(UTF_8);
+        } else {
+            method = HttpMethod.POST;
+            body = request.getBody().getRawBytes();
+        }
+        ByteBuf buffer = Unpooled.wrappedBuffer(body);
+        FullHttpRequest nettyRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_0, method, request.getPath().getValue(), buffer);
+        for (Header header : request.getHeaderList()) {
+            for (NottableString value : header.getValues()) {
+                nettyRequest.headers().add(header.getName().getValue(), value.getValue());
+            }
+        }
+
+        FullHttpResponse nettyResponse;
+        try {
+            nettyResponse = servlet.service(nettyRequest, new ServletURI(request.getPath().getValue()), null, SslReverseProxyMode.NONE);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        HttpResponse response = response()
+                .withStatusCode(nettyResponse.status().code())
+                .withBody(nettyResponse.content().array());
+
+        for (Map.Entry<String, String> header : nettyResponse.headers()) {
+            response.withHeader(header.getKey(), header.getValue());
+        }
+        return response;
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2723

This solution passes on JDK 21 but it is not ideal as the dependency version <version.org.glassfish.jaxb.jaxb-runtime>2.4.0-b180830.0438</version.org.glassfish.jaxb.jaxb-runtime> is older and contains vulnerabilities: https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime/2.4.0-b180830.0438 . This  specific version is also used in wildfly repo: https://github.com/wildfly/wildfly/blob/main/testsuite/integration/elytron/pom.xml#L46 but it should be updated there as well. When I update the version to latest, the test does not pass anymore. So this needs further investigation later.