### PR TITLE
[ELY-2890] Upgrade XNIO to 3.8.16.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <version.org.apache.santuario>2.3.0</version.org.apache.santuario>
         <version.org.keycloak.keycloak-services>23.0.7</version.org.keycloak.keycloak-services>
         <version.org.aesh>2.7</version.org.aesh>
+        <version.org.xnio>3.8.16.Final</version.org.xnio>
 
         <test.level>INFO</test.level>
         <!-- Checkstyle configuration -->
@@ -1138,7 +1139,7 @@
             <dependency>
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-api</artifactId>
-                <version>3.8.8.Final</version>
+                <version>${version.org.xnio}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2809

Supersedes https://github.com/wildfly-security/wildfly-elytron/pull/2141

Submitted a new PR as the dependabot PR is a few XNIO versions behind now.