### PR TITLE
Add blog post about AWS Secret Manager integration with Elytron Crede…

### DIFF
--- a/content/blog/2026-01-23-elytron-credential-store-with-aws-secret-manager.adoc
+++ b/content/blog/2026-01-23-elytron-credential-store-with-aws-secret-manager.adoc
@@ -1,0 +1,164 @@
+---
+layout: post
+title: 'Integrating WildFly Elytron Credential Store with AWS Secrets Manager'
+aliases: [/blog/aws-secretsmanager-credential-store]
+date: 2026-01-23
+tags: aws,secrets-manager,credential-store,credential-reference,security
+synopsis: Learn how to dynamically fetch sensitive credentials from AWS Secrets Manager using a custom WildFly Elytron CredentialStore.
+author: gabrielpadilh4
+---
+
+:toc: macro
+:toc-title:
+
+toc::[]
+
+== Introduction
+
+I'm excited to introduce a custom Wildfly Elytron Credential Store implementation that allows system administrators to integrate the Credential Store capabilities with AWS Secrets Manager.
+This integration turns AWS Secret Manager into a backing-store for Wildfly. Dynamically fetching credentials via AWS Java SDK into Credential Stores, eliminting any need of storing credentials in local files.
+
+== Key features
+
+* *Native Elytron integration*: Seamlessly integration with any Wildfly subsystems that supports the usage of credential references, such as Datasource, Mail, Messaging and more.
+* *Secure by Design*: Sensitive data reamins in AWS Secret Manager; only references are stored in the local configuration
+* *IAM Ready*: All capabilities provided by AWS Java SDK as the default AWS credentials provider. This enables it to be compatible with EC2 instances, EKS pod identities and local profiles.
+
+== Installation
+
+=== Step 1: Download and install the AWS Secrets Manager credential store module
+
+Download the JAR module located at: https://github.com/gabrielpadilh4/elytron-aws-secrets-store/releases/tag/1.0.0
+
+Add the module to Wildfly via jboss-cli.sh
+
+[source,bash]
+-----
+module add --name=elytron-aws-secrets-store --resources=/path/to/jar/elytron-aws-secrets-store-1.0-SNAPSHOT.jar --dependencies=org.wildfly.security.elytron,org.slf4j,org.jboss.logging
+-----
+
+=== Step 2: Register and configure the provided module as a credential store. 
+
+==== CLI Configuration Example
+
+[source,bash]
+----
+/subsystem=elytron/provider-loader=AwsSecretsCredentialStoreProvider:add(class-names=[org.gabrielpadilh4.AwsSecretsCredentialStoreProvider], module=elytron-aws-secrets-store)
+/subsystem=elytron:write-attribute(name=initial-providers, value=AwsSecretsCredentialStoreProvider)
+
+reload
+
+/subsystem=elytron/credential-store=AwsSecretsCredentialStore:add(providers=AwsSecretsCredentialStoreProvider,credential-reference={clear-text=''}, type=AwsSecretsCredentialStore)
+
+reload
+----
+
+==== XML Configuration Example
+[source,xml]
+----
+        <subsystem xmlns="urn:wildfly:elytron:18.0" initial-providers="AwsSecretsCredentialStoreProvider" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+            <providers>
+                <aggregate-providers name="combined-providers">
+                    <providers name="elytron"/>
+                    <providers name="openssl"/>
+                </aggregate-providers>
+                <provider-loader name="elytron" module="org.wildfly.security.elytron"/>
+                <provider-loader name="openssl" module="org.wildfly.openssl"/>
+                <provider-loader name="AwsSecretsCredentialStoreProvider" module="elytron-aws-secrets-store" class-names="org.gabrielpadilh4.AwsSecretsCredentialStoreProvider"/>
+            </providers>
+...
+            <credential-stores>
+                <credential-store name="AwsSecretsCredentialStore" type="AwsSecretsCredentialStore" providers="AwsSecretsCredentialStoreProvider">
+                    <credential-reference clear-text="''"/>
+                </credential-store>
+            </credential-stores>
+----
+
+*Note* that `clear-text` value will not be used. It is empty because is mandatory.
+
+=== Step 3: Configure the authentication method and start Wildfly
+
+Configure one of the methods supported by AWS Java SDK: https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html
+
+Once it is configured, start Wildfly. 
+
+As a example where I have a profile configured under `~/.aws/config`, I will use the `-Daws.profile` option. E.g:
+[source,bash]
+----
+./bin/standalone.sh -Daws.profile=localstack
+----
+
+Check the JVM settings reference for all system properties options: https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#JVMSettings
+
+== Usage Example
+
+=== CLI Configuration Example
+
+Configuring a existing datasource to fetch the database password from AWS Secret Manager store using the "alias" with the AWS Secret name:
+[source,bash]
+----
+/subsystem=datasources/data-source=PostgresDS:write-attribute(name=credential-reference, value=\{store=AwsSecretsCredentialStore, alias="prod/db/password"\})
+reload
+----
+
+=== XML Configuration Example
+[source,xml]
+----
+                <datasource jndi-name="java:jboss/PostgresDS" pool-name="PostgresDS">
+                    <connection-url>jdbc:postgresql://localhost:5432/testdb</connection-url>
+                    <driver>postgresql</driver>
+                    <security user-name="testuser">
+                        <credential-reference store="AwsSecretsCredentialStore" alias="prod/db/password"/>
+                    </security>
+                    <validation>
+                        <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker"/>
+                        <validate-on-match>true</validate-on-match>
+                        <background-validation>false</background-validation>
+                        <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter"/>
+                    </validation>
+                </datasource>
+----
+
+In the above example "prod/db/password" is the name of my secret that holds the password for the database in AWS Secrets Manager.
+
+The follows can be seens via AWS cli:
+[source,bash]
+----
+$ aws secretsmanager create-secret --name "prod/db/password" --secret-string 'thisismysecuredbpassword' --profile localstack
+{
+    "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod/db/password-DrjuOs",
+    "Name": "prod/db/password",
+    "VersionId": "b0c6d7bf-8540-4d5a-8e17-9aed408e898e"
+}
+$
+$ aws secretsmanager list-secrets --profile localstack
+{
+    "SecretList": [
+        {
+            "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:prod/db/password-DrjuOs",
+            "Name": "prod/db/password",
+            "LastChangedDate": "2026-01-13T10:43:13.039013-03:00",
+            "SecretVersionsToStages": {
+                "b0c6d7bf-8540-4d5a-8e17-9aed408e898e": [
+                    "AWSCURRENT"
+                ]
+            },
+            "CreatedDate": "2026-01-13T10:43:13.039013-03:00"
+        }
+    ]
+}
+----
+
+== Conclusion
+
+This post gave a simple example of how to use the AWS Secret Manager credential store module to fetch AWS secrets and extend the credential store capabilities.
+
+== Resources
+
+* Project repository: https://github.com/gabrielpadilh4/elytron-aws-secrets-store
+* Jar module: https://github.com/gabrielpadilh4/elytron-aws-secrets-store/releases/tag/1.0.0
+* AWS Java SDK: https://aws.amazon.com/pt/sdk-for-java/
+* AWS Java SDK configuration methods: https://docs.aws.amazon.com/sdkref/latest/guide/creds-config-files.html
+* AWS Java system properties: https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#JVMSettings
+* link:https://docs.wildfly.org/[WildFly Documentation]
+* link:https://docs.wildfly.org/38/WildFly_Elytron_Security.html[WildFly Elytron Security Guide]

--- a/data/authors.yaml
+++ b/data/authors.yaml
@@ -62,3 +62,7 @@ lvydra:
   name: "Lukas Vydra"
   emailhash: "963ac51a738ab1ff63a5bbdf6b206417"
   bio: "https://github.com/lvydra"
+gabrielpadilh4:
+  name: "Gabriel Santos"
+  emailhash: "fb9648a099e8d6e8ab5ac773ab271e6d"
+  bio: "https://github.com/gabrielpadilh4"


### PR DESCRIPTION
Add a blog post about AWS Secret Manager integration with Elytron Credential Store:

- https://gabrielpadilh4.github.io/wildfly-elytron/blog/integrating-wildfly-elytron-credential-store-with-aws-secrets-manager/

Discussion: https://groups.google.com/d/msgid/wildfly/2b62e945-c695-4b9a-9013-e03fe2e6f26dn%40googlegroups.com?utm_medium=email&utm_source=footer