### PR TITLE
[ELY-2814] Update UnixSHACryptPasswordImpl to make use of MessageDigest.isEqual to avoid a potential timing attack

### DIFF
--- a/password/impl/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
+++ b/password/impl/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
@@ -435,7 +435,7 @@ final class UnixSHACryptPasswordImpl extends AbstractPasswordImpl implements Uni
             return false;
         }
         UnixSHACryptPasswordImpl other = (UnixSHACryptPasswordImpl) obj;
-        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && Arrays.equals(hash, other.hash) && Arrays.equals(salt, other.salt);
+        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && MessageDigest.isEqual(hash, other.hash) && MessageDigest.isEqual(salt, other.salt);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2814