### PR TITLE
[ELY-2753] Add connection-timeout-millis, connection-ttl-millis and socket-timeout-millis to OidcJsonConfiguration to allow oidc.json configuration to parse these attributes

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
@@ -275,6 +275,15 @@ public class HttpClientBuilder {
         if (oidcClientConfig.getConnectionPoolSize() > 0) {
             size = oidcClientConfig.getConnectionPoolSize();
         }
+        if (oidcClientConfig.getConnectionTimeoutMillis() > 0) {
+            setEstablishConnectionTimeout(oidcClientConfig.getConnectionTimeoutMillis(), establishConnectionTimeoutUnits);
+        }
+        if (oidcClientConfig.getConnectionTtlMillis() > 0) {
+            setConnectionTimeToLive(oidcClientConfig.getConnectionTtlMillis(), connectionTimeToLiveUnit);
+        }
+        if (oidcClientConfig.getSocketTimeoutMillis() > 0) {
+            setSocketTimeout(oidcClientConfig.getSocketTimeoutMillis(), socketTimeoutUnits);
+        }
         HttpClientBuilder.HostnameVerificationPolicy policy = HttpClientBuilder.HostnameVerificationPolicy.WILDCARD;
         if (oidcClientConfig.isAllowAnyHostname()) {
             policy = HttpClientBuilder.HostnameVerificationPolicy.ANY;

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
@@ -66,6 +66,9 @@ public class Oidc {
     public static final String CORS_ALLOWED_METHODS = "cors-allowed-methods";
     public static final String CORS_EXPOSED_HEADERS = "cors-exposed-headers";
     public static final String CONNECTION_POOL_SIZE = "connection-pool-size";
+    public static final String CONNECTION_TIMEOUT_MILLIS = "connection-timeout-millis";
+    public static final String CONNECTION_TTL_MILLIS = "connection-ttl-millis";
+    public static final String SOCKET_TIMEOUT_MILLIS = "socket-timeout-millis";
     public static final String CLIENTS_MANAGEMENT_REGISTER_NODE_PATH = "clients-managements/register-node";
     public static final String CLIENTS_MANAGEMENT_UNREGISTER_NODE_PATH = "clients-managements/unregister-node";
     public static final String CREDENTIALS = "credentials";

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.security.http.oidc;
 
+import static org.wildfly.security.http.oidc.Oidc.CONNECTION_TIMEOUT_MILLIS;
+import static org.wildfly.security.http.oidc.Oidc.CONNECTION_TTL_MILLIS;
 import static org.wildfly.security.http.oidc.Oidc.DEFAULT_TOKEN_SIGNATURE_ALGORITHM;
 import static org.wildfly.security.http.oidc.Oidc.ADAPTER_STATE_COOKIE_PATH;
 import static org.wildfly.security.http.oidc.Oidc.ALLOW_ANY_HOSTNAME;
@@ -64,6 +66,7 @@ import static org.wildfly.security.http.oidc.Oidc.REQUEST_OBJECT_SIGNING_KEYSTOR
 import static org.wildfly.security.http.oidc.Oidc.REQUEST_OBJECT_SIGNING_KEYSTORE_PASSWORD;
 import static org.wildfly.security.http.oidc.Oidc.REQUEST_OBJECT_SIGNING_KEYSTORE_TYPE;
 import static org.wildfly.security.http.oidc.Oidc.SCOPE;
+import static org.wildfly.security.http.oidc.Oidc.SOCKET_TIMEOUT_MILLIS;
 import static org.wildfly.security.http.oidc.Oidc.SSL_REQUIRED;
 import static org.wildfly.security.http.oidc.Oidc.TOKEN_MINIMUM_TIME_TO_LIVE;
 import static org.wildfly.security.http.oidc.Oidc.TOKEN_SIGNATURE_ALGORITHM;
@@ -94,6 +97,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         USE_RESOURCE_ROLE_MAPPINGS, USE_REALM_ROLE_MAPPINGS,
         ENABLE_CORS, CORS_MAX_AGE, CORS_ALLOWED_METHODS, CORS_EXPOSED_HEADERS,
         EXPOSE_TOKEN, BEARER_ONLY, AUTODETECT_BEARER_ONLY, CONNECTION_POOL_SIZE,
+        CONNECTION_TIMEOUT_MILLIS, CONNECTION_TTL_MILLIS, SOCKET_TIMEOUT_MILLIS,
         ALLOW_ANY_HOSTNAME, DISABLE_TRUST_MANAGER, TRUSTSTORE, TRUSTSTORE_PASSWORD,
         CLIENT_KEYSTORE, CLIENT_KEYSTORE_PASSWORD, CLIENT_KEY_PASSWORD,
         ALWAYS_REFRESH_TOKEN,
@@ -134,6 +138,12 @@ public class OidcJsonConfiguration {
     protected String requestObjectSigningKeyStoreType;
     @JsonProperty(CONNECTION_POOL_SIZE)
     protected int connectionPoolSize = 20;
+    @JsonProperty(CONNECTION_TIMEOUT_MILLIS)
+    protected int connectionTimeoutMillis = -1;
+    @JsonProperty(CONNECTION_TTL_MILLIS)
+    protected int connectionTtlMillis = -1;
+    @JsonProperty(SOCKET_TIMEOUT_MILLIS)
+    protected int socketTimeoutMillis = -1;
     @JsonProperty(ALWAYS_REFRESH_TOKEN)
     protected boolean alwaysRefreshToken = false;
     @JsonProperty(REGISTER_NODE_AT_STARTUP)
@@ -329,6 +339,30 @@ public class OidcJsonConfiguration {
 
     public void setConnectionPoolSize(int connectionPoolSize) {
         this.connectionPoolSize = connectionPoolSize;
+    }
+
+    public int getConnectionTimeoutMillis() {
+        return connectionTimeoutMillis;
+    }
+
+    public void setConnectionTimeoutMillis(int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+    }
+
+    public int getConnectionTtlMillis() {
+        return connectionTtlMillis;
+    }
+
+    public void setConnectionTtlMillis(int connectionTtlMillis) {
+        this.connectionTtlMillis = connectionTtlMillis;
+    }
+
+    public int getSocketTimeoutMillis() {
+        return socketTimeoutMillis;
+    }
+
+    public void setSocketTimeoutMillis(int socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
     }
 
     public boolean isAlwaysRefreshToken() {

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -193,6 +193,11 @@ public class OidcTest extends OidcBaseTest {
     }
 
     @Test
+    public void testTimeoutConfigurationOptions() throws Exception {
+        OidcClientConfigurationBuilder.build(getOidcConfigurationInputStreamWithTimeoutOptions(5000, 5000, 5000));
+    }
+
+    @Test
     public void testSucessfulAuthenticationWithAuthServerUrl() throws Exception {
         performAuthentication(getOidcConfigurationInputStream(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
@@ -691,6 +696,23 @@ public class OidcTest extends OidcBaseTest {
                 "    \"" + SSL_REQUIRED + "\" : \"EXTERNAL\",\n" +
                 "    \"" + CREDENTIALS + "\" : {\n" +
                 "        \"" + ClientCredentialsProviderType.SECRET.getValue() + "\" : \"" + clientSecret + "\"\n" +
+                "    }\n" +
+                "}";
+        return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream getOidcConfigurationInputStreamWithTimeoutOptions(int connectionTimeoutMillis, int connectionTtlMillis, int socketTimeoutMillis) {
+        String oidcConfig = "{\n" +
+                "    \"realm\" : \"" + TEST_REALM + "\",\n" +
+                "    \"resource\" : \"" + CLIENT_ID + "\",\n" +
+                "    \"public-client\" : \"false\",\n" +
+                "    \"connection-timeout-millis\" : \"" + connectionTimeoutMillis + "\",\n" +
+                "    \"connection-ttl-millis\" : \"" + connectionTtlMillis + "\",\n" +
+                "    \"socket-timeout-millis\" : \"" + socketTimeoutMillis + "\",\n" +
+                "    \"auth-server-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "\",\n" +
+                "    \"ssl-required\" : \"EXTERNAL\",\n" +
+                "    \"credentials\" : {\n" +
+                "        \"secret\" : \"" + CLIENT_SECRET + "\"\n" +
                 "    }\n" +
                 "}";
         return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2753