### PR TITLE
[ELY-2849] upgrade the commons-io.commons-io dependency from 2.7 to 2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
-        <version.commons-io.commons-io>2.7</version.commons-io.commons-io>
+        <version.commons-io.commons-io>2.16.1</version.commons-io.commons-io>
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
         <version.org.bitbucket.b_c.jose4j>0.9.6</version.org.bitbucket.b_c.jose4j>


### PR DESCRIPTION
….16.1

https://issues.redhat.com/browse/ELY-2849