### PR TITLE
[ELY-2916] Fix NPE that occurs under heavy request load.

### DIFF
--- a/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
+++ b/http/form/src/main/java/org/wildfly/security/http/form/FormAuthenticationMechanism.java
@@ -103,7 +103,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
     @Override
     public void evaluateRequest(final HttpServerRequest request) throws HttpAuthenticationException {
         // Is current request an authentication attempt?
-        if (POST.equals(request.getRequestMethod()) && isAuthenticationRequest(request.getRequestURI().getPath())) {
+        if (POST.equals(request.getRequestMethod()) && request.getRequestURI() != null && isAuthenticationRequest(request.getRequestURI().getPath())) {
             attemptAuthentication(request);
             return;
         }
@@ -327,7 +327,7 @@ final class FormAuthenticationMechanism extends UsernamePasswordAuthenticationMe
         // Save the current request.
         URI requestURI = request.getRequestURI();
         HttpScope session = getSessionScope(request, true);
-        if (session != null && session.supportsAttachments()) {
+        if (session != null && session.supportsAttachments() && requestURI != null) {
             StringBuilder sb = new StringBuilder();
             String scheme = requestURI.getScheme();
             sb.append(scheme);


### PR DESCRIPTION
[ELY-2916](https://issues.redhat.com/browse/ELY-2916)

It happened under heavy request load from the Invicti Scanner.
When sending the same request manually, this error cannot be reproduced.

Environment: Amazon Corretto 17, Apache HTTP, WildFly 26.1.3.Final (standalone), deployed on Amazon Linux 2023.

To fix the issue, we modified the source code, rebuilt the wildfly-elytron-http-form-1.19.1.Final.jar library, and replaced it in the WildFly module directory: /modules/system/layers/base/org/wildfly/security/elytron-base/main.
After this change, the NPEs no longer occurred.

This part of the code remains the same in all versions higher than 1.19, but we have not tested it on WildFly versions newer than 26.1.3.Final.

Logs:
1. 
ERROR [io.undertow.request] (default task-839) UT005023: Exception handling request to somePath: java.lang.NullPointerException: Cannot invoke "java.net.URI.getPath()" because the return value of "org.wildfly.security.http.HttpServerRequest.getRequestURI()" is null
at org.wildfly.security.elytron-base//org.wildfly.security.http.form.FormAuthenticationMechanism.evaluateRequest(FormAuthenticationMechanism.java:106)

2. 
ERROR [io.undertow.request] (default task-3) UT005023: Exception handling request to somePath java.lang.NullPointerException: Cannot invoke "java.net.URI.getScheme()" because "requestURI" is null
at org.wildfly.security.elytron-base//org.wildfly.security.http.form.FormAuthenticationMechanism.sendLogin(FormAuthenticationMechanism.java:334)
