### PR TITLE
[ELY-2752] Ensure it's possible to make use of a custom principal-attribute value for OIDC

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/ElytronMessages.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/ElytronMessages.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.http.oidc;
 
+import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.annotations.Message.NONE;
@@ -232,6 +233,10 @@ interface ElytronMessages extends BasicLogger {
 
     @Message(id = 23056, value = "No message entity")
     IOException noMessageEntity();
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 23057, value = "principal-attribute '%s' claim does not exist, falling back to 'sub'")
+    void principalAttributeClaimDoesNotExist(String principalAttributeClaim);
 
 }
 

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/JsonWebToken.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/JsonWebToken.java
@@ -297,7 +297,14 @@ public class JsonWebToken {
             case NICKNAME:
                 return getNickName();
             default:
-                return getSubject();
+                String claimValue = getClaimValueAsString(attr);
+                if (claimValue != null) {
+                    return claimValue;
+                } else {
+                    // fall back to sub claim
+                    log.principalAttributeClaimDoesNotExist(attr);
+                    return getSubject();
+                }
         }
     }
 

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -188,6 +188,24 @@ public class OidcTest extends OidcBaseTest {
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
+    @Test
+    public void testPrincipalAttribute() throws Exception {
+        // custom principal-attribute
+        performAuthentication(getOidcConfigurationInputStreamWithPrincipalAttribute("aud"), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT,
+                getCallbackHandler("test-webapp"));
+
+        // standard principal-attribute
+        performAuthentication(getOidcConfigurationInputStreamWithPrincipalAttribute("given_name"), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT,
+                getCallbackHandler("Alice"));
+
+        // invalid principal-attribute, logging in should still succeed
+        performAuthentication(getOidcConfigurationInputStreamWithPrincipalAttribute("invalid_claim"), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT,
+                getCallbackHandler());
+    }
+
     /*****************************************************************************************************************************************
      * Tests for multi-tenancy.
      *
@@ -492,6 +510,20 @@ public class OidcTest extends OidcBaseTest {
     private InputStream getOidcConfigurationInputStreamWithTokenSignatureAlgorithm() {
         String oidcConfig = "{\n" +
                 "    \"token-signature-algorithm\" : \"RS256\",\n" +
+                "    \"resource\" : \"" + CLIENT_ID + "\",\n" +
+                "    \"public-client\" : \"false\",\n" +
+                "    \"provider-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "\",\n" +
+                "    \"ssl-required\" : \"EXTERNAL\",\n" +
+                "    \"credentials\" : {\n" +
+                "        \"secret\" : \"" + CLIENT_SECRET + "\"\n" +
+                "    }\n" +
+                "}";
+        return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream getOidcConfigurationInputStreamWithPrincipalAttribute(String principalAttributeValue) {
+        String oidcConfig = "{\n" +
+                "    \"principal-attribute\" : \"" + principalAttributeValue + "\",\n" +
                 "    \"resource\" : \"" + CLIENT_ID + "\",\n" +
                 "    \"public-client\" : \"false\",\n" +
                 "    \"provider-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "\",\n" +


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2752
https://issues.redhat.com/browse/JBEAP-26977

Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/2137

Note that forward porting this fix to 2.x would have resulted in a bunch of conflicts so I have submitted separate PRs against 2.x and 2.2.x explicitly.