### PR TITLE
[ELY-2854] Add a test to AggregateRealmEvidenceTest for the case where authentication fails with a principal transformer

### DIFF
--- a/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmEvidenceTest.java
+++ b/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmEvidenceTest.java
@@ -177,6 +177,26 @@ public class AggregateRealmEvidenceTest {
     }
 
     @Test
+    public void testAuthenticationFailsWithPrincipalTransformer() throws Exception {
+        Attributes authenticationAttributes = new MapAttributes();
+        authenticationAttributes.add("team", 0, "One");
+
+        Function<Principal, Principal> principalTransformer = new AggregateRealmEvidenceTest.CaseRewriter().asPrincipalRewriter();
+        X509PeerCertificateChainEvidence evidence = new X509PeerCertificateChainEvidence(populateCertificateChain());
+        evidence.setDecodedPrincipal(new NamePrincipal("invalid_principal"));
+
+        SecurityRealm testRealm = createSecurityRealm(true, authenticationAttributes, principalTransformer, new Attributes[] { null });
+        RealmIdentity identity = testRealm.getRealmIdentity(evidence);
+
+        Assert.assertFalse("Identity should not exist with invalid principal", identity.exists());
+
+        // Assert no authorization attributes exist
+        Attributes identityAttributes = identity.getAuthorizationIdentity().getAttributes();
+        Assert.assertEquals("Expected attribute count.", 0, identityAttributes.size());
+    }
+
+
+    @Test
     public void testAuthorizationOnlyWithPrincipalTransformer() throws Exception {
         Attributes authorizationAttributes = new MapAttributes();
         authorizationAttributes.add("team", 0, "One");


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2854