### PR TITLE
[ELY-2726] Update AlternateSecurityManagerTest to be able to run with SE 21

### DIFF
--- a/manager/base/src/test/java/org/wildfly/security/manager/AlternateSecurityManagerTest.java
+++ b/manager/base/src/test/java/org/wildfly/security/manager/AlternateSecurityManagerTest.java
@@ -32,6 +32,7 @@ import java.util.PropertyPermission;
 import java.util.Stack;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.wildfly.security.ParametricPrivilegedAction;
@@ -84,6 +85,8 @@ public class AlternateSecurityManagerTest {
 
     @Before
     public void before() {
+        Assume.assumeTrue("Skipping AlternateSecurityManagerTest suite, tests are not being run on JDK 17 or lower.",
+                Integer.parseInt(System.getProperty("java.specification.version")) <= 17);
         AccessControlContext current = AccessController.getContext();
         ProtectionDomain[] domains = getProtectionDomainStack(current);
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2764
Upstream issue: https://issues.redhat.com/browse/ELY-2726
Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/2116