### PR TITLE
[ELY-2781] ElytronXmlParserTest test class fails with Java 17 when the test class is run individually

### DIFF
--- a/auth/client/src/test/resources/org/wildfly/security/auth/client/java.security
+++ b/auth/client/src/test/resources/org/wildfly/security/auth/client/java.security
@@ -1,3 +1,4 @@
 security.provider.1=org.wildfly.security.auth.client.WildFlyElytronClientDefaultSSLContextProvider file:./src/test/resources/org/wildfly/security/auth/client/test-wildfly-config-client-default-sslcontext.xml
 security.provider.2=SUN
-security.provider.3=SunJSSE
+security.provider.3=SunRsaSign
+security.provider.4=SunJSSE


### PR DESCRIPTION
Resubmitting https://github.com/wildfly-security/wildfly-elytron/pull/2208 for CI