### PR TITLE
[ELY-2775] Rename the configuration files as they are specific to the test cases.

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -821,7 +821,7 @@ public class SSLAuthenticationTest {
     }
 
     private void performConnectionTest(SSLContext serverContext, String clientUri, boolean expectValid, String expectedServerPrincipal, String expectedClientPrincipal, boolean oneWay) throws Throwable {
-        System.setProperty("wildfly.config.url", SSLAuthenticationTest.class.getResource("wildfly-ssl-test-config-v1_7.xml").toExternalForm());
+        System.setProperty("wildfly.config.url", SSLAuthenticationTest.class.getResource("ssl-authentication-config.xml").toExternalForm());
         AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Security.insertProviderAt(WildFlyElytronPasswordProvider.getInstance(), 1));
 
         AuthenticationContext context = AuthenticationContext.getContextManager().get();

--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLv2HelloAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLv2HelloAuthenticationTest.java
@@ -88,6 +88,7 @@ import org.wildfly.security.x500.cert.X509CertificateBuilder;
  */
 public class SSLv2HelloAuthenticationTest {
 
+    private static final String CLIENT_CONFIG = "sslv2-hello-authentication-config.xml";
     private static final char[] PASSWORD = "Elytron".toCharArray();
     private static final String CA_JKS_LOCATION = "./target/test-classes/ca/jks";
     private static File ladybirdFile = null;
@@ -170,7 +171,7 @@ public class SSLv2HelloAuthenticationTest {
 
         SecurityIdentity identity = performConnectionTest(serverContext,
                 "protocol://one-way-sslv2hello.org",
-                "wildfly-ssl-test-config-v1_6.xml",
+                CLIENT_CONFIG,
                 enabledProtocols, // We expect client and server socket to only have SSLv2Hello and TLSv1 enabled
                 "TLSv1"); // We expect the negotiated protocol to be TLSv1, as SSLv2Hello is a pseudo-protocol
     }
@@ -197,7 +198,7 @@ public class SSLv2HelloAuthenticationTest {
 
         SecurityIdentity identity = performConnectionTest(serverContext,
                 "protocol://test-two-way-sslv2hello.org",
-                "wildfly-ssl-test-config-v1_6.xml",
+                CLIENT_CONFIG,
                 enabledProtocols, // We expect client and server socket to only have SSLv2Hello and TLSv1 enabled
                 "TLSv1"); // We expect the negotiated protocol to be TLSv1, as SSLv2Hello is a pseudo-protocol
 
@@ -223,7 +224,7 @@ public class SSLv2HelloAuthenticationTest {
 
         SecurityIdentity identity = performConnectionTest(serverContext,
                 "protocol://two-way-no-sslv2hello.org",
-                "wildfly-ssl-test-config-v1_6.xml",
+                CLIENT_CONFIG,
                 enabledProtocols, // We expect the default protocols to be enabled i.e. SSLv2Hello should only be enabled if explicitly configured
                 "TLSv1.2"); // We expect the negotiated protocol to be the highest version protocol in common
 
@@ -254,7 +255,7 @@ public class SSLv2HelloAuthenticationTest {
 
         SecurityIdentity identity = performConnectionTest(serverContext,
                 "protocol://two-way-no-sslv2hello.org",
-                "wildfly-ssl-test-config-v1_6.xml",
+                CLIENT_CONFIG,
                 enabledClientProtocols,
                 enabledServerProtocols,
                 "TLSv1"); // We expect the negotiated protocol to be the highest version protocol in common
@@ -284,7 +285,7 @@ public class SSLv2HelloAuthenticationTest {
 
             SecurityIdentity identity = performConnectionTest(serverContext,
                     "protocol://test-two-way-sslv2hello.org",
-                    "wildfly-ssl-test-config-v1_6.xml",
+                    CLIENT_CONFIG,
                     clientEnabledProtocols,
                     serverEnabledProtocols,
                     "NONE"); // handshake is expected to fail, which in turn returns an empty SSLSession

--- a/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
@@ -70,6 +70,7 @@ import org.wildfly.security.x500.principal.X500AttributePrincipalDecoder;
  */
 public class TLS13AuthenticationTest {
 
+    private static final String CLIENT_CONFIG = "tls13-authentication-config.xml";
     private static final char[] PASSWORD = "Elytron".toCharArray();
     private static final String CA_JKS_LOCATION = "./target/test-classes/jks";
 
@@ -113,7 +114,7 @@ public class TLS13AuthenticationTest {
                 .setNeedClientAuth(true)
                 .build().create();
 
-        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-two-way-tls13.org", "wildfly-ssl-test-config-v1_5.xml", CIPHER_SUITE, true);
+        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-two-way-tls13.org", CLIENT_CONFIG, CIPHER_SUITE, true);
         assertNotNull(identity);
         assertEquals("Principal Name", "ladybird", identity.getPrincipal().getName());
     }
@@ -132,7 +133,7 @@ public class TLS13AuthenticationTest {
                 .setNeedClientAuth(true)
                 .build().create();
 
-        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-different-preferred-tls13-suites.org", "wildfly-ssl-test-config-v1_5.xml", REQUIRED_CIPHER_SUITE, true);
+        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-different-preferred-tls13-suites.org", CLIENT_CONFIG, REQUIRED_CIPHER_SUITE, true);
         assertNotNull(identity);
         assertEquals("Principal Name", "ladybird", identity.getPrincipal().getName());
     }
@@ -153,7 +154,7 @@ public class TLS13AuthenticationTest {
                 .setNeedClientAuth(true)
                 .build().create();
 
-        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-client-tls12-only.org", "wildfly-ssl-test-config-v1_5.xml", TLS12_CIPHER_SUITE, false);
+        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-client-tls12-only.org", CLIENT_CONFIG, TLS12_CIPHER_SUITE, false);
         assertNotNull(identity);
         assertEquals("Principal Name", "ladybird", identity.getPrincipal().getName());
     }
@@ -170,7 +171,7 @@ public class TLS13AuthenticationTest {
                 .setNeedClientAuth(true)
                 .build().create();
 
-        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-server-tls12-only.org", "wildfly-ssl-test-config-v1_5.xml", SERVER_CIPHER_SUITE, false);
+        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-server-tls12-only.org", CLIENT_CONFIG, SERVER_CIPHER_SUITE, false);
         assertNotNull(identity);
         assertEquals("Principal Name", "ladybird", identity.getPrincipal().getName());
     }
@@ -184,7 +185,7 @@ public class TLS13AuthenticationTest {
                 .setKeyManager(getKeyManager("/jks/scarab.keystore"))
                 .build().create();
 
-        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-one-way-tls13.org", "wildfly-ssl-test-config-v1_5.xml", CIPHER_SUITE, true);
+        SecurityIdentity identity = performConnectionTest(serverContext, "protocol://test-one-way-tls13.org", CLIENT_CONFIG, CIPHER_SUITE, true);
         assertNull(identity);
     }
 

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/ssl-authentication-config.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/ssl-authentication-config.xml
@@ -17,6 +17,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
+<!-- Configuration for the SSLAuthenticationTest -->
 <configuration>
     <authentication-client xmlns="urn:elytron:client:1.7">
         <key-stores>

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/sslv2-hello-authentication-config.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/sslv2-hello-authentication-config.xml
@@ -17,6 +17,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
+<!-- Configuration for the SSLv2HelloAuthenticationTest-->
 <configuration>
     <authentication-client xmlns="urn:elytron:client:1.6">
         <key-stores>

--- a/tests/base/src/test/resources/org/wildfly/security/ssl/tls13-authentication-config.xml
+++ b/tests/base/src/test/resources/org/wildfly/security/ssl/tls13-authentication-config.xml
@@ -17,6 +17,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+
+<!-- Configuration for the TLS13AuthenticationTest-->
 <configuration>
     <authentication-client xmlns="urn:elytron:client:1.5">
         <key-stores>


### PR DESCRIPTION
Looking at these files we got into a trend of using versioned names but these files are not actually a part of XML version parsing so are better suited to have a name that reflects the test and a comment to identify the test class as well.

https://issues.redhat.com/browse/ELY-2775