### PR TITLE
[ELY-2704] Missing keystore password does not throw a meaningful exception

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -3649,6 +3649,9 @@ public final class ElytronXmlParser {
         public KeyStore get() throws ConfigXMLParseException {
             try {
                 KeyStore keyStore = delegateFactory.get();
+                if (passwordFactory == null || passwordFactory.get() == null) {
+                    xmlLog.noKeystorePasswordSpecified(location);
+                }
                 try (InputStream fis = createStream()) {
                     keyStore.load(fis, passwordFactory == null ? null : passwordFactory.get());
                 }

--- a/auth/client/src/main/java/org/wildfly/security/auth/client/_private/ElytronMessages.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/_private/ElytronMessages.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.security.auth.client._private;
 
+import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
@@ -128,6 +129,10 @@ public interface ElytronMessages extends BasicLogger {
     @Message(id = 1137, value = "Invalid key store entry type for alias \"%s\" (expected %s, got %s)")
     ConfigXMLParseException xmlInvalidKeyStoreEntryType(@Param Location location, String alias, Class<?> expectedClass,
             Class<?> actualClass);
+
+    @LogMessage(level = INFO)
+    @Message(id = 1138, value = "No Keystore password specified \"%s\"")
+    void noKeystorePasswordSpecified(Location location);
 
     @Message(id = 1139, value = "Failed to create credential store")
     ConfigXMLParseException xmlFailedToCreateCredentialStore(@Param Location location, @Cause Throwable cause);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2704

continuation of https://github.com/wildfly-security/wildfly-elytron/pull/2123