### PR TITLE
ELY-2769 Update CI to also run with SE 21 for branch 2.2.x

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -15,12 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        java: ['11', '17', '21']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
       # ELY-2204 - Temporarily preventing OidcTest from running on macOS since there
       # are intermittent issues with starting up the Docker container.
       #- if: matrix.os == 'macos-latest'


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2769
Depends on issues tracked through https://issues.redhat.com/browse/ELY-2760

Related issue: https://issues.redhat.com/browse/ELY-2727
Related PR: https://github.com/wildfly-security/wildfly-elytron/pull/2103