### PR TITLE
Wfcore 5691 bearer token authorization timeout blog

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -62,4 +62,8 @@ lvydra:
   name: "Lukas Vydra"
   emailhash: "963ac51a738ab1ff63a5bbdf6b206417"
   bio: "https://github.com/lvydra"
+rsearls:
+  name: "Rebecca Searls"
+  emailhash: "56c3427d6d9b5d71d2dae59d71cf7002"
+  bio: "https://github.com/rsearls"
 

--- a/_posts/2024-06-21-OAuth2-JWT-Token-Timeout.adoc
+++ b/_posts/2024-06-21-OAuth2-JWT-Token-Timeout.adoc
@@ -30,12 +30,46 @@ the public key to Elyton's processing code.
 
 === Example Server Configuration
 
-=== Quickstart example
-
 ==== Prerequisites
 
-==== Run the test
+To run the example you will need the following.
 
+* JDK-17
+* Wildfly 33 or newer
+* Wildfly quickstart, https://github.com/wildfly/quickstart.git
+
+==== Environment Setup
+
+* cd into `jaxrs-jwt` in the quickstart project.  Follow the directions
+in the README file upto and including executing the CLI script file,
+`configure-elytron.cli`.
+* Create file, `config-bearer-timeout.cli` in the jaxrs-jwt directory.
+Add the following commands to the file and save it.
+
+```
+    # append timeout attributes to the jwt element.
+    /subsystem=elytron/token-realm=jwt-realm:write-attribute(name=jwt.connection-timeout, valu
+   e=2)
+    # /subsystem=elytron/token-realm=jwt-realm:write-attribute(name=jwt.read-timeout, value=1)
+
+```
+
+====  Execute command
+```
+$WILDFLY_HOME/bin/jboss-cli.sh --connect --file=config-bearer-timeout.cli
+```
+
+==== Run the example
+
+* Follow the README directions to provision the Wildfly server
+
+* Follow the directions to run the Integration Tests with a provisioned server.
+The test will fail.
+
+* Check Wildfly's server.log for the message, "Unable to connect to $THE_URL"
+```
+$WILDFLY_HOME/standalone/log/server.log
+```
 
 == Summary
 

--- a/_posts/2024-06-21-OAuth2-JWT-Token-Timeout.adoc
+++ b/_posts/2024-06-21-OAuth2-JWT-Token-Timeout.adoc
@@ -15,7 +15,7 @@ toc::[]
 Elytron in WildFly 32+ preview version supports two new
 optional attributes, `connection-timeout` and `read-timeout`.
 These attributes allow the user to control the timeout period
-placed on the URL used in obtaining the public key from the OAuth2 and JWT
+placed on the URL used in obtaining the public key from the OAuth2 or JWT
 provider.  Both are defined on the token-realm element in the Elytron subsystem.
 
 WildFly uses a default value of 2000 milliseconds for both these
@@ -24,9 +24,18 @@ that value is sufficient.
 
 Both parameters are datatype int.  The value is in milliseonds.
 Only zero or positive integers are allowed. Zero means infinite time.
-If the connection time and/or read time expires during
+If the connection time or read time expires during
 public key retrieval a warning message is logged and null is returned as
-the public key to Elyton's process code.
+the public key to Elyton's processing code.
+
+=== Example Server Configuration
+
+=== Quickstart example
+
+==== Prerequisites
+
+==== Run the test
+
 
 == Summary
 

--- a/_posts/x-2024-mm-dd-OAuth2-JWT-Token-Timeout.adoc
+++ b/_posts/x-2024-mm-dd-OAuth2-JWT-Token-Timeout.adoc
@@ -1,0 +1,41 @@
+---
+layout: post
+title: 'OAuth2 and JWT token timeout properties added to WildFly'
+date: 2024-mm-dd
+tags: OAuth2 JWT token timeout connection-timeout read-timeout
+synopsis: Bearer token timeout properties, connection-timeout and read-timeout, have be added to WildFly's Elytron subsystem.
+author: rsearls
+---
+
+:toc: macro
+:toc-title:
+
+toc::[]
+
+Elytron in WildFly 32+ preview version supports two new
+optional attributes, `connection-timeout` and `read-timeout`.
+These attributes allow the user to control the timeout period
+placed on the URL used in obtaining the public key from the OAuth2 and JWT
+provider.  Both are defined on the token-realm element in the Elytron subsystem.
+
+WildFly uses a default value of 2000 milliseconds for both these
+properties.  The user need not set these token-realm attributes if
+that value is sufficient.
+
+Both parameters are datatype int.  The value is in milliseonds.
+Only zero or positive integers are allowed. Zero means infinite time.
+If the connection time and/or read time expires during
+public key retrieval a warning message is logged and null is returned as
+the public key to Elyton's process code.
+
+== Summary
+
+WildFly uses a default value of 2000 milliseconds (i.e. 2 seconds)
+when waiting on a connection to an OAuth2 and JWT provider, and
+2000 milliseconds when reading the public key.  The user can
+fine tune the wait times via the two attributes, `connection-timeout`
+and `read-timeout` on the Elytron's token-realm element.
+
+== Resources
+* https://docs.wildfly.org/32/wildscribe/subsystem/elytron/token-realm/index.html[token realm]
+* https://docs.wildfly.org/32/WildFly_Elytron_Security.html#realms[Elytron security realms]


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2189

RFE:https://issues.redhat.com/browse/EAP7-1856
Analysis doc: wildfly/wildfly-proposals/pull/578
Related WFCORE Issue: https://issues.redhat.com/browse/WFCORE-5691
Related ELY Issue: https://issues.redhat.com/browse/ELY-2189
