### PR TITLE
[ELY-2856] Added a test to fail the authentication in AggregateRealmTest

### DIFF
--- a/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmTest.java
+++ b/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/AggregateRealmTest.java
@@ -67,6 +67,20 @@ public class AggregateRealmTest {
     }
 
     @Test
+    public void testAuthenticationFails() throws Exception {
+        Attributes authenticationAttributes = new MapAttributes();
+        authenticationAttributes.add("team", 0, "One");
+
+        SecurityRealm testRealm = createSecurityRealm(false, authenticationAttributes, null, new Attributes[] { null });
+        RealmIdentity identity = testRealm.getRealmIdentity(new NamePrincipal("invalid_principal"));
+
+        assertFalse("Identity should not exist", identity.exists());
+
+        Attributes identityAttributes = identity.getAuthorizationIdentity().getAttributes();
+        assertEquals("Expected no attributes due to authentication failure.", 0, identityAttributes.size());
+    }
+
+    @Test
     public void testAuthorizationOnly() throws Exception {
         Attributes authorizationAttributes = new MapAttributes();
         authorizationAttributes.add("team", 0, "One");


### PR DESCRIPTION
Supercedes: https://github.com/wildfly-security/wildfly-elytron/pull/2244

https://issues.redhat.com/browse/ELY-2856