### PR TITLE
[ELY-2753] Add connection-timeout-millis, connection-ttl-millis and

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
@@ -275,6 +275,15 @@ public class HttpClientBuilder {
         if (oidcClientConfig.getConnectionPoolSize() > 0) {
             size = oidcClientConfig.getConnectionPoolSize();
         }
+        if (oidcClientConfig.getConnectionTimeoutMillis() > 0) {
+            setEstablishConnectionTimeout(oidcClientConfig.getConnectionTimeoutMillis(), establishConnectionTimeoutUnits);
+        }
+        if (oidcClientConfig.getConnectionTtlMillis() > 0) {
+            setConnectionTimeToLive(oidcClientConfig.getConnectionTtlMillis(), connectionTimeToLiveUnit);
+        }
+        if (oidcClientConfig.getSocketTimeoutMillis() > 0) {
+            setSocketTimeout(oidcClientConfig.getSocketTimeoutMillis(), socketTimeoutUnits);
+        }
         HttpClientBuilder.HostnameVerificationPolicy policy = HttpClientBuilder.HostnameVerificationPolicy.WILDCARD;
         if (oidcClientConfig.isAllowAnyHostname()) {
             policy = HttpClientBuilder.HostnameVerificationPolicy.ANY;

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcJsonConfiguration.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
         "enable-cors", "cors-max-age", "cors-allowed-methods", "cors-exposed-headers",
         "expose-token", "bearer-only", "autodetect-bearer-only",
         "connection-pool-size",
+        "connection-timeout-millis", "connection-ttl-millis", "socket-timeout-millis",
         "allow-any-hostname", "disable-trust-manager", "truststore", "truststore-password",
         "client-keystore", "client-keystore-password", "client-key-password",
         "always-refresh-token",
@@ -66,6 +67,12 @@ public class OidcJsonConfiguration {
     protected String clientKeyPassword;
     @JsonProperty("connection-pool-size")
     protected int connectionPoolSize = 20;
+    @JsonProperty("connection-timeout-millis")
+    protected int connectionTimeoutMillis = -1;
+    @JsonProperty("connection-ttl-millis")
+    protected int connectionTtlMillis = -1;
+    @JsonProperty("socket-timeout-millis")
+    protected int socketTimeoutMillis = -1;
     @JsonProperty("always-refresh-token")
     protected boolean alwaysRefreshToken = false;
     @JsonProperty("register-node-at-startup")
@@ -208,6 +215,30 @@ public class OidcJsonConfiguration {
 
     public void setConnectionPoolSize(int connectionPoolSize) {
         this.connectionPoolSize = connectionPoolSize;
+    }
+
+    public int getConnectionTimeoutMillis() {
+        return connectionTimeoutMillis;
+    }
+
+    public void setConnectionTimeoutMillis(int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+    }
+
+    public int getConnectionTtlMillis() {
+        return connectionTtlMillis;
+    }
+
+    public void setConnectionTtlMillis(int connectionTtlMillis) {
+        this.connectionTtlMillis = connectionTtlMillis;
+    }
+
+    public int getSocketTimeoutMillis() {
+        return socketTimeoutMillis;
+    }
+
+    public void setSocketTimeoutMillis(int socketTimeoutMillis) {
+        this.socketTimeoutMillis = socketTimeoutMillis;
     }
 
     public boolean isAlwaysRefreshToken() {

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -148,6 +148,11 @@ public class OidcTest extends OidcBaseTest {
     }
 
     @Test
+    public void testTimeoutConfigurationOptions() throws Exception {
+        OidcClientConfigurationBuilder.build(getOidcConfigurationInputStreamWithTimeoutOptions(5000, 5000, 5000));
+    }
+
+    @Test
     public void testSucessfulAuthenticationWithAuthServerUrl() throws Exception {
         performAuthentication(getOidcConfigurationInputStream(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
@@ -458,6 +463,23 @@ public class OidcTest extends OidcBaseTest {
                 "    \"ssl-required\" : \"EXTERNAL\",\n" +
                 "    \"credentials\" : {\n" +
                 "        \"secret\" : \"" + clientSecret + "\"\n" +
+                "    }\n" +
+                "}";
+        return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream getOidcConfigurationInputStreamWithTimeoutOptions(int connectionTimeoutMillis, int connectionTtlMillis, int socketTimeoutMillis) {
+        String oidcConfig = "{\n" +
+                "    \"realm\" : \"" + TEST_REALM + "\",\n" +
+                "    \"resource\" : \"" + CLIENT_ID + "\",\n" +
+                "    \"public-client\" : \"false\",\n" +
+                "    \"connection-timeout-millis\" : \"" + connectionTimeoutMillis + "\",\n" +
+                "    \"connection-ttl-millis\" : \"" + connectionTtlMillis + "\",\n" +
+                "    \"socket-timeout-millis\" : \"" + socketTimeoutMillis + "\",\n" +
+                "    \"auth-server-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "\",\n" +
+                "    \"ssl-required\" : \"EXTERNAL\",\n" +
+                "    \"credentials\" : {\n" +
+                "        \"secret\" : \"" + CLIENT_SECRET + "\"\n" +
                 "    }\n" +
                 "}";
         return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
socket-timeout-millis to OidcJsonConfiguration to allow oidc.json configuration to parse these attributes

Issue (8.0.x): https://issues.redhat.com/browse/JBEAP-30001
Upstream issue (8.1.x): https://issues.redhat.com/browse/JBEAP-29920
ELY issue: https://issues.redhat.com/browse/ELY-2753
Upstream PR (2.6.x): https://github.com/wildfly-security/wildfly-elytron/pull/2274