### PR TITLE
[ELY-2832][ELY-2833][ELY-2834][ELY-2835] Replacing wildcard imports with explicit declarations

### DIFF
--- a/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
+++ b/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
@@ -38,6 +38,7 @@ import static org.wildfly.security.asn1.ASN1.SET_TYPE;
 import static org.wildfly.security.asn1.ASN1.TAG_NUMBER_MASK;
 import static org.wildfly.security.asn1.ASN1.UNIVERSAL_STRING_TYPE;
 import static org.wildfly.security.asn1.ASN1.UTF8_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.validatePrintableByte;
 
 import java.math.BigInteger;
 import java.nio.charset.Charset;

--- a/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
+++ b/asn1/src/main/java/org/wildfly/security/asn1/DEREncoder.java
@@ -19,7 +19,25 @@
 package org.wildfly.security.asn1;
 
 import static org.wildfly.security.asn1.ElytronMessages.log;
-import static org.wildfly.security.asn1.ASN1.*;
+
+import static org.wildfly.security.asn1.ASN1.BIT_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.BMP_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.BOOLEAN_TYPE;
+import static org.wildfly.security.asn1.ASN1.CLASS_MASK;
+import static org.wildfly.security.asn1.ASN1.CONSTRUCTED_MASK;
+import static org.wildfly.security.asn1.ASN1.CONTEXT_SPECIFIC_MASK;
+import static org.wildfly.security.asn1.ASN1.GENERALIZED_TIME_TYPE;
+import static org.wildfly.security.asn1.ASN1.IA5_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.INTEGER_TYPE;
+import static org.wildfly.security.asn1.ASN1.NULL_TYPE;
+import static org.wildfly.security.asn1.ASN1.OBJECT_IDENTIFIER_TYPE;
+import static org.wildfly.security.asn1.ASN1.OCTET_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.PRINTABLE_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.SEQUENCE_TYPE;
+import static org.wildfly.security.asn1.ASN1.SET_TYPE;
+import static org.wildfly.security.asn1.ASN1.TAG_NUMBER_MASK;
+import static org.wildfly.security.asn1.ASN1.UNIVERSAL_STRING_TYPE;
+import static org.wildfly.security.asn1.ASN1.UTF8_STRING_TYPE;
 
 import java.math.BigInteger;
 import java.nio.charset.Charset;

--- a/auth/server/base/src/main/java/org/wildfly/security/ssl/SSLConnection.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/ssl/SSLConnection.java
@@ -18,7 +18,8 @@
 
 package org.wildfly.security.ssl;
 
-import static org.wildfly.security.ssl.TLSServerEndPointChannelBinding.*;
+import static org.wildfly.security.ssl.TLSServerEndPointChannelBinding.TLS_SERVER_ENDPOINT;
+import static org.wildfly.security.ssl.TLSServerEndPointChannelBinding.getChannelBindingData;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;

--- a/jose/jwk/src/main/java/org/wildfly/security/jose/jwk/RSAPublicJWK.java
+++ b/jose/jwk/src/main/java/org/wildfly/security/jose/jwk/RSAPublicJWK.java
@@ -21,9 +21,9 @@ package org.wildfly.security.jose.jwk;
 import static org.wildfly.security.jose.jwk.ElytronMessages.log;
 import static org.wildfly.security.jose.jwk.JWKUtil.generateThumbprint;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.security.NoSuchAlgorithmException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>

--- a/jose/util/src/main/java/org/wildfly/security/jose/util/JsonSerialization.java
+++ b/jose/util/src/main/java/org/wildfly/security/jose/util/JsonSerialization.java
@@ -20,6 +20,10 @@ package org.wildfly.security.jose.util;
 
 import static org.wildfly.security.jose.util._private.ElytronMessages.log;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -27,10 +31,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 /**
  * Utility class to handle simple JSON serialization for OpenID Connect.

--- a/keystore/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
+++ b/keystore/src/main/java/org/wildfly/security/keystore/LdapKeyStore.java
@@ -18,17 +18,18 @@
 
 package org.wildfly.security.keystore;
 
-import org.wildfly.common.Assert;
-import org.wildfly.common.function.ExceptionSupplier;
+import java.security.KeyStore;
+import java.security.KeyStoreSpi;
+import java.security.Provider;
 
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.ldap.LdapName;
-import java.security.KeyStore;
-import java.security.KeyStoreSpi;
-import java.security.Provider;
+
+import org.wildfly.common.Assert;
+import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * A LDAP backed {@link KeyStore} implementation.

--- a/keystore/src/main/java/org/wildfly/security/keystore/LdapKeyStoreSpi.java
+++ b/keystore/src/main/java/org/wildfly/security/keystore/LdapKeyStoreSpi.java
@@ -20,20 +20,6 @@ package org.wildfly.security.keystore;
 
 import static org.wildfly.security.keystore.ElytronMessages.log;
 
-import org.wildfly.common.function.ExceptionSupplier;
-import org.wildfly.security.util.LdapUtil;
-
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-import javax.naming.directory.BasicAttribute;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.ModificationItem;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
-import javax.naming.ldap.LdapName;
-import javax.naming.ldap.Rdn;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -58,6 +44,22 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.BasicAttribute;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.ModificationItem;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+
+
+import org.wildfly.common.function.ExceptionSupplier;
+import org.wildfly.security.util.LdapUtil;
 
 /**
  * A LDAP backed {@link KeyStore} implementation.

--- a/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
+++ b/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
@@ -18,15 +18,13 @@
 
 package org.wildfly.security.mechanism.digest;
 
-import org.wildfly.common.Assert;
-import org.wildfly.security.auth.callback.CredentialCallback;
-import org.wildfly.security.credential.PasswordCredential;
-import org.wildfly.security.mechanism._private.ElytronMessages;
-import org.wildfly.security.mechanism.AuthenticationMechanismException;
-import org.wildfly.security.password.TwoWayPassword;
-import org.wildfly.security.password.interfaces.ClearPassword;
-import org.wildfly.security.password.interfaces.DigestPassword;
-import org.wildfly.security.password.spec.DigestPasswordAlgorithmSpec;
+import static org.wildfly.security.mechanism.digest.DigestUtil.getTwoWayPasswordChars;
+import static org.wildfly.security.mechanism.digest.DigestUtil.userRealmPasswordDigest;
+
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.util.Arrays;
+import java.util.function.Supplier;
 
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.callback.Callback;
@@ -36,13 +34,16 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
-import java.security.MessageDigest;
-import java.security.Provider;
-import java.util.Arrays;
-import java.util.function.Supplier;
 
-import static org.wildfly.security.mechanism.digest.DigestUtil.getTwoWayPasswordChars;
-import static org.wildfly.security.mechanism.digest.DigestUtil.userRealmPasswordDigest;
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.callback.CredentialCallback;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.mechanism._private.ElytronMessages;
+import org.wildfly.security.mechanism.AuthenticationMechanismException;
+import org.wildfly.security.password.TwoWayPassword;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.interfaces.DigestPassword;
+import org.wildfly.security.password.spec.DigestPasswordAlgorithmSpec;
 
 /**
  * Utility class used to obtain username+realm+password using SASL/HTTP mechanism callbacks.

--- a/permission/src/main/java/org/wildfly/security/permission/PermissionActions.java
+++ b/permission/src/main/java/org/wildfly/security/permission/PermissionActions.java
@@ -20,11 +20,11 @@ package org.wildfly.security.permission;
 
 import static org.wildfly.security.permission.SecurityMessages.permission;
 
-import org.wildfly.common.Assert;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Iterator;
+
+import org.wildfly.common.Assert;
 
 /**
  * A helper class for defining permissions which use a finite list of actions.  Define custom permissions using

--- a/provider/util/src/main/java/org/wildfly/security/provider/util/ProviderFactory.java
+++ b/provider/util/src/main/java/org/wildfly/security/provider/util/ProviderFactory.java
@@ -18,7 +18,8 @@
 
 package org.wildfly.security.provider.util;
 
-import org.wildfly.security.provider.util._private.ElytronMessages;
+import static java.lang.System.getSecurityManager;
+import static org.wildfly.security.provider.util.ProviderUtil.INSTALLED_PROVIDERS;
 
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
@@ -27,8 +28,7 @@ import java.security.Provider;
 import java.util.ArrayList;
 import java.util.function.Supplier;
 
-import static java.lang.System.getSecurityManager;
-import static org.wildfly.security.provider.util.ProviderUtil.INSTALLED_PROVIDERS;
+import org.wildfly.security.provider.util._private.ElytronMessages;
 
 /**
  * Utility class to obtain Supplier with providers available on the classpath.

--- a/sasl/base/src/main/java/org/wildfly/security/sasl/SaslMechanismPredicate.java
+++ b/sasl/base/src/main/java/org/wildfly/security/sasl/SaslMechanismPredicate.java
@@ -18,7 +18,8 @@
 
 package org.wildfly.security.sasl;
 
-import static org.wildfly.common.math.HashMath.*;
+import static org.wildfly.common.math.HashMath.multiHashOrdered;
+import static org.wildfly.common.math.HashMath.multiHashUnordered;
 
 import java.util.Arrays;
 import java.util.function.Predicate;

--- a/sasl/otp/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
+++ b/sasl/otp/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
@@ -19,8 +19,32 @@
 package org.wildfly.security.sasl.otp;
 
 import static org.wildfly.security.mechanism._private.ElytronMessages.saslOTP;
-import static org.wildfly.security.password.interfaces.OneTimePassword.*;
-import static org.wildfly.security.sasl.otp.OTP.*;
+
+import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_MD5;
+import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA1;
+import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_256;
+import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_384;
+import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_512;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_AUTHENTICATION_ID_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_AUTHORIZATION_ID_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_PASS_PHRASE_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_SEED_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MIN_PASS_PHRASE_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MIN_SEED_LENGTH;
+import static org.wildfly.security.password.interfaces.OneTimePassword.OTP_HASH_SIZE;
+import static org.wildfly.security.password.interfaces.OneTimePassword.SHA1;
+import static org.wildfly.security.password.interfaces.OneTimePassword.MD5;
+import static org.wildfly.security.password.interfaces.OneTimePassword.SHA256;
+import static org.wildfly.security.password.interfaces.OneTimePassword.SHA384;
+import static org.wildfly.security.password.interfaces.OneTimePassword.SHA512;
+
+import static org.wildfly.security.sasl.otp.OTP.DICTIONARY_SIZE;
+import static org.wildfly.security.sasl.otp.OTP.DIRECT_OTP;
+import static org.wildfly.security.sasl.otp.OTP.HEX_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.INIT_HEX_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.INIT_WORD_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.PASS_PHRASE;
+import static org.wildfly.security.sasl.otp.OTP.WORD_RESPONSE;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/sasl/otp/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
+++ b/sasl/otp/src/main/java/org/wildfly/security/sasl/otp/OTPUtil.java
@@ -20,31 +20,31 @@ package org.wildfly.security.sasl.otp;
 
 import static org.wildfly.security.mechanism._private.ElytronMessages.saslOTP;
 
+import static org.wildfly.security.sasl.otp.OTP.WORD_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.INIT_WORD_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.HEX_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.INIT_HEX_RESPONSE;
+import static org.wildfly.security.sasl.otp.OTP.PASS_PHRASE;
+import static org.wildfly.security.sasl.otp.OTP.DIRECT_OTP;
+import static org.wildfly.security.sasl.otp.OTP.MD5;
+import static org.wildfly.security.sasl.otp.OTP.SHA1;
+import static org.wildfly.security.sasl.otp.OTP.SHA256;
+import static org.wildfly.security.sasl.otp.OTP.SHA384;
+import static org.wildfly.security.sasl.otp.OTP.SHA512;
+import static org.wildfly.security.sasl.otp.OTP.DICTIONARY_SIZE;
+import static org.wildfly.security.sasl.otp.OTP.MAX_AUTHENTICATION_ID_LENGTH;
+import static org.wildfly.security.sasl.otp.OTP.MAX_AUTHORIZATION_ID_LENGTH;
+import static org.wildfly.security.sasl.otp.OTP.MIN_SEED_LENGTH;
+import static org.wildfly.security.sasl.otp.OTP.MAX_SEED_LENGTH;
+import static org.wildfly.security.sasl.otp.OTP.MIN_PASS_PHRASE_LENGTH;
+import static org.wildfly.security.sasl.otp.OTP.MAX_PASS_PHRASE_LENGTH;
+
+import static org.wildfly.security.password.interfaces.OneTimePassword.OTP_HASH_SIZE;
 import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_MD5;
 import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA1;
 import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_256;
 import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_384;
 import static org.wildfly.security.password.interfaces.OneTimePassword.ALGORITHM_OTP_SHA_512;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_AUTHENTICATION_ID_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_AUTHORIZATION_ID_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_PASS_PHRASE_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MAX_SEED_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MIN_PASS_PHRASE_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MIN_SEED_LENGTH;
-import static org.wildfly.security.password.interfaces.OneTimePassword.OTP_HASH_SIZE;
-import static org.wildfly.security.password.interfaces.OneTimePassword.SHA1;
-import static org.wildfly.security.password.interfaces.OneTimePassword.MD5;
-import static org.wildfly.security.password.interfaces.OneTimePassword.SHA256;
-import static org.wildfly.security.password.interfaces.OneTimePassword.SHA384;
-import static org.wildfly.security.password.interfaces.OneTimePassword.SHA512;
-
-import static org.wildfly.security.sasl.otp.OTP.DICTIONARY_SIZE;
-import static org.wildfly.security.sasl.otp.OTP.DIRECT_OTP;
-import static org.wildfly.security.sasl.otp.OTP.HEX_RESPONSE;
-import static org.wildfly.security.sasl.otp.OTP.INIT_HEX_RESPONSE;
-import static org.wildfly.security.sasl.otp.OTP.INIT_WORD_RESPONSE;
-import static org.wildfly.security.sasl.otp.OTP.PASS_PHRASE;
-import static org.wildfly.security.sasl.otp.OTP.WORD_RESPONSE;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;


### PR DESCRIPTION
Fixes:

[https://issues.redhat.com/browse/ELY-2832](https://issues.redhat.com/browse/ELY-2832)
[https://issues.redhat.com/browse/ELY-2833](https://issues.redhat.com/browse/ELY-2833)
[https://issues.redhat.com/browse/ELY-2834](https://issues.redhat.com/browse/ELY-2834)
[https://issues.redhat.com/browse/ELY-2835](https://issues.redhat.com/browse/ELY-2835)

Replace wildcard imports with explicit declarations in the following classes:

SSLConnection.java
DEREncoder.java
OTPUtil.java
SaslMechanismPredicate.java
