### PR TITLE
[ELY-2969] Upgrade Testcontainers version from 1.20.1 to 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <version.org.xipki.pki.ocsp-server>3.0.0</version.org.xipki.pki.ocsp-server>
         <version.org.bitbucket.b_c.jose4j>0.9.6</version.org.bitbucket.b_c.jose4j>
         <version.org.testcontainers.nginx>1.20.1</version.org.testcontainers.nginx>
-        <version.org.testcontainers.testcontainers>1.20.1</version.org.testcontainers.testcontainers>
+        <version.org.testcontainers.testcontainers>2.0.2</version.org.testcontainers.testcontainers>
         <version.org.keycloak>18.0.2</version.org.keycloak>
         <version.io.rest-assured>4.3.3</version.io.rest-assured>
         <version.net.sourceforge.htmlunit.htmlunit>2.40.0</version.net.sourceforge.htmlunit.htmlunit>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2969

This needs to be merged otherwise the tests are skipped silently even though docker with version 29+ is available