### PR TITLE
[ELY-2273] Update CA tool to also provide SSL artifacts.

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
@@ -23,12 +23,9 @@ import static org.junit.Assert.assertNull;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.URI;
 import java.security.AccessController;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
 import java.security.PrivilegedAction;
 import java.security.Security;
 import java.util.Locale;
@@ -36,17 +33,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509ExtendedKeyManager;
-import javax.net.ssl.X509TrustManager;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -61,6 +52,8 @@ import org.wildfly.security.auth.server.SecurityRealm;
 import org.wildfly.security.permission.PermissionVerifier;
 import org.wildfly.security.ssl.test.util.CAGenerationTool;
 import org.wildfly.security.ssl.test.util.CAGenerationTool.Identity;
+import org.wildfly.security.ssl.test.util.DefinedCAIdentity;
+import org.wildfly.security.ssl.test.util.DefinedIdentity;
 import org.wildfly.security.x500.principal.X500AttributePrincipalDecoder;
 
 /**
@@ -70,7 +63,6 @@ import org.wildfly.security.x500.principal.X500AttributePrincipalDecoder;
  */
 public class TLS13AuthenticationTest {
 
-    private static final char[] PASSWORD = "Elytron".toCharArray();
     private static final String CA_JKS_LOCATION = "./target/test-classes/jks";
 
     private static CAGenerationTool caGenerationTool = null;
@@ -84,7 +76,7 @@ public class TLS13AuthenticationTest {
                 .setRequestIdentities(Identity.LADYBIRD, Identity.SCARAB)
                 .build();
 
-        SecurityRealm securityRealm = new KeyStoreBackedSecurityRealm(loadKeyStore("/jks/beetles.keystore"));
+        SecurityRealm securityRealm = new KeyStoreBackedSecurityRealm(caGenerationTool.getBeetlesKeyStore());
         securityDomain = SecurityDomain.builder()
                 .addRealm("KeystoreRealm", securityRealm)
                 .build()
@@ -105,11 +97,14 @@ public class TLS13AuthenticationTest {
     public void testTwoWayTLS13() throws Exception {
         final String CIPHER_SUITE = "TLS_AES_128_GCM_SHA256";
 
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
+
         SSLContext serverContext = new SSLContextBuilder()
                 .setSecurityDomain(securityDomain)
                 .setCipherSuiteSelector(CipherSuiteSelector.fromNamesString(CIPHER_SUITE))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
-                .setTrustManager(getCATrustManager())
+                .setKeyManager(scarab.createKeyManager())
+                .setTrustManager(ca.createTrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
 
@@ -124,11 +119,14 @@ public class TLS13AuthenticationTest {
         final String PREFERRED_CIPHER_SUITE = "TLS_AES_256_GCM_SHA384";
         final String SERVER_CIPHER_SUITE = String.format("%s:%s", PREFERRED_CIPHER_SUITE, REQUIRED_CIPHER_SUITE);
 
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
+
         SSLContext serverContext = new SSLContextBuilder()
                 .setSecurityDomain(securityDomain)
                 .setCipherSuiteSelector(CipherSuiteSelector.fromNamesString(SERVER_CIPHER_SUITE))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
-                .setTrustManager(getCATrustManager())
+                .setKeyManager(scarab.createKeyManager())
+                .setTrustManager(ca.createTrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
 
@@ -142,14 +140,17 @@ public class TLS13AuthenticationTest {
         final String TLS13_CIPHER_SUITE = "TLS_AES_128_GCM_SHA256";
         final String TLS12_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_CBC_SHA256"; // TLS v1.2
 
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
+
         SSLContext serverContext = new SSLContextBuilder()
                 .setSecurityDomain(securityDomain)
                 .setCipherSuiteSelector(CipherSuiteSelector.aggregate(
                                 CipherSuiteSelector.fromNamesString(TLS13_CIPHER_SUITE),
                                 CipherSuiteSelector.fromString(TLS12_CIPHER_SUITE)
                 ))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
-                .setTrustManager(getCATrustManager())
+                .setKeyManager(scarab.createKeyManager())
+                .setTrustManager(ca.createTrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
 
@@ -162,11 +163,14 @@ public class TLS13AuthenticationTest {
     public void testServerTLS12Only() throws Exception {
         final String SERVER_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_CBC_SHA256"; // TLS v1.2
 
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
+
         SSLContext serverContext = new SSLContextBuilder()
                 .setSecurityDomain(securityDomain)
                 .setCipherSuiteSelector(CipherSuiteSelector.fromString(SERVER_CIPHER_SUITE))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
-                .setTrustManager(getCATrustManager())
+                .setKeyManager(scarab.createKeyManager())
+                .setTrustManager(ca.createTrustManager())
                 .setNeedClientAuth(true)
                 .build().create();
 
@@ -179,9 +183,11 @@ public class TLS13AuthenticationTest {
     public void testOneWayTLS13() throws Exception {
         final String CIPHER_SUITE = "TLS_AES_128_GCM_SHA256";
 
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
+
         SSLContext serverContext = new SSLContextBuilder()
                 .setCipherSuiteSelector(CipherSuiteSelector.fromNamesString(CIPHER_SUITE))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
+                .setKeyManager(scarab.createKeyManager())
                 .build().create();
 
         SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-one-way-tls13.org", "wildfly-ssl-test-config-v1_5.xml", CIPHER_SUITE, true);
@@ -239,53 +245,6 @@ public class TLS13AuthenticationTest {
             safeClose(clientSocket);
             safeClose(sslServerSocket);
         }
-    }
-
-    /**
-     * Get the key manager backed by the specified key store.
-     *
-     * @param keystorePath the path to the keystore with X509 private key
-     * @return the initialised key manager.
-     */
-    private static X509ExtendedKeyManager getKeyManager(final String keystorePath) throws Exception {
-        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
-        keyManagerFactory.init(loadKeyStore(keystorePath), PASSWORD);
-
-        for (KeyManager current : keyManagerFactory.getKeyManagers()) {
-            if (current instanceof X509ExtendedKeyManager) {
-                return (X509ExtendedKeyManager) current;
-            }
-        }
-
-        throw new IllegalStateException("Unable to obtain X509ExtendedKeyManager.");
-    }
-
-    /**
-     * Get the trust manager that trusts all certificates signed by the certificate authority.
-     *
-     * @return the trust manager that trusts all certificates signed by the certificate authority.
-     * @throws KeyStoreException
-     */
-    private static X509TrustManager getCATrustManager() throws Exception {
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("SunX509");
-        trustManagerFactory.init(loadKeyStore("/jks/ca.truststore"));
-
-        for (TrustManager current : trustManagerFactory.getTrustManagers()) {
-            if (current instanceof X509TrustManager) {
-                return (X509TrustManager) current;
-            }
-        }
-
-        throw new IllegalStateException("Unable to obtain X509TrustManager.");
-    }
-
-    private static KeyStore loadKeyStore(final String path) throws Exception {
-        KeyStore keyStore = KeyStore.getInstance("jks");
-        try (InputStream caTrustStoreFile = SSLAuthenticationTest.class.getResourceAsStream(path)) {
-            keyStore.load(caTrustStoreFile, PASSWORD);
-        }
-
-        return keyStore;
     }
 
     private void safeClose(Closeable closeable) {

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CAGenerationTool.java
@@ -55,7 +55,8 @@ import org.wildfly.security.x500.cert.X509CertificateBuilder;
 import org.wildfly.security.x500.cert.X509CertificateExtension;
 
 /**
- * A tool for generating a complete set of certificates backed by a generated certificate authority.
+ * A tool for generating a complete set of certificates backed by a generated
+ * certificate authority.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
@@ -67,10 +68,11 @@ public class CAGenerationTool implements Closeable {
     private static final String KEY_ALGORITHM = "RSA";
     private static final String KEYSTORE_TYPE = "JKS"; // TODO Switch to PKCS#12
     private static final int OCSP_PORT = 4854;
-    private static final char[] PASSWORD = "Elytron".toCharArray();
+    static final char[] PASSWORD = "Elytron".toCharArray();
 
     private static final Set<Identity> BEETLES = Collections
-            .unmodifiableSet(new HashSet<>(Arrays.asList(Identity.LADYBIRD, Identity.SCARAB, Identity.DUNG, Identity.FIREFLY)));
+            .unmodifiableSet(
+                    new HashSet<>(Arrays.asList(Identity.LADYBIRD, Identity.SCARAB, Identity.DUNG, Identity.FIREFLY)));
     private static final Predicate<Identity> INCLUDE_IN_BEETLES = BEETLES::contains;
 
     private final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
@@ -126,7 +128,8 @@ public class CAGenerationTool implements Closeable {
 
     public DefinedCAIdentity getDefinedCAIdentity(final Identity identity) {
         if (!identity.isCertificateAuthority()) {
-            throw new IllegalStateException(String.format("Identity %s is not a CertificateAuthority", identity.toString()));
+            throw new IllegalStateException(
+                    String.format("Identity %s is not a CertificateAuthority", identity.toString()));
         }
 
         if (!caMap.containsKey(identity)) {
@@ -137,8 +140,12 @@ public class CAGenerationTool implements Closeable {
         return new DefinedCAIdentity(this, identity, caState.issuerCertificate, caState.signingKey);
     }
 
+    public KeyStore getBeetlesKeyStore() {
+        return loadKeyStore(new File(workingDir, BEETLES_STORE));
+    }
+
     /**
-     * @deprecated Use {@link CAIdentity#getCertificate()} instead.
+     * @deprecated Use {@link CommonIdentity#getCertificate()} instead.
      */
     @Deprecated()
     public X509Certificate getCertificate(final Identity identity) {
@@ -146,12 +153,13 @@ public class CAGenerationTool implements Closeable {
     }
 
     /**
-     * @deprecated Use {@link CAIdentity#getPrivateKey()} instead.
+     * @deprecated Use {@link DefinedCAIdentity#getPrivateKey()} instead.
      */
     @Deprecated()
     public PrivateKey getPrivateKey(final Identity identity) {
         if (!identity.isCertificateAuthority()) {
-            throw new IllegalStateException(String.format("Identity %s if not a CertificateAuthority", identity.toString()));
+            throw new IllegalStateException(
+                    String.format("Identity %s if not a CertificateAuthority", identity.toString()));
         }
 
         return caMap.computeIfAbsent(identity, this::createCA).signingKey;
@@ -163,7 +171,8 @@ public class CAGenerationTool implements Closeable {
         Identity signedBy = identity.getSignedBy();
         if (signedBy == null) {
             // As a root CA it will require a self signed certificate.
-            SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
+            SelfSignedX509CertificateAndSigningKey issuerSelfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey
+                    .builder()
                     .setDn(identity.getPrincipal())
                     .setKeyAlgorithmName(KEY_ALGORITHM)
                     .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
@@ -184,8 +193,8 @@ public class CAGenerationTool implements Closeable {
                         .setSerialNumber(BigInteger.valueOf(signerState.serialNumber++))
                         .addExtension(new BasicConstraintsExtension(false, true, -1))
                         .addExtension(new AuthorityInformationAccessExtension(Collections.singletonList(
-                                new AccessDescription(OID_AD_OCSP, new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp"))
-                        )))
+                                new AccessDescription(OID_AD_OCSP,
+                                        new GeneralName.URIName("http://localhost:" + OCSP_PORT + "/ocsp")))))
                         .build();
 
                 caState.issuerCertificate = intermediateIssuerCertificate;
@@ -212,28 +221,31 @@ public class CAGenerationTool implements Closeable {
         return caState;
     }
 
-    /**
-     * @deprecated Use {@link #createIdentity(String, X500Principal, String, X509CertificateExtension...)} instead.
-     */
-    @Deprecated
-    public X509Certificate createIdentity(final String alias, final X500Principal principal, final String keyStoreName,
-            final Identity ca, final X509CertificateExtension... extensions) {
-        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+    private X509Certificate createCustomCertificate(final Identity ca, final X500Principal principal,
+            final KeyPair keyPair, final X509CertificateExtension... extensions) throws CertificateException{
+
         CAState caState = caMap.computeIfAbsent(ca, this::createCA);
 
+        X509CertificateBuilder certificateBuilder = new X509CertificateBuilder()
+                .setIssuerDn(ca.getPrincipal())
+                .setSubjectDn(principal)
+                .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
+                .setSigningKey(caState.signingKey)
+                .setPublicKey(keyPair.getPublic())
+                .setSerialNumber(BigInteger.valueOf(caState.serialNumber++))
+                .addExtension(new BasicConstraintsExtension(false, false, -1));
+        for (X509CertificateExtension currentExtension : extensions) {
+            certificateBuilder.addExtension(currentExtension);
+        }
+
+        return certificateBuilder.build();
+    }
+
+    CustomIdentity createCustomIdentity(final String alias, final X500Principal principal, final String keyStoreName,
+            final Identity ca, final X509CertificateExtension... extensions) {
         try {
-            X509CertificateBuilder certificateBuilder = new X509CertificateBuilder()
-                    .setIssuerDn(ca.getPrincipal())
-                    .setSubjectDn(principal)
-                    .setSignatureAlgorithmName(SIGNATURE_ALGORTHM)
-                    .setSigningKey(caState.signingKey)
-                    .setPublicKey(keyPair.getPublic())
-                    .setSerialNumber(BigInteger.valueOf(caState.serialNumber++))
-                    .addExtension(new BasicConstraintsExtension(false, false, -1));
-            for (X509CertificateExtension currentExtension : extensions) {
-                certificateBuilder.addExtension(currentExtension);
-            }
-            X509Certificate builtCertificate = certificateBuilder.build();
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            X509Certificate builtCertificate = createCustomCertificate(ca, principal, keyPair, extensions);
 
             File keyStoreFile = new File(workingDir, keyStoreName);
             KeyStore keyStore = createEmptyKeyStore();
@@ -242,9 +254,55 @@ public class CAGenerationTool implements Closeable {
             certificates.add(builtCertificate);
 
             Identity caIdentity = ca;
+            CAState caState;
+
             do {
-                caState = caMap.get(caIdentity); // We just created a signed cert above, the complete chain must be present.
-                keyStore.setCertificateEntry(caIdentity.toString(), caState.issuerCertificate); // This could be removed as the cert chain is added to the Entry.
+                caState = caMap.get(caIdentity); // We just created a signed cert above, the complete chain must be
+                                                 // present.
+                certificates.add(caState.issuerCertificate);
+                caIdentity = caIdentity.getSignedBy();
+            } while (caIdentity != null);
+
+            keyStore.setKeyEntry(alias, keyPair.getPrivate(), PASSWORD,
+                    certificates.toArray(new X509Certificate[certificates.size()]));
+            try (OutputStream out = new FileOutputStream(keyStoreFile)) {
+                keyStore.store(out, PASSWORD);
+            }
+
+            return new CustomIdentity(this, builtCertificate, keyStoreFile);
+
+        } catch (IOException | KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+            throw new RuntimeException("Umnable to create identity", e);
+        }
+    }
+
+    /**
+     * @deprecated Use
+     *             {@link #createIdentity(String, X500Principal, String, X509CertificateExtension...)}
+     *             instead.
+     */
+    @Deprecated
+    public X509Certificate createIdentity(final String alias, final X500Principal principal, final String keyStoreName,
+            final Identity ca, final X509CertificateExtension... extensions) {
+        try {
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            X509Certificate builtCertificate = createCustomCertificate(ca, principal, keyPair, extensions);
+
+            File keyStoreFile = new File(workingDir, keyStoreName);
+            KeyStore keyStore = createEmptyKeyStore();
+
+            List<X509Certificate> certificates = new ArrayList<>();
+            certificates.add(builtCertificate);
+
+            Identity caIdentity = ca;
+            CAState caState;
+
+            do {
+                caState = caMap.get(caIdentity); // We just created a signed cert above, the complete chain must be
+                                                 // present.
+                keyStore.setCertificateEntry(caIdentity.toString(), caState.issuerCertificate); // This could be removed
+                                                                                                // as the cert chain is
+                                                                                                // added to the Entry.
                 certificates.add(caState.issuerCertificate);
                 caIdentity = caIdentity.getSignedBy();
             } while (caIdentity != null);
@@ -261,7 +319,8 @@ public class CAGenerationTool implements Closeable {
         }
     }
 
-    private X509Certificate createSelfSignedIdentity(final String alias, final X500Principal principal, final String keyStoreName) {
+    private X509Certificate createSelfSignedIdentity(final String alias, final X500Principal principal,
+            final String keyStoreName) {
         SelfSignedX509CertificateAndSigningKey selfSignedIdentity = SelfSignedX509CertificateAndSigningKey.builder()
                 .setDn(principal)
                 .setKeyAlgorithmName(KEY_ALGORITHM)
@@ -297,7 +356,7 @@ public class CAGenerationTool implements Closeable {
     private static KeyStore createEmptyKeyStore() {
         try {
             KeyStore ks = KeyStore.getInstance(KEYSTORE_TYPE);
-            ks.load(null,null);
+            ks.load(null, null);
 
             return ks;
         } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
@@ -305,7 +364,11 @@ public class CAGenerationTool implements Closeable {
         }
     }
 
-    private static KeyStore loadKeyStore(final File location) {
+    KeyStore loadKeyStore(final Identity identity) {
+        return loadKeyStore(new File(workingDir, identity.getKeyStoreName()));
+    }
+
+    static KeyStore loadKeyStore(final File location) {
         try (InputStream caTrustStoreFile = new FileInputStream(location)) {
             KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
             keyStore.load(caTrustStoreFile, PASSWORD);
@@ -354,7 +417,8 @@ public class CAGenerationTool implements Closeable {
                 CA, true, null),
         ROVE("OU=Elytron, O=Elytron, C=UK, ST=Elytron, CN=Rove",
                 INTERMEDIATE, false, "rove.keystore"),
-        SECOND_CA("CN=Wildfly CA, ST=Wildfly, C=CA, EMAILADDRESS=admin@wildfly.org O=Another Root Certificate Authority",
+        SECOND_CA(
+                "CN=Wildfly CA, ST=Wildfly, C=CA, EMAILADDRESS=admin@wildfly.org O=Another Root Certificate Authority",
                 null, true, "ca.truststore2"),
         LADYBUG("OU=Wildfly, O=Wildfly, C=CA, ST=Wildfly, CN=Ladybug", SECOND_CA, false,
                 "ladybug.keystore"),
@@ -366,8 +430,9 @@ public class CAGenerationTool implements Closeable {
         private final boolean ca;
         private final String keyStoreName;
 
-        private Identity(final String distinguishedName, final Identity signedBy, final boolean ca, final String keyStoreName) {
-            this.principal =  new X500Principal(distinguishedName);
+        private Identity(final String distinguishedName, final Identity signedBy, final boolean ca,
+                final String keyStoreName) {
+            this.principal = new X500Principal(distinguishedName);
             this.signedBy = signedBy;
             this.ca = ca;
             this.keyStoreName = keyStoreName;

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CommonIdentity.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CommonIdentity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ssl.test.util;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+
+public abstract class CommonIdentity {
+
+    protected final CAGenerationTool caGenerationTool;
+    private final X509Certificate certificate;
+
+    CommonIdentity(CAGenerationTool caGenerationTool, X509Certificate certificate) {
+        this.caGenerationTool = caGenerationTool;
+        this.certificate = certificate;
+    }
+
+    public X509Certificate getCertificate() {
+        caGenerationTool.assertNotClosed();
+
+        return certificate;
+    }
+
+    public abstract KeyStore loadKeyStore();
+
+    public X509ExtendedKeyManager createKeyManager() {
+        caGenerationTool.assertNotClosed();
+
+        try {
+            KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("SunX509");
+            keyManagerFactory.init(loadKeyStore(), CAGenerationTool.PASSWORD);
+
+            for (KeyManager current : keyManagerFactory.getKeyManagers()) {
+                if (current instanceof X509ExtendedKeyManager) {
+                    return (X509ExtendedKeyManager) current;
+                }
+            }
+        } catch (NoSuchAlgorithmException | KeyStoreException | UnrecoverableKeyException e) {
+            throw new IllegalStateException("Unable to obtain X509ExtendedKeyManager.", e);
+        }
+
+        throw new IllegalStateException("Unable to obtain X509ExtendedKeyManager.");
+    }
+
+}

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CustomIdentity.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/CustomIdentity.java
@@ -16,26 +16,22 @@
 
 package org.wildfly.security.ssl.test.util;
 
+import java.io.File;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 
-import org.wildfly.security.ssl.test.util.CAGenerationTool.Identity;
+public class CustomIdentity extends CommonIdentity {
 
-public class DefinedIdentity extends CommonIdentity {
+    private final File keyStoreFile;
 
-    protected final Identity identity;
-
-    DefinedIdentity(CAGenerationTool caGenerationTool,
-                    Identity identity,
-                    X509Certificate certificate) {
+    CustomIdentity(CAGenerationTool caGenerationTool, X509Certificate certificate, File keyStoreFile) {
         super(caGenerationTool, certificate);
-        this.identity = identity;
+        this.keyStoreFile = keyStoreFile;
     }
 
+    @Override
     public KeyStore loadKeyStore() {
-        caGenerationTool.assertNotClosed();
-
-        return caGenerationTool.loadKeyStore(identity);
+        return CAGenerationTool.loadKeyStore(keyStoreFile);
     }
 
 }

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/DefinedCAIdentity.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/DefinedCAIdentity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ssl.test.util;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.wildfly.security.ssl.test.util.CAGenerationTool.Identity;
+import org.wildfly.security.x500.cert.X509CertificateExtension;
+
+public class DefinedCAIdentity extends DefinedIdentity {
+
+    private final PrivateKey privateKey;
+
+    DefinedCAIdentity(CAGenerationTool caGenerationTool, Identity identity,
+        X509Certificate certificate, PrivateKey privateKey) {
+        super(caGenerationTool, identity, certificate);
+        this.privateKey = privateKey;
+    }
+
+    public X509Certificate createIdentity(final String alias, final X500Principal principal,
+        final String keyStoreName, final X509CertificateExtension... extensions) {
+        caGenerationTool.assertNotClosed();
+
+        return caGenerationTool.createIdentity(alias, principal, keyStoreName, identity, extensions);
+     }
+
+
+     public PrivateKey getPrivateKey() {
+        caGenerationTool.assertNotClosed();
+
+        return privateKey;
+    }
+}

--- a/tests/common/src/test/java/org/wildfly/security/ssl/test/util/DefinedIdentity.java
+++ b/tests/common/src/test/java/org/wildfly/security/ssl/test/util/DefinedIdentity.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.ssl.test.util;
+
+import java.security.cert.X509Certificate;
+
+import org.wildfly.security.ssl.test.util.CAGenerationTool.Identity;
+
+public class DefinedIdentity {
+
+    protected final CAGenerationTool caGenerationTool;
+    protected final Identity identity;
+    private final X509Certificate certificate;
+
+    DefinedIdentity(CAGenerationTool caGenerationTool,
+                    Identity identity,
+                    X509Certificate certificate) {
+        this.caGenerationTool = caGenerationTool;
+        this.identity = identity;
+        this.certificate = certificate;
+    }
+
+    public X509Certificate getCertificate() {
+        caGenerationTool.assertNotClosed();
+
+        return certificate;
+    }
+
+}


### PR DESCRIPTION
I am enabling SSL testing in Undertow under https://issues.redhat.com/browse/REM3-406, this is an ideal time to use the Elytron CA tool to set up the various identifies - however tests that use this tool need to be aware of more of the internals of the utility such as how the identities are stored so this PR adds functionality to automate the creation of the key and trust managers and the loading of the underlying stores.

Some methods have been left as deprecated as WildFly Core also uses this utility but that should be updated so the deprecated methods can be removed.

https://issues.redhat.com/browse/ELY-2773