### PR TITLE
[ELY-2917] Add synchronization to the Entry get(String key) method.

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/authz/Attributes.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/authz/Attributes.java
@@ -654,7 +654,7 @@ public interface Attributes {
             }
 
             @Override
-            public Entry get(String key) {
+            public synchronized Entry get(String key) {
                 return this.entryCache.computeIfAbsent(key, s -> new SimpleAttributesEntry(this, s));
             }
         };


### PR DESCRIPTION
This is the only method that reads and updates the entryCache HashMap.

https://issues.redhat.com/browse/ELY-2917