### PR TITLE
[ELY-3007] Revisit HTTP Digest error handling generating HA1.

### DIFF
--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -216,11 +216,13 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             return;
         }
 
-        byte[] hA1 = getH_A1(messageDigest, username, messageRealm);
+        byte[] hA1;
 
-        if (hA1 == null) {
-            httpDigest.trace("Failed: unable to get expected proof");
-            fail();
+        try {
+            hA1 = getH_A1(messageDigest, username, messageRealm); // Does not return null.
+        } catch (AuthenticationMechanismException ame) {
+            httpDigest.trace("Failed: unable to get expected proof", ame);
+            failSafely();
             request.authenticationFailed(httpDigest.authenticationFailed(), httpResponse -> prepareResponse(selectedRealm, httpResponse, false));
             return;
         }
@@ -426,6 +428,22 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
         } catch (Throwable t) {
             throw httpDigest.mechCallbackHandlerFailedForUnknownReason(t);
+        }
+    }
+
+    /**
+     * Safely handles the authentication failure callback without throwing exceptions.
+     *
+     * This method attempts to invoke the callback handler with an authentication failure notification.
+     * Unlike {@link #fail()}, any exceptions encountered during callback handling are caught and logged
+     * rather than propagated, making this method safe for use in error handling paths where exceptions
+     * cannot be thrown or where they can be ignored.
+     */
+    private void failSafely() {
+        try {
+            callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+        } catch (Throwable t) {
+            httpDigest.trace("Error handling AuthenticationCompleteCallback.FAILED", t);
         }
     }
 

--- a/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
+++ b/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
@@ -91,6 +91,12 @@ public class PasswordDigestObtainer {
         return realm;
     }
 
+    /**
+     * Handles callbacks for user and password information.
+     *
+     * @return the salted password, never {@code null}.
+     * @throws AuthenticationMechanismException if the callback handler does not support credential acquisition.
+     */
     public byte[] handleUserRealmPasswordCallbacks() throws AuthenticationMechanismException {
 
         realmChoiceCallBack = skipRealmCallbacks || realms == null || realms.length <= 1 ? null :


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-3007

We had originally intended to handle this with a null check on the returned byte aray but a thrown AuthenticationMechanismException bypasses this.

IMO it is rare that the exception will have been thrown in existing configurations but is now more common with brute force protection in place so I think we are safe to clean up like this.
