### PR TITLE
[ELY-2870] Add a new NamedGroup interface.

### DIFF
--- a/auth/base/src/main/java/org/wildfly/security/auth/principal/NamedGroup.java
+++ b/auth/base/src/main/java/org/wildfly/security/auth/principal/NamedGroup.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ package org.wildfly.security.auth.principal;
+
+import java.security.Principal;
+import java.util.Enumeration;
+
+/**
+ * An interface to represent a named group of principals.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface NamedGroup extends Principal {
+
+    /**
+     * Check if the supplied {@code Principal} is a member of this group.
+     *
+     * @param member The {@code Principal} to check for group membership.
+     * @return {@code true} if the supplied {@code Principal} is a member of this group, otherwise {@code false}.
+     */
+    boolean isMember(Principal member);
+
+    /**
+     * Return an {@code Enumeration} of the {@code Principal} instances in this group.
+     *
+     * @return an {@code Enumeration} of the {@code Principal} instances in this group.
+     */
+    Enumeration<? extends Principal> members();
+
+}


### PR DESCRIPTION
This is to replace prior uses of 'java.security.acl.Group' but defaulting to immutable.

https://issues.redhat.com/browse/ELY-2870

This is unlikely to need further changes but raising as a draft whilst I work on the rest of the integration.
