### PR TITLE
[ELY-2841] Upgrade Jackson dependencies to 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <jdk.min.version>11</jdk.min.version>
         <version-javadoc-plugin>3.7.0</version-javadoc-plugin>
-        <version.com.fasterxml.jackson>2.17.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.17.2</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.6.0</version.commons-cli>
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>


### PR DESCRIPTION
This pull request upgrades the `com.fasterxml.jackson` dependency from version `2.17.0` to `2.17.2` in the WildFly Elytron project.

### Changes Made:
- Updated `version.com.fasterxml.jackson` property in `pom.xml` from `2.17.0` to `2.17.2`.

### Testing Done:
- Built the project successfully using `mvn clean install -DskipTests`.
- Ran all tests using `mvn test`, and they passed without any issues.

Please review and let me know if additional changes are required.
https://issues.redhat.com/browse/ELY-2841