### PR TITLE
[ELY-2975] Add the jboss-logging-processor to the compiler plugin.

### DIFF
--- a/asn1/pom.xml
+++ b/asn1/pom.xml
@@ -49,11 +49,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -54,11 +54,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>provided</scope>

--- a/auth/client/pom.xml
+++ b/auth/client/pom.xml
@@ -89,11 +89,6 @@
             <scope>provided</scope>
         </dependency>        
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>                        
-        <dependency>
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
             <scope>provided</scope>

--- a/auth/realm/base/pom.xml
+++ b/auth/realm/base/pom.xml
@@ -73,11 +73,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/auth/realm/jdbc/pom.xml
+++ b/auth/realm/jdbc/pom.xml
@@ -65,11 +65,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/auth/realm/ldap/pom.xml
+++ b/auth/realm/ldap/pom.xml
@@ -77,11 +77,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.jboss.modules</groupId>

--- a/auth/realm/token/pom.xml
+++ b/auth/realm/token/pom.xml
@@ -66,11 +66,6 @@
             <scope>provided</scope>
         </dependency>        
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>

--- a/auth/server/base/pom.xml
+++ b/auth/server/base/pom.xml
@@ -74,11 +74,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>provided</scope>

--- a/auth/server/deprecated/pom.xml
+++ b/auth/server/deprecated/pom.xml
@@ -69,11 +69,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/auth/server/http/pom.xml
+++ b/auth/server/http/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/auth/server/sasl/pom.xml
+++ b/auth/server/sasl/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/auth/util/pom.xml
+++ b/auth/util/pom.xml
@@ -68,11 +68,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-common</artifactId>
         </dependency>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -48,11 +48,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>

--- a/credential/base/pom.xml
+++ b/credential/base/pom.xml
@@ -67,11 +67,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <optional>true</optional>

--- a/credential/source/deprecated/pom.xml
+++ b/credential/source/deprecated/pom.xml
@@ -73,11 +73,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>  
                 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/credential/source/impl/pom.xml
+++ b/credential/source/impl/pom.xml
@@ -69,11 +69,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/credential/store/pom.xml
+++ b/credential/store/pom.xml
@@ -114,11 +114,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/dynamic-ssl/pom.xml
+++ b/dynamic-ssl/pom.xml
@@ -24,11 +24,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>provided</scope>

--- a/encryption/pom.xml
+++ b/encryption/pom.xml
@@ -43,11 +43,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/http/base/pom.xml
+++ b/http/base/pom.xml
@@ -54,11 +54,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/http/basic/pom.xml
+++ b/http/basic/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/bearer/pom.xml
+++ b/http/bearer/pom.xml
@@ -52,11 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/cert/pom.xml
+++ b/http/cert/pom.xml
@@ -56,11 +56,6 @@
         </dependency>        
         
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/deprecated/pom.xml
+++ b/http/deprecated/pom.xml
@@ -78,11 +78,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>        

--- a/http/digest/pom.xml
+++ b/http/digest/pom.xml
@@ -60,11 +60,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/external/pom.xml
+++ b/http/external/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/form/pom.xml
+++ b/http/form/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-mechanism-http</artifactId>
@@ -46,10 +46,10 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-mechanism</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
+            <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>

--- a/http/oidc/pom.xml
+++ b/http/oidc/pom.xml
@@ -38,10 +38,10 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
         </dependency>
-        <dependency>        
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-credential</artifactId>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-http</artifactId>
@@ -61,7 +61,7 @@
 
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
+            <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>

--- a/http/spnego/pom.xml
+++ b/http/spnego/pom.xml
@@ -37,11 +37,11 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth</artifactId>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-credential</artifactId>
@@ -61,7 +61,7 @@
 
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
+            <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -69,7 +69,7 @@
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>

--- a/http/sso/pom.xml
+++ b/http/sso/pom.xml
@@ -61,11 +61,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/http/stateful-basic/pom.xml
+++ b/http/stateful-basic/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/http/util/pom.xml
+++ b/http/util/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/jose/jwk/pom.xml
+++ b/jose/jwk/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/jose/util/pom.xml
+++ b/jose/util/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/keystore/pom.xml
+++ b/keystore/pom.xml
@@ -62,11 +62,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
             <scope>provided</scope>

--- a/manager/base/pom.xml
+++ b/manager/base/pom.xml
@@ -135,11 +135,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!--Test scope-->
         <dependency>

--- a/mechanism/base/pom.xml
+++ b/mechanism/base/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/mechanism/gssapi/pom.xml
+++ b/mechanism/gssapi/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
                
     </dependencies>
 

--- a/mechanism/http/pom.xml
+++ b/mechanism/http/pom.xml
@@ -59,11 +59,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/password/impl/pom.xml
+++ b/password/impl/pom.xml
@@ -54,11 +54,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!--Test scope-->
         <dependency>

--- a/permission/pom.xml
+++ b/permission/pom.xml
@@ -52,11 +52,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!--Test scope-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,13 @@
                             <buildDirectory>${project.build.directory}</buildDirectory>
                             <compileSourceRoots>${project.compileSourceRoots}</compileSourceRoots>
                             <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-processor</artifactId>
+                                    <version>${version.org.jboss.logging.tools}</version>
+                                </path>
+                            </annotationProcessorPaths>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
                                     <artifactId>jboss-logging-processor</artifactId>
                                     <version>${version.org.jboss.logging.tools}</version>
                                 </path>
+                                <path>
+                                    <groupId>org.kohsuke.metainf-services</groupId>
+                                    <artifactId>metainf-services</artifactId>
+                                    <version>${version.org.kohsuke.metainf-services.metainf-services}</version>
+                                </path>
                             </annotationProcessorPaths>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -831,12 +831,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging-processor</artifactId>
-                <version>${version.org.jboss.logging.tools}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
                 <version>${version.org.jboss.logmanager}</version>

--- a/provider/util/pom.xml
+++ b/provider/util/pom.xml
@@ -49,10 +49,5 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/sasl/base/pom.xml
+++ b/sasl/base/pom.xml
@@ -76,11 +76,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/sasl/digest/pom.xml
+++ b/sasl/digest/pom.xml
@@ -65,11 +65,6 @@
             <scope>provided</scope>
         </dependency>
 
-         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
         
         <dependency>
             <groupId>org.wildfly.common</groupId>

--- a/ssh/util/pom.xml
+++ b/ssh/util/pom.xml
@@ -52,11 +52,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.sshd</groupId>

--- a/ssl/pom.xml
+++ b/ssl/pom.xml
@@ -128,11 +128,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -551,11 +551,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>provided</scope>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -285,11 +285,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.aesh</groupId>
             <artifactId>aesh</artifactId>
         </dependency>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -57,11 +57,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/x500/base/pom.xml
+++ b/x500/base/pom.xml
@@ -55,11 +55,6 @@
             <scope>provided</scope>
         </dependency>        
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/x500/cert/acme/pom.xml
+++ b/x500/cert/acme/pom.xml
@@ -66,11 +66,6 @@
             <scope>provided</scope>
         </dependency>        
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>

--- a/x500/cert/base/pom.xml
+++ b/x500/cert/base/pom.xml
@@ -64,11 +64,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/x500/cert/util/pom.xml
+++ b/x500/cert/util/pom.xml
@@ -49,11 +49,6 @@
             <artifactId>jboss-logging</artifactId>
             <scope>provided</scope>
         </dependency>        
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/x500/deprecated/pom.xml
+++ b/x500/deprecated/pom.xml
@@ -56,11 +56,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>        
     </dependencies>
 
 </project>

--- a/x500/principal/pom.xml
+++ b/x500/principal/pom.xml
@@ -52,11 +52,6 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>        
     </dependencies>
 
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2975

This is required for Java 25 compilation.
