### PR TITLE
[ELY-2848] Upgraded org.testcontainers.testcontainers dependency to 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
         <version.org.bitbucket.b_c.jose4j>0.9.6</version.org.bitbucket.b_c.jose4j>
-        <version.org.testcontainers.testcontainers>1.15.3</version.org.testcontainers.testcontainers>
+        <version.org.testcontainers.testcontainers>1.20.1</version.org.testcontainers.testcontainers>
         <version.org.keycloak>25.0.2</version.org.keycloak>
         <version.io.rest-assured>5.5.0</version.io.rest-assured>
         <version.net.sourceforge.htmlunit.htmlunit>2.40.0</version.net.sourceforge.htmlunit.htmlunit>


### PR DESCRIPTION
This pull request upgrades the `org.testcontainers.testcontainers` dependency from version `1.15.3` to `1.20.1` in the WildFly Elytron project.

### Changes Made:
- Updated `version.org.testcontainers.testcontainers` property in `pom.xml` from `1.15.3` to `1.20.1`.

### Testing Done:
- Built the project successfully using `mvn clean install -DskipTests`.
- Ran all tests using `mvn test`, and they passed without any issues.

Please review and let me know if additional changes are required.
https://issues.redhat.com/browse/ELY-2848
