### PR TITLE
[ELY-2144] null 'error page' can cause NPE from web component

### DIFF
--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -395,7 +395,9 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             sb.append(':').append(port);
         }
         sb.append(contextPath);
-        sb.append(location);
+        if (location != null) {
+            sb.append(location);
+        }
 
         return sb.toString();
     }

--- a/http/form/src/main/java/org/wildfly/security/http/form/FormMechanismFactory.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormMechanismFactory.java
@@ -51,6 +51,9 @@ public class FormMechanismFactory implements HttpServerAuthenticationMechanismFa
     public FormMechanismFactory(final Provider provider) {
     }
 
+    public FormMechanismFactory(final Provider... providers) {
+    }
+
     /**
      * @see org.wildfly.security.http.HttpServerAuthenticationMechanismFactory#getMechanismNames(java.util.Map)
      */

--- a/tests/base/src/test/java/org/wildfly/security/http/form/FormAuthenticationMechanismTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/form/FormAuthenticationMechanismTest.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.form;
+
+import mockit.integration.junit4.JMockit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.http.HttpConstants;
+import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.impl.AbstractBaseHttpTest;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test of server side of the Form HTTP mechanism.
+ *
+ * @author <a href="mailto:pberan@redhat.com">Petr Beran</a>
+ */
+@RunWith(JMockit.class)
+public class FormAuthenticationMechanismTest extends AbstractBaseHttpTest {
+
+    /**
+     * Tests proper redirect in case of invalid credentials if the error page is missing
+     */
+    @Test
+    public void testFormWithoutErrorPage() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(HttpConstants.CONFIG_REALM, "Realm");
+        properties.put(HttpConstants.CONFIG_CONTEXT_PATH, "/application");
+        properties.put(HttpConstants.CONFIG_LOGIN_PAGE, "/login.jsp");
+        HttpServerAuthenticationMechanism mechanism = formFactory.createAuthenticationMechanism(HttpConstants.FORM_NAME,
+                properties, getCallbackHandler("username", "Realm", "password"));
+
+        TestingHttpServerRequest request = new TestingHttpServerRequest(HttpConstants.POST, new String[]{"", "password"},
+                new URI("http://localhost:8080/application/j_security_check"));
+        mechanism.evaluateRequest(request);
+        TestingHttpServerResponse response = request.getResponse();
+
+        Assert.assertEquals(response.getStatusCode(), HttpConstants.FOUND);
+        Assert.assertEquals("http://localhost:8080/application", response.getLocation());
+    }
+
+    /**
+     * Tests proper redirect in case of invalid credentials if the error page is configured
+     */
+    @Test
+    public void testFormWithErrorPage() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(HttpConstants.CONFIG_REALM, "Realm");
+        properties.put(HttpConstants.CONFIG_CONTEXT_PATH, "/application");
+        properties.put(HttpConstants.CONFIG_LOGIN_PAGE, "/login.jsp");
+        properties.put(HttpConstants.CONFIG_ERROR_PAGE, "/error.jsp");
+        HttpServerAuthenticationMechanism mechanism = formFactory.createAuthenticationMechanism(HttpConstants.FORM_NAME,
+                properties, getCallbackHandler("username", "Realm", "password"));
+
+        TestingHttpServerRequest request = new TestingHttpServerRequest(HttpConstants.POST, new String[]{"", "password"},
+                new URI("http://localhost:8080/application/j_security_check"));
+        mechanism.evaluateRequest(request);
+        TestingHttpServerResponse response = request.getResponse();
+
+        Assert.assertEquals(response.getStatusCode(), HttpConstants.FOUND);
+        Assert.assertEquals("http://localhost:8080/application/error.jsp", response.getLocation());
+    }
+}

--- a/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/http/impl/AbstractBaseHttpTest.java
@@ -84,6 +84,7 @@ import org.wildfly.security.http.cert.ClientCertMechanismFactory;
 import org.wildfly.security.http.digest.DigestMechanismFactory;
 import org.wildfly.security.http.digest.NonceManager;
 import org.wildfly.security.http.external.ExternalMechanismFactory;
+import org.wildfly.security.http.form.FormMechanismFactory;
 import org.wildfly.security.password.Password;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
@@ -100,6 +101,7 @@ import mockit.MockUp;
 public class AbstractBaseHttpTest {
 
     protected HttpServerAuthenticationMechanismFactory basicFactory = new BasicMechanismFactory(ELYTRON_PASSWORD_PROVIDERS.get());
+    protected HttpServerAuthenticationMechanismFactory formFactory = new FormMechanismFactory(ELYTRON_PASSWORD_PROVIDERS.get());
     protected HttpServerAuthenticationMechanismFactory digestFactory = new DigestMechanismFactory(ELYTRON_PASSWORD_PROVIDERS.get());
     protected final HttpServerAuthenticationMechanismFactory externalFactory = new ExternalMechanismFactory(ELYTRON_PASSWORD_PROVIDERS.get());
     protected final HttpServerAuthenticationMechanismFactory bearerFactory = new BearerMechanismFactory(ELYTRON_PASSWORD_PROVIDERS.get());
@@ -179,7 +181,6 @@ public class AbstractBaseHttpTest {
             this.requestURI = requestURI;
             this.cookies = new ArrayList<>();
         }
-
         public TestingHttpServerRequest(String[] authorization, URI requestURI, Map<String, Object> sessionScopeAttachments) {
             if (authorization != null) {
                 requestHeaders.put(AUTHORIZATION, Arrays.asList(authorization));
@@ -188,6 +189,17 @@ public class AbstractBaseHttpTest {
             this.requestURI = requestURI;
             this.cookies = new ArrayList<>();
             this.sessionScopeAttachments = sessionScopeAttachments;
+        }
+
+        public TestingHttpServerRequest(String requestMethod, String[] authorization, URI requestURI) {
+
+            if (authorization != null) {
+                requestHeaders.put(AUTHORIZATION, Arrays.asList(authorization));
+            }
+            this.remoteUser = null;
+            this.requestURI = requestURI;
+            this.cookies = new ArrayList<>();
+            this.requestMethod = requestMethod;
         }
 
         public TestingHttpServerRequest(String[] authorization, URI requestURI, List<HttpServerCookie> cookies) {
@@ -308,6 +320,13 @@ public class AbstractBaseHttpTest {
         }
 
         public String getFirstParameterValue(String name) {
+            List<String> key = requestHeaders.get("Authorization");
+            if (name == "j_username"){
+                return key.get(0);
+            }
+            if (name == "j_password"){
+                return key.get(1);
+            }
             throw new IllegalStateException();
         }
 
@@ -447,7 +466,7 @@ public class AbstractBaseHttpTest {
         }
 
         public boolean forward(String path) {
-            throw new IllegalStateException();
+            return false;
         }
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2144

This PR is a current rebase of and replaces 
https://github.com/wildfly-security/wildfly-elytron/pull/1734