### PR TITLE
[ELY-2840] Upgrade okhttp3 mockwebserver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <version.hsqldb>2.7.1</version.hsqldb>
         <version.net.minidev.json-smart>2.4.9</version.net.minidev.json-smart>
         <version.com.nimbusds.nimbus-jose-jwt>9.37.3</version.com.nimbusds.nimbus-jose-jwt>
-        <version.com.squareup.okhttp3.mockwebserver>3.8.1</version.com.squareup.okhttp3.mockwebserver>
+        <version.com.squareup.okhttp3.mockwebserver>4.0.0</version.com.squareup.okhttp3.mockwebserver>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <properties>
         <jdk.min.version>11</jdk.min.version>
         <version-javadoc-plugin>3.7.0</version-javadoc-plugin>
-        <version.com.fasterxml.jackson>2.17.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.17.2</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.commons-cli>1.6.0</version.commons-cli>
         <version.jakarta.enterprise>4.0.1</version.jakarta.enterprise>


### PR DESCRIPTION
This pull request upgrades the `com.squareup.okhttp3.mockwebserver` dependency from version `3.x` to `4.0.0` in the WildFly Elytron project.

## Changes Made:
- Updated `version.com.squareup.okhttp3.mockwebserver` property in `pom.xml` from `3.x` to `4.0.0`.

## Testing Done:
- Built the project successfully using `mvn clean install -DskipTests`.
- Ran all tests using `mvn test`, and they passed without any issues.

Please review and let me know if additional changes are required.  

https://issues.redhat.com/browse/ELY-2840