### PR TITLE
[ELY-2851] Update ElytronXmlParser#parseLocalKerberos to use isEmpty() instead of size()

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/client/ElytronXmlParser.java
@@ -3466,7 +3466,7 @@ public final class ElytronXmlParser {
                 default: throw reader.unexpectedAttribute(i);
             }
         }
-        if (mechanismOids.size() == 0) {
+        if (mechanismOids.isEmpty()) {
             mechanismOids.add(GSSCredentialSecurityFactory.KERBEROS_V5);
             mechanismOids.add(GSSCredentialSecurityFactory.SPNEGO);
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2851