### PR TITLE
[ELY-2894] We should use URI.getRawPath() when constructing the URL by hand.

### DIFF
--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -337,7 +337,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
             if (appendPort(scheme, port)) {
                 sb.append(':').append(port);
             }
-            sb.append(requestURI.getPath());
+            sb.append(requestURI.getRawPath());
             if(requestURI.getRawQuery() != null) {
                 sb.append("?");
                 sb.append(requestURI.getRawQuery());


### PR DESCRIPTION

https://issues.redhat.com/browse/ELY-2894