### PR TITLE
[ELY-2837] Remove invalid @return tag from RegexRoleMapper.Builder Java doc

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/authz/RegexRoleMapper.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/authz/RegexRoleMapper.java
@@ -61,11 +61,8 @@ public class RegexRoleMapper implements RoleMapper {
     public Roles mapRoles(Roles rolesToMap) {
         return new RegexRoles(rolesToMap, this.pattern, this.replacement, this.keepNonMapped, this.replaceAll);
     }
-
     /**
      * Construct a new {@link Builder} for creating the {@link RegexRoleMapper}.
-     *
-     * @return a new {@link Builder} for creating the {@link RegexRoleMapper}.
      */
     public static class Builder {
         private String pattern;


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2837

- The Javadoc for RegexRoleMapper.Builder contained an invalid @return tag.
- The tag was used in class-level documentation, where @return is not allowed since it is only applicable to methods.

This change removes the invalid @return tag to resolve the Javadoc warning.

Verification:
mvn clean test
mvn javadoc:aggregate@full-javadoc

<img width="1177" height="1011" alt="Screenshot 2026-03-07 at 3 20 44 AM" src="https://github.com/user-attachments/assets/ce1ccf11-a78f-4449-a3c5-6f0e7e1853b8" />
