### PR TITLE
[2.6.x] [ELY-2925] NullPointerException where JWK uses key_ops instead of use

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/JWKEncPublicKeyLocator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/JWKEncPublicKeyLocator.java
@@ -21,6 +21,8 @@ package org.wildfly.security.http.oidc;
 import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.wildfly.security.http.oidc.ElytronMessages.log;
 import static org.wildfly.security.http.oidc.Oidc.JSON_CONTENT_TYPE;
+import static org.wildfly.security.jose.jwk.JsonWebKeySetUtil.FOR_ENCRYPTION;
+import static org.wildfly.security.jose.jwk.JsonWebKeySetUtil.getKeys;
 
 import java.security.PublicKey;
 import java.util.ArrayList;
@@ -28,9 +30,7 @@ import java.util.Map;
 import java.util.List;
 
 import org.apache.http.client.methods.HttpGet;
-import org.wildfly.security.jose.jwk.JWK;
 import org.wildfly.security.jose.jwk.JsonWebKeySet;
-import org.wildfly.security.jose.jwk.JsonWebKeySetUtil;
 
 /**
  * A public key locator that dynamically obtains the public key used for encryption
@@ -97,7 +97,7 @@ class JWKEncPublicKeyLocator implements PublicKeyLocator {
         request.addHeader(ACCEPT, JSON_CONTENT_TYPE);
         try {
             JsonWebKeySet jwks = Oidc.sendJsonHttpRequest(config, request, JsonWebKeySet.class);
-            Map<String, PublicKey> publicKeys = JsonWebKeySetUtil.getKeysForUse(jwks, JWK.Use.ENC);
+            Map<String, PublicKey> publicKeys = getKeys(jwks, FOR_ENCRYPTION);
 
             if (log.isDebugEnabled()) {
                 log.debug("Public keys successfully retrieved for client " +  config.getResourceName() + ". New kids: " + publicKeys.keySet());

--- a/jose/jwk/pom.xml
+++ b/jose/jwk/pom.xml
@@ -93,7 +93,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
+            <groupId>org.eclipse.parsson</groupId>
             <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2925

There are some differences to the 2.6.x branch so this includes the PR https://github.com/wildfly-security/wildfly-elytron/pull/2298 and adds the additional changes.