### PR TITLE
[ELY-2850] Update DEREncoder#flush to use isEmpty() instead of size()

### DIFF
--- a/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
+++ b/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
@@ -470,7 +470,7 @@ public class DEREncoder implements ASN1Encoder {
 
     @Override
     public void flush() {
-        while (states.size() != 0) {
+        while (!states.isEmpty()) {
             EncoderState lastState = states.peekLast();
             if (lastState.getTag() == SEQUENCE_TYPE) {
                 endSequence();


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2850