### PR TITLE
[ELY-2518] Move KeyStoreUtil to a new wildfly-elytron-keystore-util module

### DIFF
--- a/keystore/util/pom.xml
+++ b/keystore/util/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wildfly.security</groupId>
+        <artifactId>wildfly-elytron-parent</artifactId>
+        <version>2.8.3.CR1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wildfly-elytron-keystore-util</artifactId>
+
+    <name>WildFly Elytron - KeyStore Utilities</name>
+    <description>WildFly Security KeyStore Utilities</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-provider-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-x500-cert</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test Scope -->
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-asn1</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-x500</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcmail-jdk15on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/keystore/util/src/main/java/org/wildfly/security/keystore/util/ElytronMessages.java
+++ b/keystore/util/src/main/java/org/wildfly/security/keystore/util/ElytronMessages.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.keystore.util;
+
+import java.security.KeyStoreException;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
+
+/**
+ * Log messages and exceptions for Elytron KeyStore Utilities.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@MessageLogger(projectCode = "ELY", length = 5)
+@ValidIdRanges({
+        @ValidIdRange(min = 2035, max = 2035)
+})
+interface ElytronMessages extends BasicLogger {
+
+    ElytronMessages log = Logger.getMessageLogger(ElytronMessages.class, "org.wildfly.security");
+
+    @Message(id = 2035, value = "KeyStore type could not be detected")
+    KeyStoreException keyStoreTypeNotDetected();
+}

--- a/keystore/util/src/main/java/org/wildfly/security/keystore/util/KeyStoreUtil.java
+++ b/keystore/util/src/main/java/org/wildfly/security/keystore/util/KeyStoreUtil.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.wildfly.security.keystore;
+package org.wildfly.security.keystore.util;
 
-import static org.wildfly.security.keystore.ElytronMessages.log;
+import static org.wildfly.security.keystore.util.ElytronMessages.log;
 import static org.wildfly.security.provider.util.ProviderUtil.findProvider;
 
 import java.io.ByteArrayOutputStream;
@@ -46,12 +46,7 @@ import org.wildfly.security.pem.PemEntry;
  * Utility functions for manipulating KeyStores.
  *
  * @author <a href="mailto:mmazanek@redhat.com">Martin Mazanek</a>
- * @deprecated Use {@code org.wildfly.security.keystore.util.KeyStoreUtil} from
- *             the
- *             {@code wildfly-elytron-keystore-util} module instead.
- *             This class is deprecated and will be removed in a future release.
  */
-@Deprecated
 public class KeyStoreUtil {
 
     private static final String BCFKS = "BCFKS";
@@ -72,21 +67,29 @@ public class KeyStoreUtil {
     /**
      * Tries to parse a keystore based on known recognizable patterns.
      * <p>
-     * This method can parse JKS, JCEKS, PKCS12, BKS, BCFKS and UBER key stores as well as PEM files. At first the
-     * method looks for recognizable patterns of JKS, JCEKS, PKCS12 and BKS key store types and tries to parse them if
-     * found. If the pattern recognition fails, brute force is used to load the key store.
+     * This method can parse JKS, JCEKS, PKCS12, BKS, BCFKS and UBER key stores as
+     * well as PEM files. At first the
+     * method looks for recognizable patterns of JKS, JCEKS, PKCS12 and BKS key
+     * store types and tries to parse them if
+     * found. If the pattern recognition fails, brute force is used to load the key
+     * store.
      * <p>
      * The provider supplier is used for loading the key stores.
      *
-     * @param providers    provider supplier for loading the keystore (must not be {@code null})
+     * @param providers    provider supplier for loading the keystore (must not be
+     *                     {@code null})
      * @param providerName if specified only providers with this name will be used
-     * @param is           the key store file input stream (must not be {@code null})
-     * @param filename     the filename for prioritizing brute force checks using the file extension
-     * @param password     password of the key store. Should be the empty string for PEM files.
+     * @param is           the key store file input stream (must not be
+     *                     {@code null})
+     * @param filename     the filename for prioritizing brute force checks using
+     *                     the file extension
+     * @param password     password of the key store. Should be the empty string for
+     *                     PEM files.
      * @return loaded key store if recognized
      * @throws IOException
      */
-    public static KeyStore loadKeyStore(final Supplier<Provider[]> providers, final String providerName, FileInputStream is, String filename, char[] password) throws IOException, KeyStoreException {
+    public static KeyStore loadKeyStore(final Supplier<Provider[]> providers, final String providerName,
+            FileInputStream is, String filename, char[] password) throws IOException, KeyStoreException {
 
         DataInputStream dis = new ResettableDataFileInputStream(is);
 
@@ -131,7 +134,8 @@ public class KeyStoreUtil {
         return result;
     }
 
-    private static KeyStore tryLoadKeystore(final Supplier<Provider[]> providers, final String providerName, InputStream is, char[] password, String... types) {
+    private static KeyStore tryLoadKeystore(final Supplier<Provider[]> providers, final String providerName,
+            InputStream is, char[] password, String... types) {
         for (String type : types) {
             try {
                 log.debug("Searching provider for: " + type);
@@ -166,7 +170,7 @@ public class KeyStoreUtil {
         // Reading all of the file should not be an issue
         byte[] pem = readAllBytes(is);
         is.read(pem);
-        for (Iterator<PemEntry<?>> it = Pem.parsePemContent(CodePointIterator.ofUtf8Bytes(pem)); it.hasNext(); ) {
+        for (Iterator<PemEntry<?>> it = Pem.parsePemContent(CodePointIterator.ofUtf8Bytes(pem)); it.hasNext();) {
             Object entry = it.next().getEntry();
             if (entry instanceof PrivateKey) {
                 // Private key
@@ -180,13 +184,17 @@ public class KeyStoreUtil {
         if (pk != null) {
             // A keystore
             Certificate certificate = certificates.get(0);
-            String alias = certificate instanceof X509Certificate ? ((X509Certificate) certificate).getSubjectX500Principal().getName() : "key";
+            String alias = certificate instanceof X509Certificate
+                    ? ((X509Certificate) certificate).getSubjectX500Principal().getName()
+                    : "key";
             keyStore.setKeyEntry(alias, pk, password, certificates.toArray(new Certificate[0]));
         } else {
             // A truststore
             int i = 1;
             for (Certificate certificate : certificates) {
-                String alias = certificate instanceof X509Certificate ? ((X509Certificate)certificate).getSubjectX500Principal().getName() : Integer.toString(i++);
+                String alias = certificate instanceof X509Certificate
+                        ? ((X509Certificate) certificate).getSubjectX500Principal().getName()
+                        : Integer.toString(i++);
                 keyStore.setCertificateEntry(alias, certificate);
             }
         }
@@ -199,14 +207,15 @@ public class KeyStoreUtil {
         int readBytes = inputStream.read(buffer);
 
         // inputStream.read() returns -1 when the end of the stream is reached
-        while(readBytes != -1){
+        while (readBytes != -1) {
             outputStream.write(buffer, 0, readBytes);
             readBytes = inputStream.read(buffer);
         }
         return outputStream.toByteArray();
     }
 
-    //FileInputStream does not support marking by default and buffering unknown sized file doesn't seem right
+    // FileInputStream does not support marking by default and buffering unknown
+    // sized file doesn't seem right
     private static class ResettableDataFileInputStream extends DataInputStream {
 
         private FileChannel fc;

--- a/keystore/util/src/test/java/org/wildfly/security/keystore/util/KeyStoreUtilTest.java
+++ b/keystore/util/src/test/java/org/wildfly/security/keystore/util/KeyStoreUtilTest.java
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.keystore.util;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.common.bytes.ByteStringBuilder;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.asn1.ASN1Encodable;
+import org.wildfly.security.pem.Pem;
+import org.wildfly.security.x500.X500;
+import org.wildfly.security.x500.X500AttributeTypeAndValue;
+import org.wildfly.security.x500.X500PrincipalBuilder;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
+
+import javax.security.auth.x500.X500Principal;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Tests for KeyStoreUtil.
+ *
+ * @author <a href="mailto:mmazanek@redhat.com">Martin Mazanek</a>
+ */
+public class KeyStoreUtilTest {
+
+    private final Supplier<Provider[]> providerSupplier = () -> Security.getProviders();
+
+    private static final Provider elytronProvider = new WildFlyElytronProvider();
+    private static final Provider bcProvider = new BouncyCastleProvider();
+    private File workingDir = null;
+    private List<File> files = new LinkedList<>();
+    private KeyPairGenerator keyGen = null;
+
+    @BeforeClass
+    public static void setup() {
+        Security.addProvider(elytronProvider);
+        Security.addProvider(bcProvider);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        Security.removeProvider(elytronProvider.getName());
+        Security.removeProvider(bcProvider.getName());
+    }
+
+    @Before
+    public void beforeTest() throws NoSuchAlgorithmException {
+        keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        workingDir = getWorkingDir();
+    }
+
+    @After
+    public void afterTest() {
+        files.forEach(file -> file.delete());
+    }
+
+    @Test
+    public void testJKS() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        testKeyStore("testks.jks", "jks", false);
+    }
+
+    @Test
+    public void testJCEKS() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        testKeyStore("testks.pkcs12", "jceks", false);
+    }
+
+    @Test
+    public void testPKCS12() throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        testKeyStore("testks.asdf", "pkcs12", false);
+    }
+
+    @Test
+    public void testBKS() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+        testKeyStore("testks.asdf", "bks", true);
+    }
+
+    @Test
+    public void testUBER() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+        testKeyStore("testks.asdf", "uber", true);
+    }
+
+    @Test
+    public void testBCFKS() throws CertificateException, KeyStoreException, IOException, NoSuchAlgorithmException {
+        testKeyStore("testks.asdf", "bcfks", true);
+    }
+
+    @Test
+    public void testNoKeystore() throws IOException, KeyStoreException {
+        String filename = "notakeystore.txt";
+        File f = new File(workingDir, filename);
+        files.add(f);
+        FileWriter fw = new FileWriter(f);
+        fw.write("joejoejoe");
+        fw.flush();
+        fw.close();
+        try {
+            KeyStore loadedStore = KeyStoreUtil.loadKeyStore(providerSupplier, null, new FileInputStream(f), filename,
+                    "whatever".toCharArray());
+        } catch (Exception e) {
+            return;
+        }
+        Assert.fail("Key store detection should fail.");
+    }
+
+    @Test
+    public void testPEMFromFileInputStream()
+            throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException {
+        SelfSignedX509CertificateAndSigningKey ca = SelfSignedX509CertificateAndSigningKey.builder()
+                .setDn(new X500Principal(
+                        "O=Root Certificate Authority, EMAILADDRESS=elytron@wildfly.org, C=UK, ST=Elytron, CN=Elytron CA"))
+                .setKeyAlgorithmName("RSA")
+                .setSignatureAlgorithmName("SHA256withRSA")
+                .addExtension(false, "BasicConstraints", "CA:true,pathlen:2147483647")
+                .build();
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        KeyPair generatedKeys = keyPairGenerator.generateKeyPair();
+        PublicKey publicKey = generatedKeys.getPublic();
+        X509Certificate subjectCertificate = new X509CertificateBuilder()
+                .setIssuerDn(ca.getSelfSignedCertificate().getIssuerX500Principal())
+                .setSubjectDn(new X500Principal("O=Elytron, OU=Elytron, C=UK, ST=Elytron, CN=Firefly"))
+                .setSignatureAlgorithmName("SHA256withRSA")
+                .setSigningKey(ca.getSigningKey())
+                .setPublicKey(publicKey)
+                .build();
+        ByteStringBuilder target = new ByteStringBuilder();
+        Pem.generatePemX509Certificate(target, ca.getSelfSignedCertificate());
+        Pem.generatePemX509Certificate(target, subjectCertificate);
+        Files.write(Paths.get(workingDir.getPath(), "pem.pem"), target.toArray());
+
+        KeyStore loadedStoreFromByteArrayInputStream = KeyStoreUtil
+                .loadPemAsKeyStore(new ByteArrayInputStream(target.toArray()), "".toCharArray());
+        Assert.assertNotNull(loadedStoreFromByteArrayInputStream);
+        Assert.assertEquals(ca.getSelfSignedCertificate(), loadedStoreFromByteArrayInputStream
+                .getCertificate(ca.getSelfSignedCertificate().getSubjectX500Principal().getName()));
+        Assert.assertEquals(subjectCertificate, loadedStoreFromByteArrayInputStream
+                .getCertificate(subjectCertificate.getSubjectX500Principal().getName()));
+
+        KeyStore loadedStoreFromFileInputStream = KeyStoreUtil.loadKeyStore(providerSupplier, null,
+                new FileInputStream(new File(workingDir, "pem.pem")), "pem.pem", "".toCharArray());
+        Assert.assertNotNull(loadedStoreFromFileInputStream);
+        Assert.assertEquals(ca.getSelfSignedCertificate(), loadedStoreFromFileInputStream
+                .getCertificate(ca.getSelfSignedCertificate().getSubjectX500Principal().getName()));
+        Assert.assertEquals(subjectCertificate,
+                loadedStoreFromFileInputStream.getCertificate(subjectCertificate.getSubjectX500Principal().getName()));
+    }
+
+    private void generateKeyStoreWithKey(String filename, String type, String alias, char[] password, Certificate cert)
+            throws KeyStoreException, NoSuchAlgorithmException, IOException, CertificateException {
+        File keyStoreFile = new File(workingDir, filename);
+        files.add(keyStoreFile);
+        KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(null, null);
+        keyStore.setCertificateEntry(alias, cert);
+        keyStore.store(new FileOutputStream(keyStoreFile), password);
+    }
+
+    private X509Certificate generateCertificate() throws CertificateException {
+        X509CertificateBuilder builder = new X509CertificateBuilder();
+        X500PrincipalBuilder principalBuilder = new X500PrincipalBuilder();
+        KeyPair kp = keyGen.generateKeyPair();
+        principalBuilder
+                .addItem(X500AttributeTypeAndValue.create(X500.OID_AT_COMMON_NAME, ASN1Encodable.ofUtf8String("jane")));
+        final X500Principal dn = principalBuilder.build();
+        builder.setIssuerDn(dn);
+        builder.setSubjectDn(dn);
+        builder.setSignatureAlgorithmName("SHA256withRSA");
+        builder.setSigningKey(kp.getPrivate());
+        builder.setPublicKey(kp.getPublic());
+        return builder.build();
+    }
+
+    private static File getWorkingDir() {
+        File workingDir = new File("./target/keystore");
+        if (workingDir.exists() == false) {
+            workingDir.mkdirs();
+        }
+        return workingDir;
+    }
+
+    private void testKeyStore(String filename, String keystoreType, boolean testBCKeyStore)
+            throws CertificateException, KeyStoreException, NoSuchAlgorithmException, IOException {
+        System.out.println("Testing " + keystoreType.toUpperCase() + "...");
+        Certificate jkscert = generateCertificate();
+        String alias = "alias";
+        char[] password = "password".toCharArray();
+
+        if (testBCKeyStore) {
+            boolean bcfailed = false;
+            try {
+                generateKeyStoreWithKey(filename, keystoreType, alias, password, jkscert);
+            } catch (Exception e) {
+                bcfailed = true;
+            }
+            Assume.assumeFalse("BC elytronProvider not found, skipping BC keystore recognition", bcfailed);
+        } else {
+            generateKeyStoreWithKey(filename, keystoreType, alias, password, jkscert);
+        }
+
+        KeyStore loadedStore = KeyStoreUtil.loadKeyStore(providerSupplier, null,
+                new FileInputStream(new File(workingDir, filename)), filename, password);
+        Assert.assertNotNull(loadedStore);
+        Certificate loadedCert = loadedStore.getCertificate(alias);
+
+        Assert.assertEquals(jkscert, loadedCert);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -569,6 +569,12 @@
 
             <dependency>
                 <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron-keystore-util</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron-mechanism</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1656,6 +1662,7 @@
         <module>jose/util</module>
         <module>json-util</module>
         <module>keystore</module>
+        <module>keystore/util</module>
         <module>manager/base</module>
         <module>manager/action</module>
         <module>mechanism/base</module>

--- a/wildfly-elytron/pom.xml
+++ b/wildfly-elytron/pom.xml
@@ -362,6 +362,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron-keystore-util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron-mechanism</artifactId>
         </dependency>
         <dependency>
@@ -715,6 +719,11 @@
                                 <dependency>
                                     <groupId>org.wildfly.security</groupId>
                                     <artifactId>wildfly-elytron-keystore</artifactId>
+                                    <version>${project.version}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.wildfly.security</groupId>
+                                    <artifactId>wildfly-elytron-keystore-util</artifactId>
                                     <version>${project.version}</version>
                                 </dependency>
                                 <dependency>


### PR DESCRIPTION
/cc @darranl @fjuma 
issue: https://issues.redhat.com/browse/ELY-2518
Pretty much done what was asked for from the issue's description.

I have a few points I’d like to double-check regarding the current implementation:

1.) **ElytronMessages & ID Conflict:** Should I generate a unique message ID for this, or should I continue replicating `2035`? The current approach causes a conflict in `ELY_Messages.txt` due to a module name mismatch.

2.) **util Module Structure & Parent POM:** I’ve placed the new sub-module within `wildfly-elytron-keystore`, but I kept its parent as `wildfly-elytron-parent`. Does it make more sense for it to inherit from the `keystore` module instead?

3.) **Dependency Logic**: I haven't added a dependency from `wildfly-elytron-keystore` to the new `wildfly-elytron-keystore-util`. Since the Util class isn't actually called within the `keystore` module itself--including the deprecated sections--it seems this class is intended for end-user utility rather than internal API logic. Is that correct?
____
```sh
$ mvn dependency:tree --file keystore/util/pom.xml
```
```
[INFO] --- dependency:3.8.1:tree (default-cli) @ wildfly-elytron-keystore-util ---
[INFO] org.wildfly.security:wildfly-elytron-keystore-util:jar:2.8.3.CR1-SNAPSHOT
[INFO] +- org.wildfly.security:wildfly-elytron-provider-util:jar:2.8.3.CR1-SNAPSHOT:compile
[INFO] +- org.wildfly.security:wildfly-elytron-x500-cert:jar:2.8.3.CR1-SNAPSHOT:compile
[INFO] |  \- org.wildfly.security:wildfly-elytron-x500-cert-util:jar:2.8.3.CR1-SNAPSHOT:compile
[INFO] +- org.wildfly.common:wildfly-common:jar:2.0.1:compile
[INFO] |  +- io.smallrye.common:smallrye-common-cpu:jar:2.4.0:compile
[INFO] |  +- io.smallrye.common:smallrye-common-expression:jar:2.4.0:compile
[INFO] |  |  \- io.smallrye.common:smallrye-common-function:jar:2.4.0:compile
[INFO] |  +- io.smallrye.common:smallrye-common-net:jar:2.4.0:compile
[INFO] |  |  \- io.smallrye.common:smallrye-common-constraint:jar:2.4.0:compile
[INFO] |  +- io.smallrye.common:smallrye-common-os:jar:2.4.0:compile
[INFO] |  \- io.smallrye.common:smallrye-common-ref:jar:2.4.0:compile
[INFO] +- org.jboss.logging:jboss-logging-annotations:jar:3.0.1.Final:provided
[INFO] +- org.jboss.logging:jboss-logging:jar:3.6.1.Final:provided
[INFO] +- org.wildfly.security:wildfly-elytron-base:jar:2.8.3.CR1-SNAPSHOT:test
[INFO] +- org.wildfly.security:wildfly-elytron-asn1:jar:2.8.3.CR1-SNAPSHOT:test
[INFO] +- org.wildfly.security:wildfly-elytron-x500:jar:2.8.3.CR1-SNAPSHOT:test
[INFO] +- commons-io:commons-io:jar:2.16.1:test
[INFO] +- org.bouncycastle:bcmail-jdk15on:jar:1.67:test
[INFO] |  +- org.bouncycastle:bcprov-jdk15on:jar:1.67:test
[INFO] |  \- org.bouncycastle:bcpkix-jdk15on:jar:1.67:test
[INFO] \- junit:junit:jar:4.13.1:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
```