### PR TITLE
[ELY-2893] No SocketConfig is set for Connection Manager in HttpClientBuilder which can cause indefinitely hangs

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/HttpClientBuilder.java
@@ -46,6 +46,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
@@ -207,14 +208,20 @@ public class HttpClientBuilder {
             }
 
             org.apache.http.impl.client.HttpClientBuilder clientBuilder = org.apache.http.impl.client.HttpClientBuilder.create();
+            int socketTimeoutMillis = (int) socketTimeoutUnits.toMillis(socketTimeout);
+            if (socketTimeoutMillis > 0) {
+                clientBuilder.setDefaultSocketConfig(SocketConfig.custom()
+                        .setSoTimeout(socketTimeoutMillis)
+                        .build());
+            }
             clientBuilder.setConnectionManager(connectionManager);
 
             RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
             if (proxyHost != null) {
                 requestConfigBuilder.setProxy(proxyHost);
             }
-            if (socketTimeout > -1) {
-                requestConfigBuilder.setSocketTimeout((int) socketTimeoutUnits.toMillis(socketTimeout));
+            if (socketTimeoutMillis > -1) {
+                requestConfigBuilder.setSocketTimeout(socketTimeoutMillis);
             }
             if (establishConnectionTimeout > -1) {
                 requestConfigBuilder.setConnectTimeout((int) establishConnectionTimeoutUnits.toMillis(establishConnectionTimeout));


### PR DESCRIPTION
Issue (8.0.z): https://issues.redhat.com/browse/JBEAP-30011
Upstream issue (8.1.z): https://issues.redhat.com/browse/JBEAP-30010
ELY issue: https://issues.redhat.com/browse/ELY-2893