### PR TITLE
[ELY-2815] Renamed CA_JKS_LOCATION to CA_PKCS_LOCATION in TLS13AuthenticationTest

### DIFF
--- a/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/ssl/TLS13AuthenticationTest.java
@@ -65,7 +65,7 @@ public class TLS13AuthenticationTest {
 
     private static final String CLIENT_CONFIG = "tls13-authentication-config.xml";
     private static final char[] PASSWORD = "Elytron".toCharArray();
-    private static final String CA_JKS_LOCATION = "./target/test-classes/pkcs12";
+    private static final String CA_PKCS_LOCATION = "./target/test-classes/pkcs12";
 
     private static CAGenerationTool caGenerationTool = null;
     private static SecurityDomain securityDomain = null;
@@ -74,7 +74,7 @@ public class TLS13AuthenticationTest {
     public static void setUp() throws Exception{
 
         caGenerationTool = CAGenerationTool.builder()
-                .setBaseDir(CA_JKS_LOCATION)
+                .setBaseDir(CA_PKCS_LOCATION)
                 .setRequestIdentities(Identity.LADYBIRD, Identity.SCARAB)
                 .build();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2815