### PR TITLE
[ELY-2866] / [ELY-2867] Update "External" mode of the KeyStoreCredentialStore to not use an in memory KeyStore

### DIFF
--- a/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
+++ b/credential/store/src/main/java/org/wildfly/security/credential/store/impl/KeyStoreCredentialStore.java
@@ -44,6 +44,8 @@ import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.UnrecoverableEntryException;
+import java.security.KeyStore.Entry;
+import java.security.KeyStore.ProtectionParameter;
 import java.security.KeyStore.SecretKeyEntry;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -172,7 +174,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
     private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
     private final HashMap<String, TopEntry> cache = new HashMap<>();
     private volatile boolean modifiable;
-    private KeyStore keyStore;
+    private InMemoryStore inMemoryStore;
     private Path location;
     private Path externalPath;
     private boolean create;
@@ -389,7 +391,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             // now, store it under a unique alias
             final String ksAlias = calculateNewAlias(credentialAlias, credentialClass, algorithmName, parameterSpec);
             try (Hold hold = lockForWrite()) {
-                keyStore.setEntry(ksAlias, entry, convertParameter(protectionParameter));
+                inMemoryStore.setEntry(ksAlias, entry, convertParameter(protectionParameter));
                 final TopEntry topEntry = cache.computeIfAbsent(toLowercase(credentialAlias), TopEntry::new);
                 final MidEntry midEntry = topEntry.getMap().computeIfAbsent(credentialClass, c -> new MidEntry(topEntry, c));
                 final BottomEntry bottomEntry;
@@ -406,7 +408,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 }
                 if (oldAlias != null && ! oldAlias.equals(ksAlias)) {
                     // unlikely but possible
-                    keyStore.deleteEntry(oldAlias);
+                    inMemoryStore.deleteEntry(oldAlias);
                 }
             }
         } catch (KeyStoreException | NoSuchAlgorithmException | InvalidKeySpecException | InvalidKeyException | CertificateException e) {
@@ -474,7 +476,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                 log.tracef("KeyStoreCredentialStore: no entry for parameterSpec %s", parameterSpec);
                 return null;
             }
-            entry = keyStore.getEntry(ksAlias, convertParameter(protectionParameter));
+            entry = inMemoryStore.getEntry(ksAlias, convertParameter(protectionParameter));
         } catch (NoSuchAlgorithmException | UnrecoverableEntryException | KeyStoreException e) {
             throw log.cannotAcquireCredentialFromStore(e);
         }
@@ -776,7 +778,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
 
     private void remove(final String ksAlias) throws KeyStoreException {
         if (ksAlias != null) {
-            keyStore.deleteEntry(ksAlias);
+            inMemoryStore.deleteEntry(ksAlias);
         }
     }
 
@@ -791,7 +793,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                         if (useExternalStorage) {
                             externalStorage.store(os);
                         } else {
-                            keyStore.store(os, storePassword);
+                            inMemoryStore.store(os, storePassword);
                         }
                     } catch (Throwable t) {
                         try {
@@ -844,13 +846,14 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             setupExternalStorage(type, location);
         } else {
             dataLocation = location;
-            keyStore = getKeyStoreInstance(type);
+            KeyStore keyStore = getKeyStoreInstance(type);
+            inMemoryStore = new KeyStoreWrapper(keyStore);
         }
         if (create) {
             log.tracef("KeyStoreCredentialStore: creating empty backing KeyStore  dataLocation = %s  external = %b", dataLocation, useExternalStorage);
             if (dataLocation == null) {
                 try {
-                    keyStore.load(null, null);
+                    inMemoryStore.load(null, null);
                 } catch (CertificateException | IOException | NoSuchAlgorithmException e) {
                     throw log.cannotInitializeCredentialStore(e);
                 }
@@ -869,12 +872,12 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     if (useExternalStorage) {
                         externalStorage.load(fileStream);
                     } else {
-                        keyStore.load(fileStream, password);
+                        inMemoryStore.load(fileStream, password);
                     }
                 }
-                enumeration = keyStore.aliases();
+                enumeration = inMemoryStore.aliases();
             } else {
-                keyStore.load(null, null);
+                inMemoryStore.load(null, null);
                 enumeration = Collections.emptyEnumeration();
             }
         } catch (GeneralSecurityException e) {
@@ -963,7 +966,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
      */
     private void setupExternalStorage(final String keyContainingKeyStoreType, final Path keyContainingKeyStoreLocation) throws CredentialStoreException {
         KeyStore keyContainingKeyStore = getKeyStoreInstance(keyContainingKeyStoreType);
-        keyStore = getKeyStoreInstance("JCEKS");
+        inMemoryStore = new HashMapStore();
         externalStorage = new ExternalStorage();
         try {
             final char[] storePassword = getStorePassword(protectionParameter);
@@ -977,7 +980,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
                     keyContainingKeyStore.load(null, storePassword);
                 }
             }
-            externalStorage.init(cryptographicAlgorithm, encryptionKeyAlias, keyContainingKeyStore, storePassword, keyStore);
+            externalStorage.init(cryptographicAlgorithm, encryptionKeyAlias, keyContainingKeyStore, storePassword, inMemoryStore);
         } catch(IOException | GeneralSecurityException e) {
             throw log.cannotInitializeCredentialStore(e);
         }
@@ -1170,6 +1173,101 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
         }
     }
 
+    /**
+     * Interface to represent the in-memory form of either the direct KeyStore
+     * or the store used for external mode.
+     */
+    private interface InMemoryStore {
+
+        public Enumeration<String> aliases() throws KeyStoreException;
+        public Entry getEntry(String alias, ProtectionParameter protParam) throws NoSuchAlgorithmException, UnrecoverableEntryException, KeyStoreException;
+        public void setEntry(String alias, Entry entry, ProtectionParameter protParam) throws KeyStoreException;
+
+        public void deleteEntry(String alias) throws KeyStoreException;
+
+        public void load(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException;
+        public void store(OutputStream stream, char[] password) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException;
+    }
+
+    static final class KeyStoreWrapper implements InMemoryStore {
+
+        private final KeyStore wrapped;
+
+        KeyStoreWrapper(final KeyStore toWrap) {
+            this.wrapped = toWrap;
+        }
+
+        @Override
+        public Enumeration<String> aliases() throws KeyStoreException {
+            return wrapped.aliases();
+        }
+
+        @Override
+        public Entry getEntry(String alias, ProtectionParameter protParam)
+                throws NoSuchAlgorithmException, UnrecoverableEntryException, KeyStoreException {
+            return wrapped.getEntry(alias, protParam);
+        }
+
+        @Override
+        public void setEntry(String alias, Entry entry, ProtectionParameter protParam) throws KeyStoreException {
+            wrapped.setEntry(alias, entry, protParam);
+        }
+
+        @Override
+        public void deleteEntry(String alias) throws KeyStoreException {
+            wrapped.deleteEntry(alias);
+        }
+
+        @Override
+        public void load(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+            wrapped.load(stream, password);
+        }
+
+        @Override
+        public void store(OutputStream stream, char[] password)
+                throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+            wrapped.store(stream, password);
+        }
+
+    }
+
+    static final class HashMapStore implements InMemoryStore {
+
+        private final Map<String, Entry> map = new HashMap<>();
+
+        @Override
+        public Enumeration<String> aliases() throws KeyStoreException {
+            return  Collections.enumeration(map.keySet());
+        }
+
+        @Override
+        public Entry getEntry(String alias, ProtectionParameter protParam) {
+            return map.get(alias);
+        }
+
+        @Override
+        public void setEntry(String alias, Entry entry, ProtectionParameter protParam) {
+            map.put(alias, entry);
+        }
+
+        @Override
+        public void deleteEntry(String alias) {
+            map.remove(alias);
+        }
+
+        @Override
+        public void load(InputStream stream, char[] password) throws IOException, NoSuchAlgorithmException, CertificateException {
+            map.clear();
+        }
+
+        @Override
+        public void store(OutputStream stream, char[] password) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+            // This should not be reachable so not converted to an error coded message.
+            throw new UnsupportedOperationException("Cannot store in-memory store");
+        }
+
+    }
+
     private final class ExternalStorage {
 
         // version of external storage file, can be used later to enhance functionality and keep backward compatibility
@@ -1189,19 +1287,19 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
         private Cipher encrypt;
         private Cipher decrypt;
 
-        private KeyStore dataKeyStore;
+        private InMemoryStore inMemoryStore;
         private KeyStore storageSecretKeyStore;
         private SecretKey storageSecretKey;
 
         private ExternalStorage() {}
 
-        void init(String cryptographicAlgorithm, String keyAlias, KeyStore keyStore, char[] keyPassword, KeyStore dataKeyStore) throws CredentialStoreException {
+        void init(String cryptographicAlgorithm, String keyAlias, KeyStore keyStore, char[] keyPassword, InMemoryStore inMemoryStore) throws CredentialStoreException {
 
             if (cryptographicAlgorithm == null)
                 cryptographicAlgorithm = DEFAULT_CRYPTOGRAPHIC_ALGORITHM;
 
             storageSecretKeyStore = keyStore;
-            this.dataKeyStore = dataKeyStore;
+            this.inMemoryStore = inMemoryStore;
 
             try {
                 fetchStorageSecretKey(keyAlias, keyPassword);
@@ -1242,7 +1340,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
          * @throws IOException if something goes wrong
          */
         void load(InputStream inputStream) throws IOException, GeneralSecurityException {
-            dataKeyStore.load(null, null);
+            inMemoryStore.load(null, null);
             ObjectInputStream ois = new ObjectInputStream(inputStream);
             int fileVersion = ois.readInt();
             if (fileVersion == VERSION_ONE || fileVersion == VERSION_TWO) {
@@ -1273,7 +1371,7 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             byte[] encodedSecretKey = readBytes(entryOis);
             String algorithm = readAlgorithm ? entryOis.readUTF() : DATA_OID;
             KeyStore.Entry entry = new KeyStore.SecretKeyEntry(new SecretKeySpec(encodedSecretKey, algorithm));
-            dataKeyStore.setEntry(ksAlias, entry, convertParameter(protectionParameter));
+            inMemoryStore.setEntry(ksAlias, entry, convertParameter(protectionParameter));
         }
 
         private byte[] readBytes(ObjectInputStream ois) throws IOException {
@@ -1302,10 +1400,10 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
             final boolean writeVersionTwo = isWriteUsingVersionTwo();
 
             oos.writeInt(writeVersionTwo ? VERSION_TWO : VERSION_ONE);
-            Enumeration<String> ksAliases = dataKeyStore.aliases();
+            Enumeration<String> ksAliases = inMemoryStore.aliases();
             while(ksAliases.hasMoreElements()) {
                 String alias = ksAliases.nextElement();
-                KeyStore.Entry entry = dataKeyStore.getEntry(alias, convertParameter(protectionParameter));
+                KeyStore.Entry entry = inMemoryStore.getEntry(alias, convertParameter(protectionParameter));
                 if (entry instanceof KeyStore.SecretKeyEntry) {
                     saveSecretKey(alias, oos, (KeyStore.SecretKeyEntry)entry, writeVersionTwo);
                 } else {
@@ -1317,10 +1415,10 @@ public final class KeyStoreCredentialStore extends CredentialStoreSpi {
         }
 
         private boolean isWriteUsingVersionTwo() throws GeneralSecurityException {
-            Enumeration<String> aliases = dataKeyStore.aliases();
+            Enumeration<String> aliases = inMemoryStore.aliases();
             while(aliases.hasMoreElements()) {
                 String alias = aliases.nextElement();
-                KeyStore.Entry entry = dataKeyStore.getEntry(alias, convertParameter(protectionParameter));
+                KeyStore.Entry entry = inMemoryStore.getEntry(alias, convertParameter(protectionParameter));
                 if (entry instanceof KeyStore.SecretKeyEntry) {
                     SecretKeyEntry secretKeyEntry = (SecretKeyEntry) entry;
                     if (!DATA_OID.equals(secretKeyEntry.getSecretKey().getAlgorithm())) {

--- a/credential/store/src/test/java/org/wildfly/security/credential/store/impl/ExternalKeyStoreCredentialStoreTest.java
+++ b/credential/store/src/test/java/org/wildfly/security/credential/store/impl/ExternalKeyStoreCredentialStoreTest.java
@@ -1,0 +1,223 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.credential.store.impl;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.KeyStore;
+import java.security.KeyStore.ProtectionParameter;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.SecretKeyCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStore.CredentialSourceProtectionParameter;
+import org.wildfly.security.credential.store.CredentialStoreSpi;
+import org.wildfly.security.encryption.SecretKeyUtil;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * /**
+ * Test case to test the {@code KeyStoreCredentialStore} implementation when
+ * configured to persist to an external file.
+ *
+ * When running in this mode a KeyStore is used to obtain a SecretKey instance
+ * and the credentials are encrypted using this SecretKey before being written
+ * to the external file.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ExternalKeyStoreCredentialStoreTest {
+
+    private static final String KEY_KEY_STORE_NAME = "secret.pkcs12";
+    private static final String SECRET_KEY_ALIAS = "secret";
+    private final char[] keyStorePassword = "The quick brown fox jumped over the lazy dog".toCharArray();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File keyKeyStoreFile;
+    private PasswordFactory passwordFactory;
+    private String providerName;
+
+    private char[] secretPassword;
+    private PasswordCredential storedPasswordCredential;
+    private SecretKeyCredential storedSecretKeyCredential;
+
+    private CredentialSourceProtectionParameter storeProtection;
+
+    @Before
+    public void prepareTest() throws Exception {
+        /*
+         * Step 1 - Create a KeyStore containing a SecretKey to be used for encryption.
+         */
+        byte[] rawKey = new byte[16];  // 16 bytes = 128 bits
+        Arrays.fill(rawKey, (byte) 0x00); // This is a test, we don't need a random key.
+        SecretKey secretKey = new SecretKeySpec(rawKey, "AES");
+
+        KeyStore keyKeyStore = KeyStore.getInstance("PKCS12");
+        ProtectionParameter keyStoreProtection = new KeyStore.PasswordProtection(keyStorePassword);
+
+        keyKeyStore.load(null, keyStorePassword);
+        keyKeyStore.setEntry(SECRET_KEY_ALIAS, new KeyStore.SecretKeyEntry(secretKey), keyStoreProtection);
+
+        keyKeyStoreFile = temporaryFolder.newFile(KEY_KEY_STORE_NAME);
+
+        try (FileOutputStream fos = new FileOutputStream(keyKeyStoreFile)) {
+           keyKeyStore.store(fos, keyStorePassword);
+        }
+        /*
+         * Step 2 - Create the PasswordFactory and SecretKeyCredential to be stored.
+         */
+        final Provider provider = WildFlyElytronPasswordProvider.getInstance();
+
+        providerName = provider.getName();
+
+        Security.addProvider(provider);
+
+        passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+        final Password password = passwordFactory.generatePassword(new ClearPasswordSpec(keyStorePassword));
+        final Credential credential = new PasswordCredential(password);
+        final CredentialSource credentialSource = IdentityCredentials.NONE.withCredential(credential);
+
+        storeProtection = new CredentialStore.CredentialSourceProtectionParameter(credentialSource);
+
+        secretPassword = "this is a password".toCharArray();
+
+        final Password secret = passwordFactory.generatePassword(new ClearPasswordSpec(secretPassword));
+
+        storedPasswordCredential = new PasswordCredential(secret);
+        storedSecretKeyCredential = new SecretKeyCredential(SecretKeyUtil.generateSecretKey(256));
+    }
+
+    @After
+    public void removeWildFlyElytronProvider() {
+        Security.removeProvider(providerName);
+    }
+
+    private CredentialStoreSpi getCredentialStore(final File location) throws Exception {
+        final KeyStoreCredentialStore keyStoreCredentialStore = new KeyStoreCredentialStore();
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("keyStoreType", "PKCS12");
+        attributes.put("keyAlias", SECRET_KEY_ALIAS);
+        attributes.put("create", Boolean.TRUE.toString());
+        attributes.put("location", keyKeyStoreFile.getAbsolutePath());
+        attributes.put("external", Boolean.TRUE.toString());
+        attributes.put("externalPath", location.getAbsolutePath());
+
+        keyStoreCredentialStore.initialize(attributes, storeProtection, null);
+
+        return keyStoreCredentialStore;
+    }
+
+    @Test
+    public void testPasswordCredential() throws Exception {
+        final File credentialStoreFile = new File(temporaryFolder.getRoot(), "test.credential.store");
+
+        CredentialStoreSpi credentialStore = getCredentialStore(credentialStoreFile);
+
+        credentialStore.store("testAlias", storedPasswordCredential, null);
+        credentialStore.flush();
+
+        assertTrue("Credential Store File Created", credentialStoreFile.exists());
+
+        credentialStore = getCredentialStore(credentialStoreFile);
+
+        final PasswordCredential retrievedCredential = credentialStore.retrieve("testAlias", PasswordCredential.class, null,
+                null, null);
+
+        final ClearPasswordSpec retrievedPassword = passwordFactory.getKeySpec(retrievedCredential.getPassword(),
+                ClearPasswordSpec.class);
+
+        assertArrayEquals(secretPassword, retrievedPassword.getEncodedPassword());
+    }
+
+    @Test
+    public void testSecretKeyCredential() throws Exception {
+        final File credentialStoreFile = new File(temporaryFolder.getRoot(), "test.credential.store");
+
+        CredentialStoreSpi credentialStore = getCredentialStore(credentialStoreFile);
+
+        credentialStore.store("testAlias", storedSecretKeyCredential, null);
+        credentialStore.flush();
+
+        assertTrue("Credential Store File Created", credentialStoreFile.exists());
+
+        credentialStore = getCredentialStore(credentialStoreFile);
+
+        final SecretKeyCredential retrievedSecretKeyCredential = credentialStore.retrieve("testAlias",SecretKeyCredential.class, null,
+                null, null);
+        assertEquals("Expect SecretKeys to match", storedSecretKeyCredential.getSecretKey(), retrievedSecretKeyCredential.getSecretKey());
+    }
+
+    @Test
+    public void testBothCredentials() throws Exception {
+        final File credentialStoreFile = new File(temporaryFolder.getRoot(), "test.credential.store");
+
+        CredentialStoreSpi credentialStore = getCredentialStore(credentialStoreFile);
+
+        credentialStore.store("testAlias", storedPasswordCredential, null);
+        credentialStore.store("testAlias", storedSecretKeyCredential, null);
+        credentialStore.flush();
+
+        assertTrue("Credential Store File Created", credentialStoreFile.exists());
+
+        credentialStore = getCredentialStore(credentialStoreFile);
+
+        Set<String> aliases = credentialStore.getAliases();
+        assertEquals("Expected alias count", 1, aliases.size());
+        assertTrue("Expected alias 'testAlias'", aliases.contains("testalias"));
+
+        final PasswordCredential retrievedCredential = credentialStore.retrieve("testAlias", PasswordCredential.class, null,
+                null, null);
+
+        final ClearPasswordSpec retrievedPassword = passwordFactory.getKeySpec(retrievedCredential.getPassword(),
+                ClearPasswordSpec.class);
+        assertArrayEquals(secretPassword, retrievedPassword.getEncodedPassword());
+
+        final SecretKeyCredential retrievedSecretKeyCredential = credentialStore.retrieve("testAlias",SecretKeyCredential.class, null,
+                null, null);
+        assertEquals("Expect SecretKeys to match", storedSecretKeyCredential.getSecretKey(), retrievedSecretKeyCredential.getSecretKey());
+    }
+}


### PR DESCRIPTION

https://issues.redhat.com/browse/ELY-2866
https://issues.redhat.com/browse/ELY-2867

The code changes could possibly go further and ensure all load and store logic is wrapped behind the InMemoryStore however as this is a bug fix for the maintenance branches I have constrained it to just wrap the common entry manipulation methods to enable us to remove the KeyStore instance from external mode.


