### PR TITLE
[ELY-2725] Update the modular.jdk.args used by the tests to get GssapiTestSuite passing with JDK 21

### DIFF
--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -799,7 +799,7 @@
             </activation>
             <properties>
                 <!-- [WFCORE-1431] remove SASL workaround -->
-                <modular.jdk.args>--add-modules java.sql --illegal-access=permit</modular.jdk.args>
+                <modular.jdk.args>--add-modules java.sql --illegal-access=permit --add-exports=jdk.security.jgss/com.sun.security.sasl.gsskerb=ALL-UNNAMED</modular.jdk.args>
                 <!-- use version of jboss-logging that works much better with JDK9 -->
                 <modular.jdk.props>-Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <!-- 2.20.x doesn't start on JDK10-->


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2725

`CommunicationSuiteChild` is used by `GssapiTestSuite`. In order to get this testsuite passing with JDK 21, we need to update the `modular.jdk.args` used by the tests because `CommunicationSuiteChild` attempts to create a SASL factory using the `com.sun.security.sasl.gsskerb.FactoryImpl` which is internal API.