### PR TITLE
[ELY-2853] Return an expression directly instead of assigning it to a temporary variable

### DIFF
--- a/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmEvidenceTest.java
+++ b/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmEvidenceTest.java
@@ -275,8 +275,7 @@ public class AggregateRealmEvidenceTest {
 
         builder.setSignatureAlgorithmName("SHA256withRSA");
         builder.setPublicKey(keyPair.getPublic());
-        final X509Certificate orderedCertificate = builder.build();
-        return orderedCertificate;
+        return builder.build();
     }
 
     private Path getRootPath(String path, boolean deleteIfExists) throws Exception {


### PR DESCRIPTION
Removed the temporary variable `orderedCertificate` and return value `builder.build()` directly.

https://issues.redhat.com/browse/ELY-2853