### PR TITLE
Fixes to ELY-2756 Add tests to the elytron test suite to test to test OCSP with revoked and unknown certificates

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/SSLAuthenticationTest.java
@@ -719,12 +719,14 @@ public class SSLAuthenticationTest {
 
     @Test
     public void testOcspRevoked() throws Throwable {
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain(caGenerationTool.getBeetlesKeyStore()))
+                .setKeyManager(scarab.createKeyManager())
                 .setTrustManager(X509RevocationTrustManager.builder()
                         .setTrustManagerFactory(getTrustManagerFactory())
-                        .setTrustStore(createKeyStore("/jks/ca.truststore"))
+                        .setTrustStore(ca.loadKeyStore())
                         .setOcspResponderCert(ocspResponderCertificate)
                         .build())
                 .setNeedClientAuth(true)
@@ -736,12 +738,14 @@ public class SSLAuthenticationTest {
 
     @Test
     public void testOcspUnknown() throws Throwable {
+        DefinedCAIdentity ca = caGenerationTool.getDefinedCAIdentity(Identity.CA);
+        DefinedIdentity scarab = caGenerationTool.getDefinedIdentity(Identity.SCARAB);
         SSLContext serverContext = new SSLContextBuilder()
-                .setSecurityDomain(getKeyStoreBackedSecurityDomain("/jks/beetles.keystore"))
-                .setKeyManager(getKeyManager("/jks/scarab.keystore"))
+                .setSecurityDomain(getKeyStoreBackedSecurityDomain(caGenerationTool.getBeetlesKeyStore()))
+                .setKeyManager(scarab.createKeyManager())
                 .setTrustManager(X509RevocationTrustManager.builder()
                         .setTrustManagerFactory(getTrustManagerFactory())
-                        .setTrustStore(createKeyStore("/jks/ca.truststore"))
+                        .setTrustStore(ca.loadKeyStore())
                         .setOcspResponderCert(ocspResponderCertificate)
                         .build())
                 .setNeedClientAuth(true)


### PR DESCRIPTION
Fix for changes in https://github.com/wildfly-security/wildfly-elytron/pull/2143 breaking CI in other PRs. 
Cause: https://github.com/wildfly-security/wildfly-elytron/pull/2143 was not rebased with newer changes to CAGenerationTool class.