### PR TITLE
[ELY-2727] Update CI to also run with JDK 21

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -11,12 +11,11 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }}-jdk${{ matrix.java }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: ['11', '21']
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -11,16 +11,18 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os }}-jdk${{ matrix.java }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java: ['11', '21']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       # ELY-2204 - Temporarily preventing OidcTest from running on macOS since there
       # are intermittent issues with starting up the Docker container.
       #- if: matrix.os == 'macos-latest'


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2727

Depends on https://issues.redhat.com/browse/ELY-2722 being resolved in order for the tests to pass.

Builds on https://github.com/wildfly-security/wildfly-elytron/pull/2103