### PR TITLE
[ELY-2894] We should use URI.getRawPath() when constructing the URL by hand.

### DIFF
--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -340,7 +340,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             if (appendPort(scheme, port)) {
                 sb.append(':').append(port);
             }
-            sb.append(requestURI.getPath());
+            sb.append(requestURI.getRawPath());
             if(requestURI.getRawQuery() != null) {
                 sb.append("?");
                 sb.append(requestURI.getRawQuery());


### PR DESCRIPTION
@fjuma FYI submitting as a draft as I prepare the PR to start from the maintenance branches.

This is (IMO extensively) tested in the PR to Elytron Web https://github.com/wildfly-security/elytron-web/pull/273 where the second part of this is about how this all comes together in Undertow and in the Elytron Web implementation of the SPI.
 