### PR TITLE
[ELY-3008] Fix website header rendering

### DIFF
--- a/templates/layouts/default.html
+++ b/templates/layouts/default.html
@@ -10,12 +10,13 @@
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700" type="text/css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <!-- We override the colours from this theme manually -->
-    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <link rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-pink.min.css">
     <link rel="stylesheet" href="{site.url('/assets/css/styles.css')}">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
     <script src="{site.url('/assets/javascript/hl.js')}" type="text/javascript"></script>
     <link rel="alternate" type="application/rss+xml" href="{site.url('feed.xml')}" title="WildFly Elytron">
-    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.min.js"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-135301155-1"></script>


### PR DESCRIPTION
/cc @skyllarr @darranl
issue: https://issues.redhat.com/browse/ELY-3008

https://code.getmdl.io domain stopped working, replaced it with the cdnjs's alternative cdn.
Inspired by https://github.com/kubernetes-sigs/prow/pull/590

Screens:
<img width="3456" height="1882" alt="image" src="https://github.com/user-attachments/assets/4fe376f2-1fb8-4023-95d2-2628fe769494" />
<img width="3456" height="1882" alt="image" src="https://github.com/user-attachments/assets/402b451e-e391-4aa4-a0d0-8b212ecc4869" />
