### PR TITLE
[ELY-2900] Cookie fallback in BearerTokenAuthenticationMechanism

### DIFF
--- a/http/bearer/pom.xml
+++ b/http/bearer/pom.xml
@@ -73,6 +73,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerMechanismFactory.java
+++ b/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerMechanismFactory.java
@@ -19,10 +19,12 @@
 package org.wildfly.security.http.bearer;
 
 import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security.http.HttpConstants.AUTHORIZATION;
 import static org.wildfly.security.http.HttpConstants.BEARER_TOKEN;
 
 import java.security.Provider;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.security.auth.callback.CallbackHandler;
 
@@ -68,7 +70,11 @@ public class BearerMechanismFactory implements HttpServerAuthenticationMechanism
         checkNotNullParam("callbackHandler", callbackHandler);
 
         if (BEARER_TOKEN.equals(mechanismName)) {
-            return new BearerTokenAuthenticationMechanism(callbackHandler);
+            // Extract enableCookieFallback from properties
+            boolean enableCookieFallback = Boolean.parseBoolean((String) properties.get("enableCookieFallback"));
+            // Extract cookie-name (Default: "Authorization")
+            String tokenCookieName = Optional.ofNullable(properties.get("token-cookie-name")).map(Object::toString).orElse(AUTHORIZATION);
+            return new BearerTokenAuthenticationMechanism(callbackHandler, enableCookieFallback, tokenCookieName);
         }
 
         return null;

--- a/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanism.java
+++ b/http/bearer/src/main/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanism.java
@@ -26,6 +26,7 @@ import static org.wildfly.security.http.HttpConstants.WWW_AUTHENTICATE;
 import static org.wildfly.security.mechanism._private.ElytronMessages.httpBearer;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,6 +45,7 @@ import org.wildfly.security.evidence.BearerTokenEvidence;
 import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpConstants;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
+import org.wildfly.security.http.HttpServerCookie;
 import org.wildfly.security.http.HttpServerRequest;
 import org.wildfly.security.http.HttpServerResponse;
 import org.wildfly.security.mechanism._private.MechanismUtil;
@@ -68,9 +70,13 @@ final class BearerTokenAuthenticationMechanism implements HttpServerAuthenticati
     private static final Pattern BEARER_TOKEN_PATTERN = Pattern.compile("^Bearer *([^ ]+) *$", Pattern.CASE_INSENSITIVE);
 
     private final CallbackHandler callbackHandler;
+    private final boolean enableCookieFallback;
+    private final String tokenCookie;
 
-    BearerTokenAuthenticationMechanism(CallbackHandler callbackHandler) {
+    BearerTokenAuthenticationMechanism(CallbackHandler callbackHandler, boolean enableCookieFallback, String tokenCookie) {
         this.callbackHandler = callbackHandler;
+        this.enableCookieFallback = enableCookieFallback;
+        this.tokenCookie = tokenCookie;
     }
 
     @Override
@@ -81,6 +87,19 @@ final class BearerTokenAuthenticationMechanism implements HttpServerAuthenticati
     @Override
     public void evaluateRequest(HttpServerRequest request) throws HttpAuthenticationException {
         List<String> authorizationValues = request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+
+        // Fallback: read token from cookies, if no authorization-header present
+        if (enableCookieFallback && (authorizationValues == null || authorizationValues.isEmpty())) {
+            List<HttpServerCookie> cookies = request.getCookies(); // Cookie handling
+            if (cookies != null) {
+                for (HttpServerCookie cookie : cookies) {
+                    if (tokenCookie.equals(cookie.getName())) {
+                        authorizationValues = Collections.singletonList("Bearer " + cookie.getValue());
+                        break;
+                    }
+                }
+            }
+        }
 
         if (authorizationValues != null) {
             Matcher matcher;

--- a/http/bearer/src/test/java/org/wildfly/security/http/bearer/BearerMechanismFactoryTest.java
+++ b/http/bearer/src/test/java/org/wildfly/security/http/bearer/BearerMechanismFactoryTest.java
@@ -25,7 +25,9 @@ import org.wildfly.security.http.HttpAuthenticationException;
 import org.wildfly.security.http.HttpServerAuthenticationMechanism;
 
 import javax.security.auth.callback.CallbackHandler;
+import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.wildfly.security.http.HttpConstants.BASIC_NAME;
 import static org.wildfly.security.http.HttpConstants.BEARER_TOKEN;
@@ -122,6 +124,78 @@ public class BearerMechanismFactoryTest {
     public void testCreateValidBearerAuthenticationMechanism() throws HttpAuthenticationException{
         HttpServerAuthenticationMechanism httpServerAuthenticationMechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, emptyProperties, dummyCallbackHandler);
         Assert.assertNotNull("HttpServerAuthenticationMechanism cannot be null.",httpServerAuthenticationMechanism);
+    }
+
+    /**
+     * Tests default enableCookieFallback when not provided.
+     */
+    @Test
+    public void testDefaultCookieFallback() throws HttpAuthenticationException, NoSuchFieldException, IllegalAccessException {
+        HttpServerAuthenticationMechanism mechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, emptyProperties, dummyCallbackHandler);
+        Assert.assertNotNull(mechanism);
+        // Use reflection to verify internal value
+        Field enableCookieFallbackField = mechanism.getClass().getDeclaredField("enableCookieFallback");
+        enableCookieFallbackField.setAccessible(true);
+        Boolean enableCookieFallback = (boolean) enableCookieFallbackField.get(mechanism);
+        Assert.assertEquals(false, enableCookieFallback);
+    }
+
+    /**
+     * Tests that the mechanism is created with cookie fallback enabled when property is set to true.
+     * Verifies behavior indirectly through authentication process.
+     */
+    @Test
+    public void testCreateMechanismWithCookieFallbackEnabled() throws HttpAuthenticationException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("enableCookieFallback", "true");
+        HttpServerAuthenticationMechanism mechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, properties, dummyCallbackHandler);
+        Assert.assertNotNull(mechanism);
+        Assert.assertEquals(BEARER_TOKEN, mechanism.getMechanismName());
+    }
+
+    /**
+     * Tests that the mechanism is created with cookie fallback enabled when property is set to false.
+     * Verifies behavior indirectly through authentication process.
+     */
+    @Test
+    public void testCreateMechanismWithCookieFallbackDisabled() throws HttpAuthenticationException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("enableCookieFallback", "false");
+        HttpServerAuthenticationMechanism mechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, properties, dummyCallbackHandler);
+        Assert.assertNotNull(mechanism);
+        Assert.assertEquals(BEARER_TOKEN, mechanism.getMechanismName());
+    }
+
+    /**
+     * Tests default cookie name when not provided.
+     */
+    @Test
+    public void testDefaultCookieName() throws HttpAuthenticationException, NoSuchFieldException, IllegalAccessException {
+        HttpServerAuthenticationMechanism mechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, emptyProperties, dummyCallbackHandler);
+        Assert.assertNotNull(mechanism);
+        // Use reflection to verify internal value
+        Field tokenCookieField = mechanism.getClass().getDeclaredField("tokenCookie");
+        tokenCookieField.setAccessible(true);
+        String tokenCookie = (String) tokenCookieField.get(mechanism);
+        Assert.assertEquals("Authorization", tokenCookie);
+    }
+
+    /**
+     * Tests custom cookie name extraction and that the mechanism uses custom cookie name when provided.
+     * Verifies through authentication behavior.
+     */
+    @Test
+    public void testCustomCookieNameExtraction() throws HttpAuthenticationException, NoSuchFieldException, IllegalAccessException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("token-cookie-name", "CUSTOM_AUTH");
+        HttpServerAuthenticationMechanism mechanism = bearerMechanismFactory.createAuthenticationMechanism(BEARER_TOKEN, properties, dummyCallbackHandler);
+        Assert.assertNotNull(mechanism);
+        // Use reflection to verify internal value
+        Field tokenCookieField = mechanism.getClass().getDeclaredField("tokenCookie");
+        tokenCookieField.setAccessible(true);
+        String tokenCookie = (String) tokenCookieField.get(mechanism);
+        Assert.assertEquals("CUSTOM_AUTH", tokenCookie);
+        Assert.assertEquals(BEARER_TOKEN, mechanism.getMechanismName());
     }
 
 }

--- a/http/bearer/src/test/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanismTest.java
+++ b/http/bearer/src/test/java/org/wildfly/security/http/bearer/BearerTokenAuthenticationMechanismTest.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.http.bearer;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.security.auth.callback.EvidenceVerifyCallback;
+import org.wildfly.security.http.HttpConstants;
+import org.wildfly.security.http.HttpServerCookie;
+import org.wildfly.security.http.HttpServerRequest;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.AuthorizeCallback;
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Test class for BearerTokenAuthenticationMechanism.
+ */
+public class BearerTokenAuthenticationMechanismTest {
+    private CallbackHandler callbackHandler;
+    private BearerTokenAuthenticationMechanism mechanism;
+
+    @Mocked
+    private HttpServerRequest request;
+
+    @Before
+    public void setUp() {
+        // Prepare a callback handler that always verifies evidence and authorizes
+        callbackHandler = callbacks -> {
+            for (Callback callback : callbacks) {
+                if (callback instanceof EvidenceVerifyCallback) {
+                    ((EvidenceVerifyCallback) callback).setVerified(true);
+                }
+                if (callback instanceof AuthorizeCallback) {
+                    ((AuthorizeCallback) callback).setAuthorized(true); // Always allow authorization
+                }
+            }
+        };
+    }
+
+    /**
+     * Test successful token extraction from cookie when fallback is enabled.
+     */
+    @Test
+    public void testTokenExtractionFromCookie() throws Exception {
+        mechanism = new BearerTokenAuthenticationMechanism(callbackHandler, true, "AUTH_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = null; // No Authorization header
+
+            request.getCookies();
+            result = Collections.singletonList(new SimpleHttpServerCookie("AUTH_TOKEN", "test_token"));
+
+            // Expect successful authentication
+            request.authenticationComplete();
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    /**
+     * Test that cookie fallback is not used when disabled.
+     */
+    @Test
+    public void testCookieFallbackDisabled() throws Exception {
+        mechanism = new BearerTokenAuthenticationMechanism(callbackHandler, false, "AUTH_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = null; // No Authorization header
+
+            // Should not query cookies
+            request.getCookies(); times = 0;
+
+            // Expect no authentication in progress
+            request.noAuthenticationInProgress(withNotNull());
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    /**
+     * Test prioritization of Authorization header over cookie.
+     */
+    @Test
+    public void testHeaderPriorityOverCookie() throws Exception {
+        mechanism = new BearerTokenAuthenticationMechanism(callbackHandler, true, "AUTH_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = Collections.singletonList("Bearer header_token");
+
+            // Should not query cookies
+            request.getCookies(); times = 0;
+
+            // Expect successful authentication
+            request.authenticationComplete();
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    /**
+     * Test custom cookie name handling.
+     */
+    @Test
+    public void testCustomCookieNameHandling() throws Exception {
+        mechanism = new BearerTokenAuthenticationMechanism(callbackHandler, true, "CUSTOM_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = null; // No header
+
+            request.getCookies();
+            result = Arrays.asList(
+                    new SimpleHttpServerCookie("WRONG_COOKIE", "wrong_token"),
+                    new SimpleHttpServerCookie("CUSTOM_TOKEN", "correct_token")
+            );
+
+            // Expect successful authentication
+            request.authenticationComplete();
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    /**
+     * Test missing token in both header and cookie.
+     */
+    @Test
+    public void testMissingToken() throws Exception {
+        mechanism = new BearerTokenAuthenticationMechanism(callbackHandler, true, "AUTH_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = null; // No header
+
+            request.getCookies();
+            result = Collections.emptyList(); // No relevant cookies
+
+            // Expect no authentication in progress
+            request.noAuthenticationInProgress(withNotNull());
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    /**
+     * Test token verification failure.
+     */
+    @Test
+    public void testTokenVerificationFailed() throws Exception {
+        // Special callback handler for failed verification
+        CallbackHandler failingHandler = callbacks -> {
+            for (Callback callback : callbacks) {
+                if (callback instanceof EvidenceVerifyCallback) {
+                    ((EvidenceVerifyCallback) callback).setVerified(false);
+                }
+            }
+        };
+
+        mechanism = new BearerTokenAuthenticationMechanism(failingHandler, true, "AUTH_TOKEN");
+
+        new Expectations() {{
+            request.getRequestHeaderValues(HttpConstants.AUTHORIZATION);
+            result = Collections.singletonList("Bearer invalid_token");
+
+            // Expect authentication failure
+            request.authenticationFailed(anyString, withNotNull());
+        }};
+
+        mechanism.evaluateRequest(request);
+    }
+
+    // Helper class for cookie mocking
+    private static class SimpleHttpServerCookie implements HttpServerCookie {
+        private final String name;
+        private final String value;
+
+        SimpleHttpServerCookie(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override public String getName() {
+            return name;
+        }
+        @Override public String getValue() {
+            return value;
+        }
+        @Override public String getDomain() {
+            return null;
+        }
+        @Override public String getPath() {
+            return null;
+        }
+        @Override public int getMaxAge() {
+            return 0;
+        }
+        @Override public boolean isSecure() {
+            return false;
+        }
+        @Override public int getVersion() {
+            return 0;
+        }
+        @Override public boolean isHttpOnly() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
I opened [ELY-2900](https://issues.redhat.com/browse/ELY-2900) to accomplish a cookie fallback in BearerTokenAuthenticationMechanism.

There are 2 related issues to this:

[ELY-2884](https://issues.redhat.com/browse/ELY-2884)
[ELY-2885](https://issues.redhat.com/browse/ELY-2885)