### PR TITLE
[ELY-2549] Make appropriate methods in AbstractDelegatingSSLServerSocket synchronized

### DIFF
--- a/ssl/src/main/java/org/wildfly/security/ssl/AbstractDelegatingSSLServerSocket.java
+++ b/ssl/src/main/java/org/wildfly/security/ssl/AbstractDelegatingSSLServerSocket.java
@@ -64,7 +64,7 @@ abstract class AbstractDelegatingSSLServerSocket extends SSLServerSocket {
         return delegate.accept();
     }
 
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         delegate.close();
     }
 
@@ -76,15 +76,15 @@ abstract class AbstractDelegatingSSLServerSocket extends SSLServerSocket {
         return delegate.isBound();
     }
 
-    public boolean isClosed() {
+    public synchronized boolean isClosed() {
         return delegate.isClosed();
     }
 
-    public void setSoTimeout(final int timeout) throws SocketException {
+    public synchronized void setSoTimeout(final int timeout) throws SocketException {
         delegate.setSoTimeout(timeout);
     }
 
-    public int getSoTimeout() throws IOException {
+    public synchronized int getSoTimeout() throws IOException {
         return delegate.getSoTimeout();
     }
 
@@ -100,15 +100,15 @@ abstract class AbstractDelegatingSSLServerSocket extends SSLServerSocket {
         return delegate.toString();
     }
 
-    public static void setSocketFactory(final SocketImplFactory fac) throws IOException {
+    public static synchronized void setSocketFactory(final SocketImplFactory fac) throws IOException {
         ServerSocket.setSocketFactory(fac);
     }
 
-    public void setReceiveBufferSize(final int size) throws SocketException {
+    public synchronized void setReceiveBufferSize(final int size) throws SocketException {
         delegate.setReceiveBufferSize(size);
     }
 
-    public int getReceiveBufferSize() throws SocketException {
+    public synchronized int getReceiveBufferSize() throws SocketException {
         return delegate.getReceiveBufferSize();
     }
 


### PR DESCRIPTION
Solves JIRA issue ELY-2549.
Added the synchronized keyword to the appropriate methods in AbstractDelegatingSSLServerSocket to match the thread-safety contract of the parent java.net.ServerSocket class.

Note on testing: No new unit tests were added as this is just a thread-safety contract fix, and the existing test suite passes successfully.