### PR TITLE
[JBEAP-30165] CVE-2022-3143 wildfly-elytron: possible timing attacks via use of unsafe comparator

### DIFF
--- a/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
+++ b/src/main/java/org/wildfly/security/auth/realm/ldap/X509EvidenceVerifier.java
@@ -36,7 +36,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
@@ -203,7 +202,7 @@ class X509EvidenceVerifier implements EvidenceVerifier {
             final int size = attribute.size();
             try {
                 for (int i = 0; i < size; i++) {
-                    if (Arrays.equals(certificate.getEncoded(), (byte[]) attribute.get(i))) {
+                    if (MessageDigest.isEqual(certificate.getEncoded(), (byte[]) attribute.get(i))) {
                         return true;
                     }
                 }

--- a/src/main/java/org/wildfly/security/credential/AbstractX509CertificateChainCredential.java
+++ b/src/main/java/org/wildfly/security/credential/AbstractX509CertificateChainCredential.java
@@ -21,8 +21,8 @@ package org.wildfly.security.credential;
 import java.security.Provider;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.security.MessageDigest;
 import java.security.spec.AlgorithmParameterSpec;
-import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.wildfly.common.Assert;
@@ -56,7 +56,7 @@ abstract class AbstractX509CertificateChainCredential implements X509Certificate
         if (evidence instanceof X509PeerCertificateChainEvidence) {
             final X509PeerCertificateChainEvidence peerCertificateChainEvidence = (X509PeerCertificateChainEvidence) evidence;
             try {
-                return getAlgorithm().equals(peerCertificateChainEvidence.getAlgorithm()) && Arrays.equals(getFirstCertificate().getEncoded(), peerCertificateChainEvidence.getFirstCertificate().getEncoded());
+                return getAlgorithm().equals(peerCertificateChainEvidence.getAlgorithm()) && MessageDigest.isEqual(getFirstCertificate().getEncoded(), peerCertificateChainEvidence.getFirstCertificate().getEncoded());
             } catch (CertificateEncodingException e) {
             }
         }

--- a/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/DigestPasswordImpl.java
@@ -115,7 +115,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
     boolean verify(char[] guess) throws InvalidKeyException {
         try {
             byte[] guessDigest = userRealmPasswordDigest(getMessageDigest(algorithm), username, realm, guess);
-            return Arrays.equals(digest, guessDigest);
+            return MessageDigest.isEqual(digest, guessDigest);
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyNoSuchMessageDigestAlgorithm(algorithm);
         }
@@ -152,7 +152,7 @@ class DigestPasswordImpl extends AbstractPasswordImpl implements DigestPassword 
             return false;
         }
         DigestPasswordImpl other = (DigestPasswordImpl) obj;
-        return Arrays.equals(digest, other.digest) && username.equals(other.username) && realm.equals(other.realm) && algorithm.equals(other.algorithm);
+        return MessageDigest.isEqual(digest, other.digest) && username.equals(other.username) && realm.equals(other.realm) && algorithm.equals(other.algorithm);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/MaskedPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/MaskedPasswordImpl.java
@@ -25,6 +25,7 @@ import java.io.ObjectInputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.util.Arrays;
@@ -206,7 +207,7 @@ final class MaskedPasswordImpl extends AbstractPasswordImpl implements MaskedPas
             return false;
         }
         MaskedPasswordImpl other = (MaskedPasswordImpl) obj;
-        return iterationCount == other.iterationCount && Arrays.equals(initialKeyMaterial, other.initialKeyMaterial) && Arrays.equals(salt, other.salt) && Arrays.equals(maskedPasswordBytes, other.maskedPasswordBytes) && algorithm.equals(other.algorithm);
+        return iterationCount == other.iterationCount && Arrays.equals(initialKeyMaterial, other.initialKeyMaterial) && MessageDigest.isEqual(salt, other.salt) && MessageDigest.isEqual(maskedPasswordBytes, other.maskedPasswordBytes) && algorithm.equals(other.algorithm);
     }
 
     Object writeReplace() {

--- a/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SaltedSimpleDigestPasswordImpl.java
@@ -119,7 +119,7 @@ class SaltedSimpleDigestPasswordImpl extends AbstractPasswordImpl implements Sal
     @Override
     boolean verify(char[] guess) throws InvalidKeyException {
         try {
-            return Arrays.equals(digest, digestOf(algorithm, salt, guess));
+            return MessageDigest.isEqual(digest, digestOf(algorithm, salt, guess));
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyNoSuchMessageDigestAlgorithm(algorithm);
         }
@@ -195,7 +195,7 @@ class SaltedSimpleDigestPasswordImpl extends AbstractPasswordImpl implements Sal
             return false;
         }
         SaltedSimpleDigestPasswordImpl other = (SaltedSimpleDigestPasswordImpl) obj;
-        return algorithm.equals(other.algorithm) && Arrays.equals(digest, other.digest) && Arrays.equals(salt, other.salt);
+        return algorithm.equals(other.algorithm) && MessageDigest.isEqual(digest, other.digest) && MessageDigest.isEqual(salt, other.salt);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/ScramDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/ScramDigestPasswordImpl.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
@@ -193,7 +194,7 @@ class ScramDigestPasswordImpl extends AbstractPasswordImpl implements ScramDiges
     boolean verify(char[] guess) throws InvalidKeyException {
         try {
             byte[] output = scramDigest(this.getAlgorithm(), getNormalizedPasswordBytes(guess), this.getSalt(), this.getIterationCount());
-            return Arrays.equals(this.digest, output);
+            return MessageDigest.isEqual(this.digest, output);
         } catch (NoSuchAlgorithmException nsae) {
             throw new InvalidKeyException(nsae);
         }
@@ -308,7 +309,7 @@ class ScramDigestPasswordImpl extends AbstractPasswordImpl implements ScramDiges
             return false;
         }
         ScramDigestPasswordImpl other = (ScramDigestPasswordImpl) obj;
-        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && Arrays.equals(digest, other.digest) && Arrays.equals(salt, other.salt);
+        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && MessageDigest.isEqual(digest, other.digest) && MessageDigest.isEqual(salt, other.salt);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/SimpleDigestPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SimpleDigestPasswordImpl.java
@@ -101,7 +101,7 @@ class SimpleDigestPasswordImpl extends AbstractPasswordImpl implements SimpleDig
 
     boolean verify(final char[] guess) throws InvalidKeyException {
         try {
-            return Arrays.equals(digest, getDigestOf(algorithm, guess));
+            return MessageDigest.isEqual(digest, getDigestOf(algorithm, guess));
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyNoSuchMessageDigestAlgorithm(algorithm);
         }
@@ -128,7 +128,7 @@ class SimpleDigestPasswordImpl extends AbstractPasswordImpl implements SimpleDig
             return false;
         }
         SimpleDigestPasswordImpl other = (SimpleDigestPasswordImpl) obj;
-        return algorithm.equals(other.algorithm) && Arrays.equals(digest, other.digest);
+        return algorithm.equals(other.algorithm) && MessageDigest.isEqual(digest, other.digest);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/SunUnixMD5CryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/SunUnixMD5CryptPasswordImpl.java
@@ -187,7 +187,7 @@ final class SunUnixMD5CryptPasswordImpl extends AbstractPasswordImpl implements 
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyCannotVerifyPassword(e);
         }
-        return Arrays.equals(getHash(), test);
+        return MessageDigest.isEqual(getHash(), test);
     }
 
     @Override
@@ -292,7 +292,7 @@ final class SunUnixMD5CryptPasswordImpl extends AbstractPasswordImpl implements 
             return false;
         }
         SunUnixMD5CryptPasswordImpl other = (SunUnixMD5CryptPasswordImpl) obj;
-        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && Arrays.equals(hash, other.hash) && Arrays.equals(salt, other.salt);
+        return iterationCount == other.iterationCount && algorithm.equals(other.algorithm) && MessageDigest.isEqual(hash, other.hash) && MessageDigest.isEqual(salt, other.salt);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixMD5CryptPasswordImpl.java
@@ -123,7 +123,7 @@ final class UnixMD5CryptPasswordImpl extends AbstractPasswordImpl implements Uni
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyCannotVerifyPassword(e);
         }
-        return Arrays.equals(getHash(), test);
+        return MessageDigest.isEqual(getHash(), test);
     }
 
     @Override
@@ -239,7 +239,7 @@ final class UnixMD5CryptPasswordImpl extends AbstractPasswordImpl implements Uni
             return false;
         }
         UnixMD5CryptPasswordImpl other = (UnixMD5CryptPasswordImpl) obj;
-        return Arrays.equals(hash, other.hash) && Arrays.equals(salt, other.salt);
+        return MessageDigest.isEqual(hash, other.hash) && MessageDigest.isEqual(salt, other.salt);
     }
 
     private void readObject(ObjectInputStream ignored) throws NotSerializableException {

--- a/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
+++ b/src/main/java/org/wildfly/security/password/impl/UnixSHACryptPasswordImpl.java
@@ -146,7 +146,7 @@ final class UnixSHACryptPasswordImpl extends AbstractPasswordImpl implements Uni
         try {
             byte[] password = getNormalizedPasswordBytes(guess);
             byte[] encodedGuess = doEncode(algorithm, password, salt, iterationCount);
-            return Arrays.equals(getHash(), encodedGuess);
+            return MessageDigest.isEqual(getHash(), encodedGuess);
         } catch (NoSuchAlgorithmException e) {
             throw log.invalidKeyCannotVerifyPassword(e);
         }

--- a/src/main/java/org/wildfly/security/password/interfaces/RawDigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/RawDigestPassword.java
@@ -20,6 +20,7 @@ package org.wildfly.security.password.interfaces;
 
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 class RawDigestPassword extends RawPassword implements DigestPassword {
@@ -62,6 +63,6 @@ class RawDigestPassword extends RawPassword implements DigestPassword {
             return false;
         }
         RawDigestPassword other = (RawDigestPassword) obj;
-        return Arrays.equals(digest, other.digest) && username.equals(other.username) && realm.equals(other.realm) && getAlgorithm().equals(other.getAlgorithm());
+        return MessageDigest.isEqual(digest, other.digest) && username.equals(other.username) && realm.equals(other.realm) && getAlgorithm().equals(other.getAlgorithm());
     }
 }

--- a/src/main/java/org/wildfly/security/password/interfaces/RawSaltedSimpleDigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/RawSaltedSimpleDigestPassword.java
@@ -20,6 +20,7 @@ package org.wildfly.security.password.interfaces;
 
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 class RawSaltedSimpleDigestPassword extends RawPassword implements SaltedSimpleDigestPassword {
@@ -56,6 +57,7 @@ class RawSaltedSimpleDigestPassword extends RawPassword implements SaltedSimpleD
             return false;
         }
         RawSaltedSimpleDigestPassword other = (RawSaltedSimpleDigestPassword) obj;
-        return getAlgorithm().equals(other.getAlgorithm()) && Arrays.equals(digest, other.digest) && Arrays.equals(salt, other.salt);
+        return getAlgorithm().equals(other.getAlgorithm()) && MessageDigest.isEqual(digest, other.digest)
+                && MessageDigest.isEqual(salt, other.salt);
     }
 }

--- a/src/main/java/org/wildfly/security/password/interfaces/RawScramDigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/RawScramDigestPassword.java
@@ -20,6 +20,7 @@ package org.wildfly.security.password.interfaces;
 
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 class RawScramDigestPassword extends RawPassword implements ScramDigestPassword {
@@ -62,6 +63,7 @@ class RawScramDigestPassword extends RawPassword implements ScramDigestPassword 
             return false;
         }
         RawScramDigestPassword other = (RawScramDigestPassword) obj;
-        return iterationCount == other.iterationCount && getAlgorithm().equals(other.getAlgorithm()) && Arrays.equals(digest, other.digest) && Arrays.equals(salt, other.salt);
+        return iterationCount == other.iterationCount && getAlgorithm().equals(other.getAlgorithm())
+                && MessageDigest.isEqual(digest, other.digest) && MessageDigest.isEqual(salt, other.salt);
     }
 }

--- a/src/main/java/org/wildfly/security/password/interfaces/RawSimpleDigestPassword.java
+++ b/src/main/java/org/wildfly/security/password/interfaces/RawSimpleDigestPassword.java
@@ -20,6 +20,7 @@ package org.wildfly.security.password.interfaces;
 
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 class RawSimpleDigestPassword extends RawPassword implements SimpleDigestPassword {
@@ -50,6 +51,6 @@ class RawSimpleDigestPassword extends RawPassword implements SimpleDigestPasswor
             return false;
         }
         RawSimpleDigestPassword other = (RawSimpleDigestPassword) obj;
-        return getAlgorithm().equals(other.getAlgorithm()) && Arrays.equals(digest, other.digest);
+        return getAlgorithm().equals(other.getAlgorithm()) && MessageDigest.isEqual(digest, other.digest);
     }
 }

--- a/src/main/java/org/wildfly/security/x500/GeneralName.java
+++ b/src/main/java/org/wildfly/security/x500/GeneralName.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.MessageDigest;
 import java.util.Arrays;
 
 import javax.security.auth.x500.X500Principal;
@@ -191,7 +192,7 @@ public abstract class GeneralName implements ASN1Encodable {
         }
 
         public boolean equals(final OtherName other) {
-            return other != null && Arrays.equals(encodedName, other.getName());
+            return other != null && MessageDigest.isEqual(encodedName, other.getName());
         }
 
         public int hashCode() {
@@ -355,7 +356,7 @@ public abstract class GeneralName implements ASN1Encodable {
         }
 
         public boolean equals(final X400Address other) {
-            return other != null && Arrays.equals(encodedName, other.getName());
+            return other != null && MessageDigest.isEqual(encodedName, other.getName());
         }
 
         public int hashCode() {
@@ -475,7 +476,7 @@ public abstract class GeneralName implements ASN1Encodable {
         }
 
         public boolean equals(final EDIPartyName other) {
-            return other != null && Arrays.equals(encodedName, other.getName());
+            return other != null && MessageDigest.isEqual(encodedName, other.getName());
         }
 
         public int hashCode() {
@@ -600,7 +601,7 @@ public abstract class GeneralName implements ASN1Encodable {
                     }
                     return true;
                 } else {
-                    return Arrays.equals(address, other.getName());
+                    return MessageDigest.isEqual(address, other.getName());
                 }
             }
             return false;


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-30165
Upstream issue: https://issues.redhat.com/browse/ELY-2418

Included upstream issues and PRs:
https://issues.redhat.com/browse/ELY-2419 #1776
https://issues.redhat.com/browse/ELY-2420 #1779
https://issues.redhat.com/browse/ELY-2421 #1786
https://issues.redhat.com/browse/ELY-2422 #1786
https://issues.redhat.com/browse/ELY-2423 #1786
https://issues.redhat.com/browse/ELY-2424 #1786
https://issues.redhat.com/browse/ELY-2431 #1786
https://issues.redhat.com/browse/ELY-2425 #1778
https://issues.redhat.com/browse/ELY-2426 #1778
https://issues.redhat.com/browse/ELY-2427 #1778
https://issues.redhat.com/browse/ELY-2428 #1778
https://issues.redhat.com/browse/ELY-2429 #1778
https://issues.redhat.com/browse/ELY-2430 #1778
https://issues.redhat.com/browse/ELY-2432 #1775
https://issues.redhat.com/browse/ELY-2433 #1775
https://issues.redhat.com/browse/ELY-2434 #1775
https://issues.redhat.com/browse/ELY-2435 #1775
https://issues.redhat.com/browse/ELY-2436 #1765
https://issues.redhat.com/browse/ELY-2437 #1770
https://issues.redhat.com/browse/ELY-2438 #1773