### PR TITLE
[2.6.x] [ELY-2868] When handling CachedIdentityAuthorizeCallback current authentication not prioritised.

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/auth/callback/CachedIdentityAuthorizeCallback.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/callback/CachedIdentityAuthorizeCallback.java
@@ -46,7 +46,7 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
 
     private final Function<SecurityDomain, IdentityCache> identityCache;
     private final boolean localCache;
-    private Principal principal;
+    private final Principal principal;
     private boolean authorized;
     private SecurityDomain securityDomain;
 
@@ -85,10 +85,13 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
         checkNotNullParam("identityCache", identityCache);
         this.identityCache = identityCache;
         this.localCache = localCache;
+        this.principal = null;
     }
 
     /**
      * Creates a new instance to authenticate, authorize and cache the identity associated with the given <code>name</code>.
+     *
+     * <p>By supplying a name authorizing the supplied name will be prioritised over restoring an identify from the cache</p>
      *
      * @param name the name associated with the identity
      * @param identityCache the identity cache
@@ -99,6 +102,8 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
 
     /**
      * Creates a new instance to authenticate, authorize and cache the identity associated with the given <code>principal</code>.
+     *
+     * <p>By supplying a {@code Principal} authorizing the supplied {@code Principal} will be prioritised over restoring an identify from the cache</p>
      *
      * @param principal the principal associated with the identity
      * @param identityCache the identity cache
@@ -113,6 +118,8 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
     /**
      * Creates a new instance to authenticate, authorize and cache the identity associated with the given <code>principal</code>.
      *
+     * <p>By supplying a {@code Principal} authorizing the supplied {@code Principal} will be prioritised over restoring an identify from the cache</p>
+     *
      * @param principal the principal associated with the identity
      * @param identityCache the identity cache
      */
@@ -124,6 +131,8 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
      * <p>Creates a new instance to authenticate, authorize and cache the identity associated with the given <code>principal</code>.
      *
      * <p>This constructor can be used to perform caching operations (e.g.: put, get and remove) in the context of a {@link SecurityDomain}.
+     *
+     * <p>By supplying a {@code Principal} authorizing the supplied {@code Principal} will be prioritised over restoring an identify from the cache</p>
      *
      * @param principal the principal associated with the identity
      * @param identityCache a function that creates an {@link IdentityCache} given a {@link SecurityDomain}
@@ -156,7 +165,11 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
     public void setAuthorized(SecurityIdentity securityIdentity) {
         authorized = securityIdentity != null;
         if (authorized) {
-            createDomainCache().put(securityIdentity);
+            IdentityCache cache = createDomainCache();
+            if (this.principal != null) {
+                cache.remove();
+            }
+            cache.put(securityIdentity);
         } else {
             createDomainCache().remove();
         }
@@ -178,7 +191,7 @@ public class CachedIdentityAuthorizeCallback implements ExtendedCallback {
     /**
      * Returns the authorization {@link Principal}.
      *
-     * @return the principal (not {@code null})
+     * @return the principal
      */
     public Principal getAuthorizationPrincipal() {
         return this.principal;

--- a/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -1124,20 +1124,18 @@ public final class ServerAuthenticationContext implements AutoCloseable {
                     CachedIdentityAuthorizeCallback authorizeCallback = (CachedIdentityAuthorizeCallback) callback;
                     authorizeCallback.setSecurityDomain(stateRef.get().getSecurityDomain());
                     SecurityIdentity authorizedIdentity = null;
-                    Principal principal = null;
-                    SecurityIdentity identity = authorizeCallback.getIdentity();
-                    if (identity != null && importIdentity(identity)) {
+                    Principal principal = authorizeCallback.getAuthorizationPrincipal();
+                    SecurityIdentity identity;
+                    if (principal == null && (identity = authorizeCallback.getIdentity()) != null && importIdentity(identity)) {
                         authorizedIdentity = getAuthorizedIdentity();
-                    } else {
+                    } else if (principal == null) {
                         principal = authorizeCallback.getPrincipal();
-                        if (principal == null) {
-                            principal = authorizeCallback.getAuthorizationPrincipal();
-                        }
-                        if (principal != null) {
-                            setAuthenticationPrincipal(principal);
-                            if (authorize()) {
-                                authorizedIdentity = getAuthorizedIdentity();
-                            }
+                    }
+
+                    if (principal != null) {
+                        setAuthenticationPrincipal(principal);
+                        if (authorize()) {
+                            authorizedIdentity = getAuthorizedIdentity();
                         }
                     }
                     log.tracef("Handling CachedIdentityAuthorizeCallback: principal = %s  authorizedIdentity = %s", principal, authorizedIdentity);

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/DefaultSingleSignOnSession.java
@@ -72,7 +72,7 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
         this.map.put(SINGLE_SIGN_ON_KEY, sso);
         this.request = checkNotNullParam("request", request);
         checkNotNullParam("sso", sso);
-        this.ssoFactory = identity -> sso;
+        this.ssoFactory = identity -> context.getSingleSignOnManager().create(sso.getMechanism(), sso.isProgrammatic(), identity);
     }
 
     @Override
@@ -181,7 +181,7 @@ public class DefaultSingleSignOnSession implements SingleSignOnSession {
 
     @Override
     public CachedIdentity remove() {
-        SingleSignOn sso = this.map.get(SINGLE_SIGN_ON_KEY);
+        SingleSignOn sso = this.map.remove(SINGLE_SIGN_ON_KEY);
 
         if (sso == null) return null;
 

--- a/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
+++ b/http/sso/src/main/java/org/wildfly/security/http/util/sso/SingleSignOnServerMechanismFactory.java
@@ -171,8 +171,7 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                                 String id = singleSignOnSession.getId();
                                 if (id != null) {
                                     HttpServerCookie cookie = getCookie(request);
-
-                                    if (cookie == null) {
+                                    if (cookie == null || !id.equals(cookie.getValue())) {
                                         response.setResponseCookie(createCookie(id, -1));
                                     }
                                 }
@@ -194,7 +193,7 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                                 if (id != null) {
                                     HttpServerCookie cookie = getCookie(request);
 
-                                    if (cookie == null) {
+                                    if (cookie == null || !id.equals(cookie.getValue())) {
                                         response.setResponseCookie(createCookie(id, -1));
                                     }
                                 }
@@ -273,6 +272,7 @@ public class SingleSignOnServerMechanismFactory implements HttpServerAuthenticat
                         }
                         Principal principal = delegate.getAuthorizationPrincipal();
                         if (principal != null) {
+
                             callbacks[i] = new CachedIdentityAuthorizeCallback(principal, singleSignOnSession) {
                                 @Override
                                 public void setAuthorized(SecurityIdentity securityIdentity) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2868

This merges the fix from 2.2.x so we may skip this if we merge in order and rely on forward port during release instead.