### PR TITLE
[ELY-2340] Add the ability to allow query params in redirect URIs via a new system property

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
@@ -65,6 +65,7 @@ public class Oidc {
     public static final String FACES_REQUEST = "Faces-Request";
     public static final String GRANT_TYPE = "grant_type";
     public static final String INVALID_TOKEN = "invalid_token";
+    public static final String ISSUER = "iss";
     public static final String LOGIN_HINT = "login_hint";
     public static final String DOMAIN_HINT = "domain_hint";
     public static final String MAX_AGE = "max_age";
@@ -113,6 +114,7 @@ public class Oidc {
     static final String KEYCLOAK_QUERY_BEARER_TOKEN = "k_query_bearer_token";
     static final String DEFAULT_TOKEN_SIGNATURE_ALGORITHM = "RS256";
     public static final String DISABLE_TYP_CLAIM_VALIDATION_PROPERTY_NAME = "wildfly.elytron.oidc.disable.typ.claim.validation";
+    public static final String ALLOW_QUERY_PARAMS_PROPERTY_NAME = "wildfly.elytron.oidc.allow.query.params";
     public static final String X_REQUESTED_WITH = "X-Requested-With";
     public static final String XML_HTTP_REQUEST = "XMLHttpRequest";
 

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/BearerTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/BearerTest.java
@@ -488,7 +488,7 @@ public class BearerTest extends OidcBaseTest {
         return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
     }
 
-    private InputStream getOidcConfigurationInputStreamWithProviderUrl() {
+    protected InputStream getOidcConfigurationInputStreamWithProviderUrl() {
         String oidcConfig = "{\n" +
                 "    \"client-id\" : \"" + BEARER_ONLY_CLIENT_ID + "\",\n" +
                 "    \"provider-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "\",\n" +

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcBaseTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcBaseTest.java
@@ -299,7 +299,12 @@ public class OidcBaseTest extends AbstractBaseHttpTest {
     }
 
     protected void performAuthentication(InputStream oidcConfig, String username, String password, boolean loginToKeycloak,
-                                       int expectedDispatcherStatusCode, String expectedLocation, String clientPageText) throws Exception {
+                                         int expectedDispatcherStatusCode, String expectedLocation, String clientPageText) throws Exception {
+        performAuthentication(oidcConfig, username, password, loginToKeycloak, expectedDispatcherStatusCode, getClientUrl(), expectedLocation, clientPageText);
+    }
+
+    protected void performAuthentication(InputStream oidcConfig, String username, String password, boolean loginToKeycloak,
+                                       int expectedDispatcherStatusCode, String clientUrl, String expectedLocation, String clientPageText) throws Exception {
         try {
             Map<String, Object> props = new HashMap<>();
             OidcClientConfiguration oidcClientConfiguration = OidcClientConfigurationBuilder.build(oidcConfig);
@@ -309,7 +314,7 @@ public class OidcBaseTest extends AbstractBaseHttpTest {
             oidcFactory = new OidcMechanismFactory(oidcClientContext);
             HttpServerAuthenticationMechanism mechanism = oidcFactory.createAuthenticationMechanism(OIDC_NAME, props, getCallbackHandler());
 
-            URI requestUri = new URI(getClientUrl());
+            URI requestUri = new URI(clientUrl);
             TestingHttpServerRequest request = new TestingHttpServerRequest(null, requestUri);
             mechanism.evaluateRequest(request);
             TestingHttpServerResponse response = request.getResponse();

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -132,13 +132,13 @@ public class OidcTest extends OidcBaseTest {
 
     @Test
     public void testWrongAuthServerUrl() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStream(CLIENT_SECRET, "http://fakeauthserver/auth"), KeycloakConfiguration.ALICE,
+        performAuthentication(getOidcConfigurationInputStream(CLIENT_SECRET, "http://fakeauthserver/auth"), KeycloakConfiguration.ALICE,
                 KeycloakConfiguration.ALICE_PASSWORD, false, -1, null, null);
     }
 
     @Test
     public void testWrongClientSecret() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStream("WRONG_CLIENT_SECRET"), KeycloakConfiguration.ALICE,
+        performAuthentication(getOidcConfigurationInputStream("WRONG_CLIENT_SECRET"), KeycloakConfiguration.ALICE,
                 KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_FORBIDDEN, null,"Forbidden");
     }
 
@@ -149,19 +149,19 @@ public class OidcTest extends OidcBaseTest {
 
     @Test
     public void testSucessfulAuthenticationWithAuthServerUrl() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStream(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStream(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
     @Test
     public void testSucessfulAuthenticationWithProviderUrl() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
     @Test
     public void testSucessfulAuthenticationWithProviderUrlTrailingSlash() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStreamWithProviderUrlTrailingSlash(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrlTrailingSlash(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
@@ -171,20 +171,20 @@ public class OidcTest extends OidcBaseTest {
         String providerUrlEnv = System.getenv("OIDC_PROVIDER_URL_ENV");
         assertEquals(oidcProviderUrl, providerUrlEnv);
 
-        loginToAppMultiTenancy(getOidcConfigurationInputStreamWithEnvironmentVariableExpression(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStreamWithEnvironmentVariableExpression(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
     @Test
     public void testSucessfulAuthenticationWithSystemPropertyExpression() throws Exception {
-        loginToAppMultiTenancy(getOidcConfigurationInputStreamWithSystemPropertyExpression(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStreamWithSystemPropertyExpression(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
     @Test
     public void testTokenSignatureAlgorithm() throws Exception {
         // keycloak uses RS256
-        loginToAppMultiTenancy(getOidcConfigurationInputStreamWithTokenSignatureAlgorithm(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+        performAuthentication(getOidcConfigurationInputStreamWithTokenSignatureAlgorithm(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
     }
 
@@ -363,8 +363,8 @@ public class OidcTest extends OidcBaseTest {
         assertTrue(page.getBody().asText().contains("Invalid username or password"));
     }
 
-    private void loginToAppMultiTenancy(InputStream oidcConfig, String username, String password, boolean loginToKeycloak,
-                                        int expectedDispatcherStatusCode, String expectedLocation, String clientPageText) throws Exception {
+    private void performAuthentication(InputStream oidcConfig, String username, String password, boolean loginToKeycloak,
+                                       int expectedDispatcherStatusCode, String expectedLocation, String clientPageText) throws Exception {
         try {
             Map<String, Object> props = new HashMap<>();
             OidcClientConfiguration oidcClientConfiguration = OidcClientConfigurationBuilder.build(oidcConfig);

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsBaseTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsBaseTest.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.http.oidc;
+
+import static org.junit.Assume.assumeTrue;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import io.restassured.RestAssured;
+import okhttp3.mockwebserver.MockWebServer;
+
+/**
+ * Tests for the {@code wildfly.elytron.oidc.allow.query.params} system property.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class QueryParamsBaseTest extends OidcBaseTest {
+
+    @BeforeClass
+    public static void startTestContainers() throws Exception {
+        assumeTrue("Docker isn't available, OIDC tests will be skipped", isDockerAvailable());
+        KEYCLOAK_CONTAINER = new KeycloakContainer();
+        KEYCLOAK_CONTAINER.start();
+        sendRealmCreationRequest(KeycloakConfiguration.getRealmRepresentation(TEST_REALM, CLIENT_ID, CLIENT_SECRET, CLIENT_HOST_NAME, CLIENT_PORT, CLIENT_APP, 3, 3, true));
+        client = new MockWebServer();
+        client.start(CLIENT_PORT);
+    }
+
+    @AfterClass
+    public static void generalCleanup() throws Exception {
+        if (KEYCLOAK_CONTAINER != null) {
+            RestAssured
+                    .given()
+                    .auth().oauth2(KeycloakConfiguration.getAdminAccessToken(KEYCLOAK_CONTAINER.getAuthServerUrl()))
+                    .when()
+                    .delete(KEYCLOAK_CONTAINER.getAuthServerUrl() + "/admin/realms/" + TEST_REALM).then().statusCode(204);
+            KEYCLOAK_CONTAINER.stop();
+        }
+        if (client != null) {
+            client.shutdown();
+        }
+    }
+
+}

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsDisabledTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsDisabledTest.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.http.oidc;
+
+import static org.junit.Assume.assumeFalse;
+import static org.wildfly.security.http.oidc.Oidc.ALLOW_QUERY_PARAMS_PROPERTY_NAME;
+
+import org.apache.http.HttpStatus;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for disabling query params via the {@code wildfly.elytron.oidc.allow.query.params} system property.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class QueryParamsDisabledTest extends QueryParamsBaseTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        assumeFalse("wildfly.elytron.oidc.allow.query.params should default to false",
+                Boolean.parseBoolean(System.getProperty(ALLOW_QUERY_PARAMS_PROPERTY_NAME)));
+    }
+
+    /**
+     * Test successfully logging in without query params included in the URL.
+     */
+    @Test
+    public void testSuccessfulAuthenticationWithoutQueryParamsWithSystemPropertyDisabled() throws Exception {
+        String originalUrl = getClientUrl();
+        String expectedUrlAfterRedirect = originalUrl;
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, originalUrl,
+                expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+    }
+
+    /**
+     * Test successfully logging in with query params included in the URL.
+     * The query params should not be present upon redirect.
+     */
+    @Test
+    public void testSuccessfulAuthenticationWithQueryParamsWithSystemPropertyDisabled() throws Exception {
+        String queryParams = "?myparam=abc";
+        String originalUrl = getClientUrl() + queryParams;
+        String expectedUrlAfterRedirect = getClientUrl();
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY,
+                originalUrl, expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+
+        queryParams = "?one=abc&two=def&three=ghi";
+        originalUrl = getClientUrl() + queryParams;
+        expectedUrlAfterRedirect = getClientUrl();
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, originalUrl,
+                expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+    }
+
+}
+

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsEnabledTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/QueryParamsEnabledTest.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.http.oidc;
+
+import static org.wildfly.security.http.oidc.Oidc.ALLOW_QUERY_PARAMS_PROPERTY_NAME;
+
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for enabling query params via the {@code wildfly.elytron.oidc.allow.query.params} system property.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+public class QueryParamsEnabledTest extends QueryParamsBaseTest {
+
+    private static String ALLOW_QUERY_PARAMS_PROPERTY;
+
+    @BeforeClass
+    public static void beforeClass() {
+        ALLOW_QUERY_PARAMS_PROPERTY = System.setProperty(ALLOW_QUERY_PARAMS_PROPERTY_NAME, "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (ALLOW_QUERY_PARAMS_PROPERTY == null) {
+            System.clearProperty(ALLOW_QUERY_PARAMS_PROPERTY_NAME);
+        } else {
+            System.setProperty(ALLOW_QUERY_PARAMS_PROPERTY_NAME, ALLOW_QUERY_PARAMS_PROPERTY);
+        }
+    }
+
+    /**
+     * Test successfully logging in without query params included in the URL.
+     */
+    @Test
+    public void testSuccessfulAuthenticationWithoutQueryParamsWithSystemPropertyEnabled() throws Exception {
+        String originalUrl = getClientUrl();
+        String expectedUrlAfterRedirect = originalUrl;
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, originalUrl,
+                expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+    }
+
+    /**
+     * Test successfully logging in with query params included in the URL.
+     * The query params should be present upon redirect.
+     */
+    @Test
+    public void testSuccessfulAuthenticationWithQueryParamsWithSystemPropertyEnabled() throws Exception {
+        String queryParams = "?myparam=abc";
+        String originalUrl = getClientUrl() + queryParams;
+        String expectedUrlAfterRedirect = originalUrl;
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, originalUrl,
+                expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+
+        queryParams = "?one=abc&two=def&three=ghi";
+        originalUrl = getClientUrl() + queryParams;
+        expectedUrlAfterRedirect = originalUrl;
+        performAuthentication(getOidcConfigurationInputStreamWithProviderUrl(), KeycloakConfiguration.ALICE,
+                KeycloakConfiguration.ALICE_PASSWORD, true, HttpStatus.SC_MOVED_TEMPORARILY, originalUrl,
+                expectedUrlAfterRedirect, CLIENT_PAGE_TEXT);
+    }
+
+}
+


### PR DESCRIPTION
https://issues.redhat.com/browse/JBEAP-26323
https://issues.redhat.com/browse/ELY-2340

Upstream: https://github.com/wildfly-security/wildfly-elytron/pull/2135

Note that forward porting this fix to 2.x would have resulted in a bunch of conflicts so I have submitted separate PRs against 2.x and 2.2.x explicitly.