### PR TITLE
[ELY-3027] Fix synchronization issues and stale reverse mappings in LRURealmIdentityCache

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/cache/LRURealmIdentityCache.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/cache/LRURealmIdentityCache.java
@@ -23,12 +23,12 @@ import static org.wildfly.common.Assert.checkMinimumParameter;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.wildfly.security.auth.server.RealmIdentity;
 
@@ -47,15 +47,16 @@ public final class LRURealmIdentityCache implements RealmIdentityCache {
     /**
      * Holds the cached identitys where the key is the domain principal, the one used to lookup the identity
      */
-    private final Map<Principal, CacheEntry> identityCache;
+    private final LinkedHashMap<Principal, CacheEntry> identityCache;
 
     /**
      * Holds a mapping between a realm principal and domain principals
      */
     private final Map<Principal, Set<Principal>> domainPrincipalMap;
 
-    private final AtomicBoolean writing = new AtomicBoolean(false);
+    private final ReentrantLock lock = new ReentrantLock();
 
+    private final int maxEntries;
     private final long maxAge;
 
     /**
@@ -76,88 +77,87 @@ public final class LRURealmIdentityCache implements RealmIdentityCache {
     public LRURealmIdentityCache(int maxEntries, long maxAge) {
         checkMinimumParameter("maxEntries", 1, maxEntries);
         checkMinimumParameter("maxAge", -1, maxAge);
-        identityCache = new LinkedHashMap<Principal, CacheEntry>(16, DEFAULT_LOAD_FACTOR, true) {
-            @Override
-            protected boolean removeEldestEntry(Entry<Principal, CacheEntry> eldest) {
-                return identityCache.size()  > maxEntries;
-            }
-        };
+        identityCache = new LinkedHashMap<>(16, DEFAULT_LOAD_FACTOR, true);
         domainPrincipalMap = new HashMap<>(16);
+        this.maxEntries = maxEntries;
         this.maxAge = maxAge;
     }
 
     @Override
     public void put(Principal key, RealmIdentity newValue) {
+        lock.lock();
         try {
-            if (parkForWriteAndCheckInterrupt()) {
-                return;
+            CacheEntry entry = identityCache.get(key);
+
+            if (entry == null) {
+                entry = new CacheEntry(newValue, maxAge);
+                identityCache.put(key, entry);
             }
 
-            CacheEntry entry = identityCache.computeIfAbsent(key, principal -> {
-                domainPrincipalMap.computeIfAbsent(newValue.getRealmIdentityPrincipal(), principal1 -> {
-                    Set<Principal> principals = new HashSet<>();
-
-                    principals.add(key);
-
-                    return principals;
-                });
-                return new CacheEntry(key, newValue, maxAge);
-            });
-
-            if (entry != null) {
-                domainPrincipalMap.get(entry.value().getRealmIdentityPrincipal()).add(key);
-            }
+            domainPrincipalMap.computeIfAbsent(entry.value().getRealmIdentityPrincipal(), ignored -> new HashSet<>()).add(key);
+            evictIfNecessary();
         } finally {
-            writing.lazySet(false);
+            lock.unlock();
         }
     }
 
     @Override
     public RealmIdentity get(Principal key) {
-        if (parkForReadAndCheckInterrupt()) {
+        lock.lock();
+        try {
+            CacheEntry cached = identityCache.get(key);
+
+            if (cached != null) {
+                return removeIfExpired(cached);
+            }
+
+            Set<Principal> domainPrincipals = domainPrincipalMap.get(key);
+
+            if (domainPrincipals != null) {
+                for (Principal domainPrincipal : new HashSet<>(domainPrincipals)) {
+                    CacheEntry associated = identityCache.get(domainPrincipal);
+
+                    if (associated == null) {
+                        removeDomainPrincipal(domainPrincipal, key);
+                        continue;
+                    }
+
+                    return removeIfExpired(associated);
+                }
+            }
+
             return null;
+        } finally {
+            lock.unlock();
         }
-
-        CacheEntry cached = identityCache.get(key);
-
-        if (cached != null) {
-            return removeIfExpired(cached);
-        }
-
-        Set<Principal> domainPrincipal = domainPrincipalMap.get(key);
-
-        if (domainPrincipal != null) {
-            return removeIfExpired(identityCache.get(domainPrincipal.iterator().next()));
-        }
-
-        return null;
     }
 
     @Override
     public void remove(Principal key) {
+        lock.lock();
         try {
-            if (parkForWriteAndCheckInterrupt()) {
-                return;
-            }
+            CacheEntry cached = identityCache.get(key);
 
-            if (identityCache.containsKey(key)) {
-                domainPrincipalMap.remove(identityCache.remove(key).value().getRealmIdentityPrincipal()).forEach(identityCache::remove);
-            } else if (domainPrincipalMap.containsKey(key)) {
-                domainPrincipalMap.remove(key).forEach(identityCache::remove);
+            if (cached != null) {
+                if (! removeAllDomainPrincipals(cached.value().getRealmIdentityPrincipal())) {
+                    identityCache.remove(key);
+                }
+            } else {
+                removeAllDomainPrincipals(key);
             }
         } finally {
-            writing.lazySet(false);
+            lock.unlock();
         }
     }
 
     @Override
     public void clear() {
+        lock.lock();
         try {
-            parkForWriteAndCheckInterrupt();
             identityCache.clear();
             domainPrincipalMap.clear();
         } finally {
-            writing.lazySet(false);
+            lock.unlock();
         }
     }
 
@@ -167,51 +167,67 @@ public final class LRURealmIdentityCache implements RealmIdentityCache {
         }
 
         if (cached.isExpired()) {
-            remove(cached.key());
+            removeAllDomainPrincipals(cached.value().getRealmIdentityPrincipal());
             return null;
         }
 
         return cached.value();
     }
 
-    private boolean parkForWriteAndCheckInterrupt() {
-        while (!writing.compareAndSet(false, true)) {
-            LockSupport.parkNanos(1L);
-            if (Thread.interrupted()) {
-                return true;
+    private void evictIfNecessary() {
+        while (identityCache.size() > maxEntries) {
+            Iterator<Entry<Principal, CacheEntry>> iterator = identityCache.entrySet().iterator();
+
+            if (! iterator.hasNext()) {
+                return;
             }
+
+            Entry<Principal, CacheEntry> eldest = iterator.next();
+            iterator.remove();
+            removeDomainPrincipal(eldest.getKey(), eldest.getValue().value().getRealmIdentityPrincipal());
         }
-        return false;
     }
 
-    private boolean parkForReadAndCheckInterrupt() {
-        while (writing.get()) {
-            LockSupport.parkNanos(1L);
-            if (Thread.interrupted()) {
-                return true;
-            }
+    private boolean removeAllDomainPrincipals(Principal realmPrincipal) {
+        Set<Principal> domainPrincipals = domainPrincipalMap.remove(realmPrincipal);
+
+        if (domainPrincipals == null) {
+            return false;
         }
-        return false;
+
+        for (Principal domainPrincipal : domainPrincipals) {
+            identityCache.remove(domainPrincipal);
+        }
+
+        return true;
+    }
+
+    private void removeDomainPrincipal(Principal domainPrincipal, Principal realmPrincipal) {
+        Set<Principal> domainPrincipals = domainPrincipalMap.get(realmPrincipal);
+
+        if (domainPrincipals == null) {
+            return;
+        }
+
+        domainPrincipals.remove(domainPrincipal);
+
+        if (domainPrincipals.isEmpty()) {
+            domainPrincipalMap.remove(realmPrincipal);
+        }
     }
 
     private static final class CacheEntry {
 
-        final Principal key;
         final RealmIdentity value;
         final long expiration;
 
-        CacheEntry(Principal key, RealmIdentity value, long maxAge) {
-            this.key = key;
+        CacheEntry(RealmIdentity value, long maxAge) {
             this.value = value;
             if(maxAge == -1) {
                 expiration = -1;
             } else {
                 expiration = System.currentTimeMillis() + maxAge;
             }
-        }
-
-        Principal key() {
-            return key;
         }
 
         RealmIdentity value() {

--- a/auth/server/base/src/test/java/org/wildfly/security/auth/realm/cache/LRURealmIdentityCacheTest.java
+++ b/auth/server/base/src/test/java/org/wildfly/security/auth/realm/cache/LRURealmIdentityCacheTest.java
@@ -18,13 +18,26 @@
 
 package org.wildfly.security.auth.realm.cache;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
 import java.security.Principal;
 import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -157,11 +170,123 @@ public class LRURealmIdentityCacheTest {
         }
     }
 
+    @Test
+    public void testRemoveInvalidatesAllDomainPrincipalsForRealmIdentity() {
+        LRURealmIdentityCache cache = new LRURealmIdentityCache(5);
+        Principal realmPrincipal = createPrincipal(new LinkedList<>());
+        Principal firstDomainPrincipal = createPrincipal(new LinkedList<>());
+        Principal secondDomainPrincipal = createPrincipal(new LinkedList<>());
+
+        cache.put(firstDomainPrincipal, createRealmIdentity(realmPrincipal));
+        cache.put(secondDomainPrincipal, createRealmIdentity(realmPrincipal));
+
+        assertNotNull(cache.get(realmPrincipal));
+
+        cache.remove(firstDomainPrincipal);
+
+        assertNull(cache.get(firstDomainPrincipal));
+        assertNull(cache.get(secondDomainPrincipal));
+        assertNull(cache.get(realmPrincipal));
+    }
+
+    @Test
+    public void testMaxEntriesCleanupRealmPrincipalMapping() throws Exception {
+        LRURealmIdentityCache cache = new LRURealmIdentityCache(1);
+        Principal evictedRealmPrincipal = createPrincipal(new LinkedList<>());
+        Principal survivingRealmPrincipal = createPrincipal(new LinkedList<>());
+        Principal evictedDomainPrincipal = createPrincipal(new LinkedList<>());
+        Principal survivingDomainPrincipal = createPrincipal(new LinkedList<>());
+
+        cache.put(evictedDomainPrincipal, createRealmIdentity(evictedRealmPrincipal));
+        cache.put(survivingDomainPrincipal, createRealmIdentity(survivingRealmPrincipal));
+
+        assertFalse(getDomainPrincipalMap(cache).containsKey(evictedRealmPrincipal));
+        assertNull(cache.get(evictedDomainPrincipal));
+        assertNotNull(cache.get(survivingDomainPrincipal));
+        assertNotNull(cache.get(survivingRealmPrincipal));
+    }
+
+    @Test
+    public void testExpirationCleanupRealmPrincipalMapping() throws Exception {
+        LRURealmIdentityCache cache = new LRURealmIdentityCache(1, 1);
+        Principal realmPrincipal = createPrincipal(new LinkedList<>());
+        Principal domainPrincipal = createPrincipal(new LinkedList<>());
+
+        cache.put(domainPrincipal, createRealmIdentity(realmPrincipal));
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+
+        while (cache.get(domainPrincipal) != null && System.nanoTime() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(10);
+        }
+
+        assertNull(cache.get(domainPrincipal));
+        assertNull(cache.get(realmPrincipal));
+        assertFalse(getDomainPrincipalMap(cache).containsKey(realmPrincipal));
+    }
+
+    @Test
+    public void testConcurrentAccessMaintainsConsistentMappings() throws Exception {
+        LRURealmIdentityCache cache = new LRURealmIdentityCache(16);
+        List<Principal> domainPrincipals = new ArrayList<>();
+        List<Principal> realmPrincipals = new ArrayList<>();
+
+        for (int i = 0; i < 16; i++) {
+            domainPrincipals.add(createPrincipal(new LinkedList<>()));
+        }
+        for (int i = 0; i < 4; i++) {
+            realmPrincipals.add(createPrincipal(new LinkedList<>()));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int thread = 0; thread < 4; thread++) {
+                final int offset = thread;
+                futures.add(executor.submit(() -> {
+                    start.await();
+
+                    for (int i = 0; i < 250; i++) {
+                        int index = offset + ((i % 4) * 4);
+                        Principal domainPrincipal = domainPrincipals.get(index);
+                        Principal realmPrincipal = realmPrincipals.get(index % realmPrincipals.size());
+
+                        cache.put(domainPrincipal, createRealmIdentity(realmPrincipal));
+                        cache.get(domainPrincipal);
+                        cache.get(realmPrincipal);
+
+                        if ((i % 5) == 0) {
+                            cache.remove(domainPrincipal);
+                        }
+                    }
+
+                    return null;
+                }));
+            }
+
+            start.countDown();
+
+            for (Future<?> future : futures) {
+                future.get(10, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertMappingConsistency(cache);
+    }
+
     private RealmIdentity createRealmIdentity() {
+        return createRealmIdentity(null);
+    }
+
+    private RealmIdentity createRealmIdentity(Principal realmPrincipal) {
         return new RealmIdentity() {
             @Override
             public Principal getRealmIdentityPrincipal() {
-                return null;
+                return realmPrincipal;
             }
 
             @Override
@@ -189,5 +314,47 @@ public class LRURealmIdentityCacheTest {
                 return false;
             }
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Principal, Set<Principal>> getDomainPrincipalMap(LRURealmIdentityCache cache) throws Exception {
+        Field field = LRURealmIdentityCache.class.getDeclaredField("domainPrincipalMap");
+        field.setAccessible(true);
+        return (Map<Principal, Set<Principal>>) field.get(cache);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Principal, Object> getIdentityCache(LRURealmIdentityCache cache) throws Exception {
+        Field field = LRURealmIdentityCache.class.getDeclaredField("identityCache");
+        field.setAccessible(true);
+        return new HashMap<>((Map<Principal, Object>) field.get(cache));
+    }
+
+    private RealmIdentity getRealmIdentity(Object cacheEntry) throws Exception {
+        Field valueField = cacheEntry.getClass().getDeclaredField("value");
+        valueField.setAccessible(true);
+        return (RealmIdentity) valueField.get(cacheEntry);
+    }
+
+    private void assertMappingConsistency(LRURealmIdentityCache cache) throws Exception {
+        Map<Principal, Object> identityCache = getIdentityCache(cache);
+        Map<Principal, Set<Principal>> domainPrincipalMap = getDomainPrincipalMap(cache);
+
+        for (Map.Entry<Principal, Set<Principal>> mapping : domainPrincipalMap.entrySet()) {
+            for (Principal domainPrincipal : mapping.getValue()) {
+                Object cacheEntry = identityCache.get(domainPrincipal);
+
+                assertNotNull(cacheEntry);
+                assertSame(mapping.getKey(), getRealmIdentity(cacheEntry).getRealmIdentityPrincipal());
+            }
+        }
+
+        for (Map.Entry<Principal, Object> entry : identityCache.entrySet()) {
+            Principal realmPrincipal = getRealmIdentity(entry.getValue()).getRealmIdentityPrincipal();
+            Set<Principal> domainPrincipals = domainPrincipalMap.get(realmPrincipal);
+
+            assertNotNull(domainPrincipals);
+            assertTrue(domainPrincipals.contains(entry.getKey()));
+        }
     }
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ELY-3027

This fixes a couple of issues in LRURealmIdentityCache.

The cache was using an access-order LinkedHashMap, which means get() updates internal state, but that access was not properly synchronized. It also wasn’t fully cleaning up domainPrincipalMap when entries were evicted or expired, which could leave stale mappings behind.

This change adds proper locking around cache access, cleans up reverse mappings during eviction and expiry, and adds tests to cover those cases.