### PR TITLE
[ELY-2787] Adjust the offsets used for getCallerClass so individual methods only need to compensate for how they affected the call stack without second guessing other influences.

### DIFF
--- a/src/main/java/org/wildfly/security/manager/StackInspector.java
+++ b/src/main/java/org/wildfly/security/manager/StackInspector.java
@@ -60,7 +60,7 @@ public final class StackInspector {
      * @return the caller class
      */
     public Class<?> getCallerClass(int skipFrames) {
-        return WildFlySecurityManager.getCallerClass(max(0, skipFrames) + 2);
+        return WildFlySecurityManager.getCallerClass(max(0, skipFrames) + 1);
     }
 
     /**

--- a/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
+++ b/src/main/java/org/wildfly/security/manager/WildFlySecurityManager.java
@@ -145,9 +145,21 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
     @SuppressWarnings("deprecation")
     static Class<?> getCallerClass(int n) {
         if (hasGetCallerClass) {
-            return Reflection.getCallerClass(n + callerOffset);
+            /*
+             * The callerOffset identifies how many calls on the stack by calling
+             * Reflection.getCallerClass.
+             *
+             * An additional 1 is added to take into account the call to.
+             *   WildFlySecurityManager.getCallerClass(int);
+             */
+            return Reflection.getCallerClass(n + callerOffset + 1);
         } else {
-            return getCallStack()[n + callerOffset];
+            /*
+             * Fixed offset of 2 to take into account the following calls on the call stack: -
+             *   WildFlySecurityManager.getCallStack();
+             *   WildFlySecurityManager.getCallerClass(int);
+             */
+            return getCallStack()[n + 2];
         }
     }
 
@@ -805,7 +817,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return action.run();
         } finally {
@@ -835,7 +847,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return action.run();
         } catch (Exception e) {
@@ -863,7 +875,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return AccessController.doPrivileged(action, context);
         } finally {
@@ -890,7 +902,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return AccessController.doPrivileged(action, context);
         } finally {
@@ -917,7 +929,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return action.run(parameter);
         } finally {
@@ -949,7 +961,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return action.run(parameter);
         } catch (Exception e) {
@@ -979,7 +991,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return doPrivilegedWithParameter(parameter, action, context);
         } finally {
@@ -1008,7 +1020,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             final SecurityManager sm = getSecurityManager();
             if (sm != null) {
-                checkPDPermission(getCallerClass(2), doUncheckedPermission);
+                checkPDPermission(getCallerClass(1), doUncheckedPermission);
             }
             return doPrivilegedWithParameter(parameter, action, context);
         } finally {
@@ -1123,13 +1135,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPropertyReadPermission(getCallerClass(2), name);
+                checkPropertyReadPermission(getCallerClass(1), name);
                 return getProperty(name, def);
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPropertyReadPermission(getCallerClass(2), name);
+            checkPropertyReadPermission(getCallerClass(1), name);
             return doPrivileged(new ReadPropertyAction(name, def));
         }
     }
@@ -1157,13 +1169,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkEnvPropertyReadPermission(getCallerClass(2), name);
+                checkEnvPropertyReadPermission(getCallerClass(1), name);
                 return def(getenv(name), def);
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkEnvPropertyReadPermission(getCallerClass(2), name);
+            checkEnvPropertyReadPermission(getCallerClass(1), name);
             return doPrivileged(new ReadEnvironmentPropertyAction(name, def));
         }
     }
@@ -1187,13 +1199,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPropertyWritePermission(getCallerClass(2), name);
+                checkPropertyWritePermission(getCallerClass(1), name);
                 return setProperty(name, value);
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPropertyWritePermission(getCallerClass(2), name);
+            checkPropertyWritePermission(getCallerClass(1), name);
             return doPrivileged(new WritePropertyAction(name, value));
         }
     }
@@ -1216,13 +1228,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPropertyWritePermission(getCallerClass(2), name);
+                checkPropertyWritePermission(getCallerClass(1), name);
                 return clearProperty(name);
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPropertyWritePermission(getCallerClass(2), name);
+            checkPropertyWritePermission(getCallerClass(1), name);
             return doPrivileged(new ClearPropertyAction(name));
         }
     }
@@ -1245,13 +1257,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPDPermission(getCallerClass(2), GET_CLASS_LOADER_PERMISSION);
+                checkPDPermission(getCallerClass(1), GET_CLASS_LOADER_PERMISSION);
                 return currentThread().getContextClassLoader();
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPDPermission(getCallerClass(2), GET_CLASS_LOADER_PERMISSION);
+            checkPDPermission(getCallerClass(1), GET_CLASS_LOADER_PERMISSION);
             return doPrivileged(GetContextClassLoaderAction.getInstance());
         }
     }
@@ -1281,7 +1293,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             ctx.checking = false;
             // separate try/finally to guarantee proper exception flow
             try {
-                checkPDPermission(getCallerClass(2), SET_CLASS_LOADER_PERMISSION);
+                checkPDPermission(getCallerClass(1), SET_CLASS_LOADER_PERMISSION);
                 try {
                     return thread.getContextClassLoader();
                 } finally {
@@ -1291,7 +1303,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
                 ctx.checking = true;
             }
         } else {
-            checkPDPermission(getCallerClass(2), SET_CLASS_LOADER_PERMISSION);
+            checkPDPermission(getCallerClass(1), SET_CLASS_LOADER_PERMISSION);
             return doPrivileged(new SetContextClassLoaderAction(newClassLoader));
         }
     }
@@ -1321,7 +1333,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             ctx.checking = false;
             // separate try/finally to guarantee proper exception flow
             try {
-                final Class<?> caller = getCallerClass(2);
+                final Class<?> caller = getCallerClass(1);
                 checkPDPermission(caller, SET_CLASS_LOADER_PERMISSION);
                 checkPDPermission(caller, GET_CLASS_LOADER_PERMISSION);
                 try {
@@ -1333,7 +1345,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
                 ctx.checking = true;
             }
         } else {
-            final Class<?> caller = getCallerClass(2);
+            final Class<?> caller = getCallerClass(1);
             checkPDPermission(caller, SET_CLASS_LOADER_PERMISSION);
             checkPDPermission(caller, GET_CLASS_LOADER_PERMISSION);
             return doPrivileged(new SetContextClassLoaderAction(clazz.getClassLoader()));
@@ -1358,13 +1370,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPDPermission(getCallerClass(2), PROPERTIES_PERMISSION);
+                checkPDPermission(getCallerClass(1), PROPERTIES_PERMISSION);
                 return getProperties();
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPDPermission(getCallerClass(2), PROPERTIES_PERMISSION);
+            checkPDPermission(getCallerClass(1), PROPERTIES_PERMISSION);
             return doPrivileged(GetSystemPropertiesAction.getInstance());
         }
     }
@@ -1387,13 +1399,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPDPermission(getCallerClass(2), ENVIRONMENT_PERMISSION);
+                checkPDPermission(getCallerClass(1), ENVIRONMENT_PERMISSION);
                 return getenv();
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPDPermission(getCallerClass(2), ENVIRONMENT_PERMISSION);
+            checkPDPermission(getCallerClass(1), ENVIRONMENT_PERMISSION);
             return doPrivileged(GetEnvironmentAction.getInstance());
         }
     }
@@ -1417,13 +1429,13 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
             }
             ctx.checking = false;
             try {
-                checkPDPermission(getCallerClass(2), GET_CLASS_LOADER_PERMISSION);
+                checkPDPermission(getCallerClass(1), GET_CLASS_LOADER_PERMISSION);
                 return clazz.getClassLoader();
             } finally {
                 ctx.checking = true;
             }
         } else {
-            checkPDPermission(getCallerClass(2), GET_CLASS_LOADER_PERMISSION);
+            checkPDPermission(getCallerClass(1), GET_CLASS_LOADER_PERMISSION);
             return doPrivileged(new GetClassLoaderAction(clazz));
         }
     }
@@ -1481,7 +1493,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         final Context ctx = CTX.get();
         ctx.action1 = (ParametricPrivilegedAction<Object, Object>) action;
         ctx.parameter = parameter;
-        return (T) doPrivileged(PA_TRAMPOLINE1, ACC_CACHE.get(getCallerClass(2)));
+        return (T) doPrivileged(PA_TRAMPOLINE1, ACC_CACHE.get(getCallerClass(1)));
     }
 
     /**
@@ -1498,7 +1510,7 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         final Context ctx = CTX.get();
         ctx.action2 = (ParametricPrivilegedExceptionAction<Object, Object>) action;
         ctx.parameter = parameter;
-        return (T) doPrivileged(PA_TRAMPOLINE2, ACC_CACHE.get(getCallerClass(2)));
+        return (T) doPrivileged(PA_TRAMPOLINE2, ACC_CACHE.get(getCallerClass(1)));
     }
 
     /**
@@ -1521,10 +1533,10 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             ProtectionDomain[] protectionDomainStack = getProtectionDomainStack(accessControlContext);
             if (protectionDomainStack == null || protectionDomainStack.length == 0) {
-                combined = ACC_CACHE.get(getCallerClass(2));
+                combined = ACC_CACHE.get(getCallerClass(1));
             } else {
                 final ProtectionDomain[] finalDomains = Arrays.copyOf(protectionDomainStack, protectionDomainStack.length + 1);
-                finalDomains[protectionDomainStack.length] = getCallerClass(2).getProtectionDomain();
+                finalDomains[protectionDomainStack.length] = getCallerClass(1).getProtectionDomain();
                 combined = new AccessControlContext(finalDomains);
             }
         } finally {
@@ -1553,10 +1565,10 @@ public final class WildFlySecurityManager extends SecurityManager implements Per
         try {
             ProtectionDomain[] protectionDomainStack = getProtectionDomainStack(accessControlContext);
             if (protectionDomainStack == null || protectionDomainStack.length == 0) {
-                combined = ACC_CACHE.get(getCallerClass(2));
+                combined = ACC_CACHE.get(getCallerClass(1));
             } else {
                 final ProtectionDomain[] finalDomains = Arrays.copyOf(protectionDomainStack, protectionDomainStack.length + 1);
-                finalDomains[protectionDomainStack.length] = getCallerClass(2).getProtectionDomain();
+                finalDomains[protectionDomainStack.length] = getCallerClass(1).getProtectionDomain();
                 combined = new AccessControlContext(finalDomains);
             }
         } finally {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ELY-2787