### PR TITLE
[ELY-2793] The value of OidcClientConfiguration.pkce is never used when configuring the OIDC authentication request

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/Oidc.java
@@ -121,6 +121,10 @@ public class Oidc {
     public static final String RESPONSE_TYPE = "response_type";
     public static final String SESSION_RANDOM_VALUE="session_random_value";
     public static final String SESSION_STATE = "session_state";
+    public static final String CODE_VERIFIER = "code_verifier";
+    public static final String CODE_CHALLENGE = "code_challenge";
+    public static final String CODE_CHALLENGE_METHOD = "code_challenge_method";
+    public static final String CODE_CHALLENGE_METHOD_S256 = "S256";
     public static final String SOAP_ACTION = "SOAPAction";
     public static final String SSL_REQUIRED = "ssl-required";
     public static final String STALE_TOKEN = "Stale token";

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcRequestAuthenticator.java
@@ -46,10 +46,16 @@ import static org.wildfly.security.http.oidc.Oidc.STATE;
 import static org.wildfly.security.http.oidc.Oidc.UI_LOCALES;
 import static org.wildfly.security.http.oidc.Oidc.ClientCredentialsProviderType.SECRET;
 
+import static org.wildfly.security.http.oidc.Oidc.CODE_CHALLENGE;
+import static org.wildfly.security.http.oidc.Oidc.CODE_CHALLENGE_METHOD;
+import static org.wildfly.security.http.oidc.Oidc.CODE_CHALLENGE_METHOD_S256;
+import static org.wildfly.security.http.oidc.Oidc.CODE_VERIFIER;
 import static org.wildfly.security.http.oidc.Oidc.logToken;
 import static org.wildfly.security.http.oidc.Oidc.generateId;
 import static org.wildfly.security.http.oidc.Oidc.getQueryParamValue;
 import static org.wildfly.security.http.oidc.Oidc.stripQueryParam;
+import static org.wildfly.security.http.oidc.OidcCookieTokenStore.getCookiePath;
+import static org.wildfly.security.jose.jwk.JWKUtil.BASE64_URL;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -273,6 +279,15 @@ public class OidcRequestAuthenticator {
                 .addParameter(STATE, state)
                 .addParameters(forwardedQueryParams)
                 .addParameter(NONCE, sessionRandomValueHash);
+
+        if (deployment.isPkce()) {
+            String codeVerifier = generateCodeVerifier();
+            String codeChallenge = generateCodeChallenge(codeVerifier);
+            redirectUriBuilder.addParameter(CODE_CHALLENGE, codeChallenge)
+                    .addParameter(CODE_CHALLENGE_METHOD, CODE_CHALLENGE_METHOD_S256);
+            facade.getResponse().setCookie(CODE_VERIFIER, codeVerifier, getCookiePath(deployment, facade), null, -1, deployment.getSSLRequired().isRequired(facade.getRequest().getRemoteAddr()), true);
+        }
+
         return redirectUriBuilder;
     }
 
@@ -425,8 +440,19 @@ public class OidcRequestAuthenticator {
         AccessAndIDTokenResponse tokenResponse;
         strippedOauthParametersRequestUri = rewrittenRedirectUri(stripOauthParametersFromRedirect(facade.getRequest().getURI()));
 
+        String codeVerifier = null;
+        if (deployment.isPkce()) {
+            codeVerifier = getCookieValue(CODE_VERIFIER);
+            if (codeVerifier != null) {
+                OidcHttpFacade.Cookie cookie = getCookie(CODE_VERIFIER);
+                if (cookie != null) {
+                    facade.getResponse().resetCookie(CODE_VERIFIER, cookie.getPath());
+                }
+            }
+        }
+
         try {
-            tokenResponse = ServerRequest.invokeAccessCodeToToken(deployment, code, strippedOauthParametersRequestUri);
+            tokenResponse = ServerRequest.invokeAccessCodeToToken(deployment, code, strippedOauthParametersRequestUri, codeVerifier);
         } catch (ServerRequest.HttpFailure failure) {
             log.error("failed to turn code into token");
             log.error("status from server: " + failure.getStatus());
@@ -645,5 +671,30 @@ public class OidcRequestAuthenticator {
         byte[] nonceData = new byte[NONCE_SIZE];
         random.nextBytes(nonceData);
         return ByteIterator.ofBytes(nonceData).base64Encode().drainToString();
+    }
+
+    /**
+     * Generate a code verifier for PKCE as per RFC 7636.
+     * The code verifier is a cryptographically random string using the characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+     * with a minimum length of 43 characters and a maximum length of 128 characters.
+     *
+     * @return the code verifier
+     */
+    private String generateCodeVerifier() {
+        SecureRandom random = new SecureRandom();
+        byte[] randomBytes = new byte[32];
+        random.nextBytes(randomBytes);
+        return ByteIterator.ofBytes(randomBytes).base64Encode(BASE64_URL, false).drainToString();
+    }
+
+    /**
+     * Generate a code challenge from the code verifier for PKCE as per RFC 7636.
+     * The code challenge is the Base64-URL encoded SHA-256 hash of the code verifier.
+     *
+     * @param codeVerifier the code verifier
+     * @return the code challenge
+     */
+    private String generateCodeChallenge(String codeVerifier) {
+        return Oidc.getCryptographicValue(codeVerifier);
     }
 }

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/ServerRequest.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/ServerRequest.java
@@ -125,10 +125,18 @@ public class ServerRequest {
     }
 
     public static AccessAndIDTokenResponse invokeAccessCodeToToken(OidcClientConfiguration deployment, String code, String redirectUri) throws IOException, HttpFailure {
+        return invokeAccessCodeToToken(deployment, code, redirectUri, null);
+    }
+
+    public static AccessAndIDTokenResponse invokeAccessCodeToToken(OidcClientConfiguration deployment, String code, String redirectUri, String codeVerifier) throws IOException, HttpFailure {
         List<NameValuePair> formparams = new ArrayList<>();
         formparams.add(new BasicNameValuePair(GRANT_TYPE, AUTHORIZATION_CODE));
         formparams.add(new BasicNameValuePair(CODE, code));
         formparams.add(new BasicNameValuePair(REDIRECT_URI, redirectUri));
+
+        if (codeVerifier != null) {
+            formparams.add(new BasicNameValuePair(Oidc.CODE_VERIFIER, codeVerifier));
+        }
 
         HttpPost post = new HttpPost(deployment.getTokenUrl());
         ClientCredentialsProviderUtils.setClientCredentials(deployment, post, formparams);

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/OidcTest.java
@@ -278,6 +278,35 @@ public class OidcTest extends OidcBaseTest {
                 true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT, expectedScope, false);
     }
 
+    @Test
+    public void testSuccessfulAuthenticationWithPkce() throws Exception {
+        performAuthentication(getOidcConfigurationInputStreamWithPkce(), KeycloakConfiguration.ALICE, KeycloakConfiguration.ALICE_PASSWORD,
+                true, HttpStatus.SC_MOVED_TEMPORARILY, getClientUrl(), CLIENT_PAGE_TEXT);
+    }
+
+    @Test
+    public void testPkceParametersInAuthorizationRequest() throws Exception {
+        Map<String, Object> props = new HashMap<>();
+        OidcClientConfiguration oidcClientConfiguration = OidcClientConfigurationBuilder.build(getOidcConfigurationInputStreamWithPkce());
+        assertTrue("PKCE should be enabled", oidcClientConfiguration.isPkce());
+
+        OidcClientContext oidcClientContext = new OidcClientContext(oidcClientConfiguration);
+        oidcFactory = new OidcMechanismFactory(oidcClientContext);
+        HttpServerAuthenticationMechanism mechanism = oidcFactory.createAuthenticationMechanism(OIDC_NAME, props, getCallbackHandler());
+
+        URI requestUri = new URI(getClientUrl());
+        TestingHttpServerRequest request = new TestingHttpServerRequest(null, requestUri);
+        mechanism.evaluateRequest(request);
+        TestingHttpServerResponse response = request.getResponse();
+
+        assertEquals(HttpStatus.SC_MOVED_TEMPORARILY, response.getStatusCode());
+        assertEquals(Status.NO_AUTH, request.getResult());
+
+        String location = response.getLocation();
+        assertTrue("Authorization URL should contain code_challenge parameter", location.contains("code_challenge="));
+        assertTrue("Authorization URL should contain code_challenge_method parameter", location.contains("code_challenge_method=S256"));
+    }
+
     // Note: The tests will fail if `localhost` is not listed first in `/etc/hosts` file for the loopback addresses (IPv4 and IPv6).
     @Test
     public void testSuccessfulOauth2Request() throws Exception {
@@ -971,6 +1000,20 @@ public class OidcTest extends OidcBaseTest {
                 "    \"" + SSL_REQUIRED + "\" : \"EXTERNAL\",\n" +
                 "    \"" + CREDENTIALS + "\" : {\n" +
                 "        \"" + ClientCredentialsProviderType.SECRET.getValue() + "\" : \"" + clientSecret + "\"\n" +
+                "    }\n" +
+                "}";
+        return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream getOidcConfigurationInputStreamWithPkce() {
+        String oidcConfig = "{\n" +
+                "    \"" + RESOURCE + "\" : \"" + CLIENT_ID + "\",\n" +
+                "    \"" + PUBLIC_CLIENT + "\" : \"false\",\n" +
+                "    \"" + PROVIDER_URL + "\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "\",\n" +
+                "    \"" + SSL_REQUIRED + "\" : \"EXTERNAL\",\n" +
+                "    \"" + Oidc.ENABLE_PKCE + "\" : \"true\",\n" +
+                "    \"" + CREDENTIALS + "\" : {\n" +
+                "        \"" + ClientCredentialsProviderType.SECRET.getValue() + "\" : \"" + CLIENT_SECRET + "\"\n" +
                 "    }\n" +
                 "}";
         return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2793