### PR TITLE
[ELY-2754] URL encode access token to introspect.

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/OAuth2IntrospectValidator.java
@@ -41,6 +41,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class OAuth2IntrospectValidator implements TokenValidator {
 
             HashMap<String, String> parameters = new HashMap<>();
 
-            parameters.put("token", token);
+            parameters.put("token", URLEncoder.encode(token, StandardCharsets.UTF_8.toString()));
             parameters.put("token_type_hint", "access_token");
 
             byte[] params = buildParameters(parameters);


### PR DESCRIPTION
URL encode the access token before making the introspect request.

Jira ticket: https://issues.redhat.com/browse/ELY-2754