### PR TITLE
[ELY-3005] Correct the check before the first WARN message is logged on cache eviction due to size.

### DIFF
--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/BruteForceRealmWrapper.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/BruteForceRealmWrapper.java
@@ -316,7 +316,7 @@ public class BruteForceRealmWrapper {
                         eldest.getValue().cancelExpiry(true);
 
                         long nowNanos = System.nanoTime();
-                        if ((nowNanos - lastWarnLoggedNanos) > LOG_INTERVAL_NANOS) {
+                        if (lastWarnLoggedNanos == Long.MIN_VALUE || (nowNanos - lastWarnLoggedNanos) > LOG_INTERVAL_NANOS) {
                             // We don't want to flood the log, but we do want to ensure we are periodically reporting
                             // this situation so an administrator can take action.
                             log.bruteForceSessionEvicted(realmName);


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-3005