### PR TITLE
[ELY-2951] Add support for external account binding to the ACME client

### DIFF
--- a/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/Acme.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/Acme.java
@@ -54,6 +54,7 @@ public final class Acme {
     public static final String DETAIL = "detail";
     public static final String DNS = "dns";
     public static final String EXPONENT = "e";
+    public static final String EXTERNAL_ACCOUNT_BINDING = "externalAccountBinding";
     public static final String EXTERNAL_ACCOUNT_REQUIRED = "externalAccountRequired";
     public static final String FINALIZE = "finalize";
     public static final String IDENTIFIER = "identifier";

--- a/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeAccount.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeAccount.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import javax.security.auth.x500.X500Principal;
 
 import org.wildfly.common.Assert;
+import org.wildfly.common.iteration.CodePointIterator;
 import org.wildfly.security.asn1.ASN1Encodable;
 import org.wildfly.security.x500.X500;
 import org.wildfly.security.x500.X500AttributeTypeAndValue;
@@ -64,6 +65,8 @@ public final class AcmeAccount {
     private int keySize;
     private String keyAlgorithmName;
     private String accountUrl;
+    private String externalAccountBindingKeyIdentifier;
+    private byte[] externalAccountBindingKey;
     private HashMap<AcmeResource, URL> resourceUrls = new HashMap<>(AcmeResource.values().length);
     private HashMap<AcmeResource, URL> stagingResourceUrls = new HashMap<>(AcmeResource.values().length);
     private byte[] nonce;
@@ -80,6 +83,8 @@ public final class AcmeAccount {
         this.keySize = builder.keySize;
         this.keyAlgorithmName = builder.keyAlgorithmName;
         this.dn = builder.dn;
+        this.externalAccountBindingKeyIdentifier = builder.externalAccountBindingKeyIdentifier;
+        this.externalAccountBindingKey = builder.externalAccountBindingKey != null ? builder.externalAccountBindingKey.clone() : null;
     }
 
     /**
@@ -240,6 +245,33 @@ public final class AcmeAccount {
     }
 
     /**
+     * Get the external account binding key identifier (kid) supplied by the certificate authority.
+     *
+     * @return the external account binding key identifier or {@code null} if not configured
+     */
+    public String getExternalAccountBindingKeyIdentifier() {
+        return externalAccountBindingKeyIdentifier;
+    }
+
+    /**
+     * Get the external account binding HMAC key supplied by the certificate authority.
+     *
+     * @return the external account binding HMAC key or {@code null} if not configured
+     */
+    public byte[] getExternalAccountBindingKey() {
+        return externalAccountBindingKey != null ? externalAccountBindingKey.clone() : null;
+    }
+
+    /**
+     * Return whether external account binding credentials have been configured for this account.
+     *
+     * @return {@code true} if external account binding credentials have been configured and {@code false} otherwise
+     */
+    public boolean hasExternalAccountBinding() {
+        return externalAccountBindingKeyIdentifier != null && externalAccountBindingKey != null;
+    }
+
+    /**
      * Set the account location URL provided by the ACME server.
      *
      * @param accountUrl the account location URL (must not be {@code null})
@@ -347,6 +379,8 @@ public final class AcmeAccount {
         private int keySize = -1;
         private String algHeader;
         private String signatureAlgorithm;
+        private String externalAccountBindingKeyIdentifier;
+        private byte[] externalAccountBindingKey;
 
         /**
          * Construct a new uninitialized instance.
@@ -450,6 +484,33 @@ public final class AcmeAccount {
             this.certificate = certificate;
             this.privateKey = privateKey;
             return this;
+        }
+
+        /**
+         * Set the external account binding (EAB) credentials to use when registering this account.
+         *
+         * @param keyIdentifier the key identifier supplied by the certificate authority (must not be empty)
+         * @param hmacKey the HMAC key supplied by the certificate authority (must not be empty)
+         * @return this builder instance
+         */
+        public Builder setExternalAccountBinding(final String keyIdentifier, final byte[] hmacKey) {
+            Assert.checkNotEmptyParam("keyIdentifier", keyIdentifier);
+            Assert.checkNotEmptyParam("hmacKey", hmacKey);
+            this.externalAccountBindingKeyIdentifier = keyIdentifier;
+            this.externalAccountBindingKey = hmacKey.clone();
+            return this;
+        }
+
+        /**
+         * Set the external account binding (EAB) credentials to use when registering this account.
+         *
+         * @param keyIdentifier the key identifier supplied by the certificate authority (must not be empty)
+         * @param base64UrlEncodedHmacKey the base64url-encoded HMAC key supplied by the certificate authority (must not be empty)
+         * @return this builder instance
+         */
+        public Builder setExternalAccountBinding(final String keyIdentifier, final String base64UrlEncodedHmacKey) {
+            Assert.checkNotEmptyParam("base64UrlEncodedHmacKey", base64UrlEncodedHmacKey);
+            return setExternalAccountBinding(keyIdentifier, CodePointIterator.ofString(base64UrlEncodedHmacKey).base64Decode(Acme.BASE64_URL, false).drain());
         }
 
         /**

--- a/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeAccount.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeAccount.java
@@ -32,6 +32,7 @@ import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -66,7 +67,8 @@ public final class AcmeAccount {
     private String keyAlgorithmName;
     private String accountUrl;
     private String externalAccountBindingKeyIdentifier;
-    private byte[] externalAccountBindingKey;
+    private Supplier<byte[]> externalAccountBindingKeySupplier;
+    private ExternalAccountBindingAlgorithm externalAccountBindingAlgorithm;
     private HashMap<AcmeResource, URL> resourceUrls = new HashMap<>(AcmeResource.values().length);
     private HashMap<AcmeResource, URL> stagingResourceUrls = new HashMap<>(AcmeResource.values().length);
     private byte[] nonce;
@@ -84,7 +86,8 @@ public final class AcmeAccount {
         this.keyAlgorithmName = builder.keyAlgorithmName;
         this.dn = builder.dn;
         this.externalAccountBindingKeyIdentifier = builder.externalAccountBindingKeyIdentifier;
-        this.externalAccountBindingKey = builder.externalAccountBindingKey != null ? builder.externalAccountBindingKey.clone() : null;
+        this.externalAccountBindingKeySupplier = builder.externalAccountBindingKeySupplier;
+        this.externalAccountBindingAlgorithm = builder.externalAccountBindingAlgorithm;
     }
 
     /**
@@ -259,7 +262,23 @@ public final class AcmeAccount {
      * @return the external account binding HMAC key or {@code null} if not configured
      */
     public byte[] getExternalAccountBindingKey() {
-        return externalAccountBindingKey != null ? externalAccountBindingKey.clone() : null;
+        if (externalAccountBindingKeySupplier == null) {
+            return null;
+        }
+        byte[] externalAccountBindingKey = Assert.checkNotNullParam("externalAccountBindingKey",
+                externalAccountBindingKeySupplier.get());
+        Assert.checkMinimumParameter("externalAccountBindingKey.length",
+                externalAccountBindingAlgorithm.getMinimumKeySize(), externalAccountBindingKey.length);
+        return externalAccountBindingKey.clone();
+    }
+
+    /**
+     * Get the algorithm to use for external account binding.
+     *
+     * @return the external account binding algorithm
+     */
+    public ExternalAccountBindingAlgorithm getExternalAccountBindingAlgorithm() {
+        return externalAccountBindingAlgorithm;
     }
 
     /**
@@ -268,7 +287,7 @@ public final class AcmeAccount {
      * @return {@code true} if external account binding credentials have been configured and {@code false} otherwise
      */
     public boolean hasExternalAccountBinding() {
-        return externalAccountBindingKeyIdentifier != null && externalAccountBindingKey != null;
+        return externalAccountBindingKeyIdentifier != null && externalAccountBindingKeySupplier != null;
     }
 
     /**
@@ -349,6 +368,31 @@ public final class AcmeAccount {
         return new Builder();
     }
 
+    /**
+     * The HMAC algorithms supported for ACME external account binding.
+     */
+    public enum ExternalAccountBindingAlgorithm {
+        HS256("HmacSHA256", 32),
+        HS384("HmacSHA384", 48),
+        HS512("HmacSHA512", 64);
+
+        private final String macAlgorithmName;
+        private final int minimumKeySize;
+
+        ExternalAccountBindingAlgorithm(String macAlgorithmName, int minimumKeySize) {
+            this.macAlgorithmName = macAlgorithmName;
+            this.minimumKeySize = minimumKeySize;
+        }
+
+        String getMacAlgorithmName() {
+            return macAlgorithmName;
+        }
+
+        int getMinimumKeySize() {
+            return minimumKeySize;
+        }
+    }
+
     public static class Builder {
 
         /**
@@ -366,6 +410,11 @@ public final class AcmeAccount {
          */
         public static final int DEFAULT_ACCOUNT_EC_KEY_SIZE = 256;
 
+        /**
+         * The default external account binding algorithm.
+         */
+        public static final ExternalAccountBindingAlgorithm DEFAULT_EXTERNAL_ACCOUNT_BINDING_ALGORITHM = ExternalAccountBindingAlgorithm.HS256;
+
         static final String ACCOUNT_KEY_NAME = "account.key";
 
         private String[] contactUrls;
@@ -380,7 +429,8 @@ public final class AcmeAccount {
         private String algHeader;
         private String signatureAlgorithm;
         private String externalAccountBindingKeyIdentifier;
-        private byte[] externalAccountBindingKey;
+        private Supplier<byte[]> externalAccountBindingKeySupplier;
+        private ExternalAccountBindingAlgorithm externalAccountBindingAlgorithm = DEFAULT_EXTERNAL_ACCOUNT_BINDING_ALGORITHM;
 
         /**
          * Construct a new uninitialized instance.
@@ -490,14 +540,29 @@ public final class AcmeAccount {
          * Set the external account binding (EAB) credentials to use when registering this account.
          *
          * @param keyIdentifier the key identifier supplied by the certificate authority (must not be empty)
-         * @param hmacKey the HMAC key supplied by the certificate authority (must not be empty)
+         * @param hmacKey the HMAC key supplied by the certificate authority (must meet the minimum size for the selected algorithm)
          * @return this builder instance
          */
         public Builder setExternalAccountBinding(final String keyIdentifier, final byte[] hmacKey) {
             Assert.checkNotEmptyParam("keyIdentifier", keyIdentifier);
             Assert.checkNotEmptyParam("hmacKey", hmacKey);
+            Assert.checkMinimumParameter("hmacKey.length", externalAccountBindingAlgorithm.getMinimumKeySize(), hmacKey.length);
+            final byte[] copiedHmacKey = hmacKey.clone();
+            return setExternalAccountBinding(keyIdentifier, () -> copiedHmacKey.clone());
+        }
+
+        /**
+         * Set the external account binding (EAB) credentials to use when registering this account.
+         *
+         * @param keyIdentifier the key identifier supplied by the certificate authority (must not be empty)
+         * @param hmacKeySupplier the supplier for the HMAC key supplied by the certificate authority (must not be {@code null})
+         * @return this builder instance
+         */
+        public Builder setExternalAccountBinding(final String keyIdentifier, final Supplier<byte[]> hmacKeySupplier) {
+            Assert.checkNotEmptyParam("keyIdentifier", keyIdentifier);
+            Assert.checkNotNullParam("hmacKeySupplier", hmacKeySupplier);
             this.externalAccountBindingKeyIdentifier = keyIdentifier;
-            this.externalAccountBindingKey = hmacKey.clone();
+            this.externalAccountBindingKeySupplier = hmacKeySupplier;
             return this;
         }
 
@@ -511,6 +576,18 @@ public final class AcmeAccount {
         public Builder setExternalAccountBinding(final String keyIdentifier, final String base64UrlEncodedHmacKey) {
             Assert.checkNotEmptyParam("base64UrlEncodedHmacKey", base64UrlEncodedHmacKey);
             return setExternalAccountBinding(keyIdentifier, CodePointIterator.ofString(base64UrlEncodedHmacKey).base64Decode(Acme.BASE64_URL, false).drain());
+        }
+
+        /**
+         * Set the HMAC algorithm to use for external account binding. The default is {@link ExternalAccountBindingAlgorithm#HS256}.
+         *
+         * @param externalAccountBindingAlgorithm the external account binding algorithm (must not be {@code null})
+         * @return this builder instance
+         */
+        public Builder setExternalAccountBindingAlgorithm(final ExternalAccountBindingAlgorithm externalAccountBindingAlgorithm) {
+            this.externalAccountBindingAlgorithm = Assert.checkNotNullParam("externalAccountBindingAlgorithm",
+                    externalAccountBindingAlgorithm);
+            return this;
         }
 
         /**

--- a/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
@@ -170,8 +170,6 @@ public abstract class AcmeClientSpi {
     private static final long DEFAULT_RETRY_AFTER_MILLI = 3000;
     private static final int[] CONTENT_TYPE_DELIMS = new int[] {';', '='};
     private static final String CHARSET = "charset";
-    private static final String HMAC_SHA256 = "HmacSHA256";
-    private static final String HS256 = "HS256";
     private static final String UTF_8 = "utf-8";
     private static final String USER_AGENT_STRING = "Elytron ACME Client/" + Version.getVersion();
 
@@ -291,9 +289,9 @@ public abstract class AcmeClientSpi {
                 }
                 payloadBuilder.add(CONTACT, contactBuilder.build());
             }
-        }
-        if (account.hasExternalAccountBinding()) {
-            payloadBuilder.add(EXTERNAL_ACCOUNT_BINDING, getExternalAccountBinding(account, newAccountUrl));
+            if (account.hasExternalAccountBinding()) {
+                payloadBuilder.add(EXTERNAL_ACCOUNT_BINDING, getExternalAccountBinding(account, newAccountUrl));
+            }
         }
 
         HttpURLConnection connection = sendPostRequestWithRetries(account, staging, newAccountUrl, true,
@@ -1050,9 +1048,10 @@ public abstract class AcmeClientSpi {
         return getEncodedJson(protectedHeader);
     }
 
-    private static String getEncodedExternalAccountBindingProtectedHeader(String keyIdentifier, String resourceUrl) {
+    private static String getEncodedExternalAccountBindingProtectedHeader(String keyIdentifier,
+            AcmeAccount.ExternalAccountBindingAlgorithm algorithm, String resourceUrl) {
         JsonObject protectedHeader = Json.createObjectBuilder()
-                .add(ALG, HS256)
+                .add(ALG, algorithm.name())
                 .add(KID, keyIdentifier)
                 .add(URL, resourceUrl)
                 .build();
@@ -1118,10 +1117,11 @@ public abstract class AcmeClientSpi {
         }
     }
 
-    private static String getEncodedMacSignature(byte[] key, String encodedProtectedHeader, String encodedPayload) throws AcmeException {
+    private static String getEncodedMacSignature(byte[] key, String algorithm, String encodedProtectedHeader,
+            String encodedPayload) throws AcmeException {
         try {
-            Mac mac = Mac.getInstance(HMAC_SHA256);
-            mac.init(new SecretKeySpec(key, HMAC_SHA256));
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(new SecretKeySpec(key, algorithm));
             return base64UrlEncode(mac.doFinal((encodedProtectedHeader + "." + encodedPayload).getBytes(StandardCharsets.UTF_8)));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw acme.unableToCreateAcmeSignature(e);
@@ -1145,9 +1145,12 @@ public abstract class AcmeClientSpi {
      * Build the nested JWS object required for external account binding during account creation.
      */
     private static JsonObject getExternalAccountBinding(AcmeAccount account, String newAccountUrl) throws AcmeException {
-        final String encodedProtectedHeader = getEncodedExternalAccountBindingProtectedHeader(account.getExternalAccountBindingKeyIdentifier(), newAccountUrl);
+        final AcmeAccount.ExternalAccountBindingAlgorithm algorithm = account.getExternalAccountBindingAlgorithm();
+        final String encodedProtectedHeader = getEncodedExternalAccountBindingProtectedHeader(
+                account.getExternalAccountBindingKeyIdentifier(), algorithm, newAccountUrl);
         final String encodedPayload = getEncodedJson(getJwk(account.getPublicKey(), account.getAlgHeader()));
-        final String encodedSignature = getEncodedMacSignature(account.getExternalAccountBindingKey(), encodedProtectedHeader, encodedPayload);
+        final String encodedSignature = getEncodedMacSignature(account.getExternalAccountBindingKey(),
+                algorithm.getMacAlgorithmName(), encodedProtectedHeader, encodedPayload);
         return getJws(encodedProtectedHeader, encodedPayload, encodedSignature);
     }
 

--- a/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/x500/cert/acme/AcmeClientSpi.java
@@ -34,6 +34,7 @@ import static org.wildfly.security.x500.cert.acme.Acme.CSR;
 import static org.wildfly.security.x500.cert.acme.Acme.DEACTIVATED;
 import static org.wildfly.security.x500.cert.acme.Acme.DETAIL;
 import static org.wildfly.security.x500.cert.acme.Acme.DNS;
+import static org.wildfly.security.x500.cert.acme.Acme.EXTERNAL_ACCOUNT_BINDING;
 import static org.wildfly.security.x500.cert.acme.Acme.EXTERNAL_ACCOUNT_REQUIRED;
 import static org.wildfly.security.x500.cert.acme.Acme.FINALIZE;
 import static org.wildfly.security.x500.cert.acme.Acme.GET;
@@ -123,6 +124,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.x500.X500Principal;
 
 import org.wildfly.common.Assert;
@@ -167,6 +170,8 @@ public abstract class AcmeClientSpi {
     private static final long DEFAULT_RETRY_AFTER_MILLI = 3000;
     private static final int[] CONTENT_TYPE_DELIMS = new int[] {';', '='};
     private static final String CHARSET = "charset";
+    private static final String HMAC_SHA256 = "HmacSHA256";
+    private static final String HS256 = "HS256";
     private static final String UTF_8 = "utf-8";
     private static final String USER_AGENT_STRING = "Elytron ACME Client/" + Version.getVersion();
 
@@ -286,6 +291,9 @@ public abstract class AcmeClientSpi {
                 }
                 payloadBuilder.add(CONTACT, contactBuilder.build());
             }
+        }
+        if (account.hasExternalAccountBinding()) {
+            payloadBuilder.add(EXTERNAL_ACCOUNT_BINDING, getExternalAccountBinding(account, newAccountUrl));
         }
 
         HttpURLConnection connection = sendPostRequestWithRetries(account, staging, newAccountUrl, true,
@@ -1042,6 +1050,15 @@ public abstract class AcmeClientSpi {
         return getEncodedJson(protectedHeader);
     }
 
+    private static String getEncodedExternalAccountBindingProtectedHeader(String keyIdentifier, String resourceUrl) {
+        JsonObject protectedHeader = Json.createObjectBuilder()
+                .add(ALG, HS256)
+                .add(KID, keyIdentifier)
+                .add(URL, resourceUrl)
+                .build();
+        return getEncodedJson(protectedHeader);
+    }
+
     private String getEncodedProtectedHeader(boolean useJwk, String resourceUrl, AcmeAccount account, boolean staging) throws AcmeException {
         JsonObjectBuilder protectedHeaderBuilder = Json.createObjectBuilder().add(ALG, account.getAlgHeader());
         if (useJwk) {
@@ -1101,6 +1118,16 @@ public abstract class AcmeClientSpi {
         }
     }
 
+    private static String getEncodedMacSignature(byte[] key, String encodedProtectedHeader, String encodedPayload) throws AcmeException {
+        try {
+            Mac mac = Mac.getInstance(HMAC_SHA256);
+            mac.init(new SecretKeySpec(key, HMAC_SHA256));
+            return base64UrlEncode(mac.doFinal((encodedProtectedHeader + "." + encodedPayload).getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw acme.unableToCreateAcmeSignature(e);
+        }
+    }
+
     private static int getECSignatureByteLength(String signatureAlgorithm) throws AcmeException {
         switch(signatureAlgorithm) {
             case "SHA256withECDSA":
@@ -1112,6 +1139,16 @@ public abstract class AcmeClientSpi {
             default:
                 throw acme.unsupportedAcmeAccountSignatureAlgorithm(signatureAlgorithm);
         }
+    }
+
+    /**
+     * Build the nested JWS object required for external account binding during account creation.
+     */
+    private static JsonObject getExternalAccountBinding(AcmeAccount account, String newAccountUrl) throws AcmeException {
+        final String encodedProtectedHeader = getEncodedExternalAccountBindingProtectedHeader(account.getExternalAccountBindingKeyIdentifier(), newAccountUrl);
+        final String encodedPayload = getEncodedJson(getJwk(account.getPublicKey(), account.getAlgHeader()));
+        final String encodedSignature = getEncodedMacSignature(account.getExternalAccountBindingKey(), encodedProtectedHeader, encodedPayload);
+        return getJws(encodedProtectedHeader, encodedPayload, encodedSignature);
     }
 
     private byte[] getNonce(AcmeAccount account, boolean staging) throws AcmeException {

--- a/x500/cert/acme/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/x500/cert/acme/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -71,6 +71,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -210,17 +211,42 @@ public class AcmeClientSpiTest {
 
     @Test
     public void testCreateAccountWithExternalAccountBinding() throws Exception {
+        assertCreateAccountWithExternalAccountBinding(AcmeAccount.ExternalAccountBindingAlgorithm.HS256);
+    }
+
+    @Test
+    public void testCreateAccountWithExternalAccountBindingUsingSha512() throws Exception {
+        assertCreateAccountWithExternalAccountBinding(AcmeAccount.ExternalAccountBindingAlgorithm.HS512);
+    }
+
+    @Test
+    public void testCreateAccountWithExternalAccountBindingUsingSha384() throws Exception {
+        assertCreateAccountWithExternalAccountBinding(AcmeAccount.ExternalAccountBindingAlgorithm.HS384);
+    }
+
+    private void assertCreateAccountWithExternalAccountBinding(
+            AcmeAccount.ExternalAccountBindingAlgorithm externalAccountBindingAlgorithm) throws Exception {
         final String NEW_ACCT_LOCATION = "http://localhost:4001/acme/acct/390";
         final String NEW_ACCT_URL = "http://localhost:4001/acme/new-acct";
+        final byte[] externalAccountBindingKey = new byte[externalAccountBindingAlgorithm.getMinimumKeySize()];
+        final AtomicInteger keySupplierInvocations = new AtomicInteger();
 
-        AcmeAccount account = populateBasicBuilder()
+        AcmeAccount.Builder accountBuilder = populateBasicBuilder()
                 .setKey(aliasToCertificateMap.get(ACCOUNT_1_V2), aliasToPrivateKeyMap.get(ACCOUNT_1_V2))
-                .setExternalAccountBinding("sectigo-account-123", "bWFjLXNlY3JldA")
-                .build();
+                .setExternalAccountBinding("sectigo-account-123", () -> {
+                    keySupplierInvocations.incrementAndGet();
+                    return externalAccountBindingKey;
+                });
+        if (externalAccountBindingAlgorithm != AcmeAccount.Builder.DEFAULT_EXTERNAL_ACCOUNT_BINDING_ALGORITHM) {
+            accountBuilder.setExternalAccountBindingAlgorithm(externalAccountBindingAlgorithm);
+        }
+        AcmeAccount account = accountBuilder.build();
         server = setupTestCreateAccountWithExternalAccountBinding();
 
         assertNull(account.getAccountUrl());
+        assertEquals(0, keySupplierInvocations.get());
         acmeClient.createAccount(account, false);
+        assertEquals(1, keySupplierInvocations.get());
         assertEquals(NEW_ACCT_LOCATION, account.getAccountUrl());
 
         // Inspect the recorded request instead of reconstructing the outer JWS in the test.
@@ -235,14 +261,34 @@ public class AcmeClientSpiTest {
         assertEquals(account.getContactUrls()[0], outerPayload.getJsonArray(CONTACT).getString(0));
 
         JsonObject externalAccountBindingProtectedHeader = decodeJson(externalAccountBinding.getString(PROTECTED));
-        assertEquals("HS256", externalAccountBindingProtectedHeader.getString(ALG));
+        assertEquals(externalAccountBindingAlgorithm.name(), externalAccountBindingProtectedHeader.getString(ALG));
         assertEquals(account.getExternalAccountBindingKeyIdentifier(), externalAccountBindingProtectedHeader.getString(KID));
         assertEquals(NEW_ACCT_URL, externalAccountBindingProtectedHeader.getString(URL));
         assertEquals(Acme.getJwk(account.getPublicKey(), account.getAlgHeader()),
                 decodeJson(externalAccountBinding.getString(PAYLOAD)));
-        assertEquals(getEncodedMacSignature(account.getExternalAccountBindingKey(),
+        assertEquals(getEncodedMacSignature(externalAccountBindingKey,
+                        externalAccountBindingAlgorithm.getMacAlgorithmName(),
                         externalAccountBinding.getString(PROTECTED), externalAccountBinding.getString(PAYLOAD)),
                 externalAccountBinding.getString(SIGNATURE));
+    }
+
+    @Test
+    public void testExternalAccountBindingRejectsUndersizedKeys() throws Exception {
+        try {
+            populateBasicBuilder().setExternalAccountBinding("key-identifier", new byte[15]);
+            fail("Expected IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException expected) {
+        }
+
+        AcmeAccount account = populateBasicBuilder()
+                .setKey(aliasToCertificateMap.get(ACCOUNT_1_V2), aliasToPrivateKeyMap.get(ACCOUNT_1_V2))
+                .setExternalAccountBinding("key-identifier", () -> new byte[31])
+                .build();
+        try {
+            account.getExternalAccountBindingKey();
+            fail("Expected IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException expected) {
+        }
     }
 
     @Test
@@ -252,7 +298,13 @@ public class AcmeClientSpiTest {
         AcmeAccount account = populateBasicAccount(ACCOUNT_2_V2);
         acmeClient.createAccount(account, false);
         assertEquals(NEW_ACCT_LOCATION_1, account.getAccountUrl());
-        AcmeAccount sameAccount = populateBasicAccount(ACCOUNT_2_V2);
+        AcmeAccount sameAccount = populateBasicBuilder()
+                .setKey(aliasToCertificateMap.get(ACCOUNT_2_V2), aliasToPrivateKeyMap.get(ACCOUNT_2_V2))
+                .setExternalAccountBinding("unused-key-identifier", () -> {
+                    fail("The external account binding key must not be requested when onlyReturnExisting is true");
+                    return new byte[AcmeAccount.ExternalAccountBindingAlgorithm.HS256.getMinimumKeySize()];
+                })
+                .build();
 
         // the key corresponding to ACCOUNT_2 is associated with an already registered account
         acmeClient.createAccount(sameAccount, false, true);
@@ -2513,19 +2565,16 @@ public class AcmeClientSpiTest {
         return account;
     }
 
-    private static String getEncodedJson(JsonObject jsonObject) {
-        return CodePointIterator.ofString(jsonObject.toString()).asUtf8().base64Encode(BASE64_URL, false).drainToString();
-    }
-
     private static JsonObject decodeJson(String encodedJson) {
         String decodedJson = new String(CodePointIterator.ofString(encodedJson).base64Decode(BASE64_URL, false).drain(),
                 StandardCharsets.UTF_8);
         return Json.createReader(new StringReader(decodedJson)).readObject();
     }
 
-    private static String getEncodedMacSignature(byte[] key, String encodedProtectedHeader, String encodedPayload) throws Exception {
-        Mac mac = Mac.getInstance("HmacSHA256");
-        mac.init(new SecretKeySpec(key, "HmacSHA256"));
+    private static String getEncodedMacSignature(byte[] key, String algorithm, String encodedProtectedHeader,
+            String encodedPayload) throws Exception {
+        Mac mac = Mac.getInstance(algorithm);
+        mac.init(new SecretKeySpec(key, algorithm));
         return ByteIterator.ofBytes(mac.doFinal((encodedProtectedHeader + "." + encodedPayload).getBytes(StandardCharsets.UTF_8)))
                 .base64Encode(BASE64_URL, false)
                 .drainToString();

--- a/x500/cert/acme/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
+++ b/x500/cert/acme/src/test/java/org/wildfly/security/x500/cert/acme/AcmeClientSpiTest.java
@@ -29,9 +29,20 @@ import static org.junit.Assert.fail;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.wildfly.security.x500.cert.acme.Acme.ACCOUNT;
+import static org.wildfly.security.x500.cert.acme.Acme.ALG;
 import static org.wildfly.security.x500.cert.acme.Acme.BASE64_URL;
+import static org.wildfly.security.x500.cert.acme.Acme.CONTACT;
+import static org.wildfly.security.x500.cert.acme.Acme.EXTERNAL_ACCOUNT_BINDING;
+import static org.wildfly.security.x500.cert.acme.Acme.KID;
 import static org.wildfly.security.x500.cert.acme.Acme.ORDER;
+import static org.wildfly.security.x500.cert.acme.Acme.PAYLOAD;
+import static org.wildfly.security.x500.cert.acme.Acme.PROTECTED;
+import static org.wildfly.security.x500.cert.acme.Acme.SIGNATURE;
+import static org.wildfly.security.x500.cert.acme.Acme.TERMS_OF_SERVICE_AGREED;
+import static org.wildfly.security.x500.cert.acme.Acme.URL;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -47,6 +58,7 @@ import org.wildfly.security.x500.cert.X509CertificateChainAndSigningKey;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -60,6 +72,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import javax.security.auth.x500.X500Principal;
 
 import mockit.Mock;
@@ -192,6 +206,43 @@ public class AcmeClientSpiTest {
         } catch(AcmeException e) {
             assertTrue(e.getMessage().contains(ACCOUNT));
         }
+    }
+
+    @Test
+    public void testCreateAccountWithExternalAccountBinding() throws Exception {
+        final String NEW_ACCT_LOCATION = "http://localhost:4001/acme/acct/390";
+        final String NEW_ACCT_URL = "http://localhost:4001/acme/new-acct";
+
+        AcmeAccount account = populateBasicBuilder()
+                .setKey(aliasToCertificateMap.get(ACCOUNT_1_V2), aliasToPrivateKeyMap.get(ACCOUNT_1_V2))
+                .setExternalAccountBinding("sectigo-account-123", "bWFjLXNlY3JldA")
+                .build();
+        server = setupTestCreateAccountWithExternalAccountBinding();
+
+        assertNull(account.getAccountUrl());
+        acmeClient.createAccount(account, false);
+        assertEquals(NEW_ACCT_LOCATION, account.getAccountUrl());
+
+        // Inspect the recorded request instead of reconstructing the outer JWS in the test.
+        HttpRequest[] recordedRequests = server.retrieveRecordedRequests(request().withMethod("POST").withPath("/acme/new-acct"));
+        assertEquals(1, recordedRequests.length);
+
+        JsonObject outerJws = Json.createReader(new StringReader(recordedRequests[0].getBodyAsString())).readObject();
+        JsonObject outerPayload = decodeJson(outerJws.getString(PAYLOAD));
+        JsonObject externalAccountBinding = outerPayload.getJsonObject(EXTERNAL_ACCOUNT_BINDING);
+        assertNotNull(externalAccountBinding);
+        assertTrue(outerPayload.getBoolean(TERMS_OF_SERVICE_AGREED));
+        assertEquals(account.getContactUrls()[0], outerPayload.getJsonArray(CONTACT).getString(0));
+
+        JsonObject externalAccountBindingProtectedHeader = decodeJson(externalAccountBinding.getString(PROTECTED));
+        assertEquals("HS256", externalAccountBindingProtectedHeader.getString(ALG));
+        assertEquals(account.getExternalAccountBindingKeyIdentifier(), externalAccountBindingProtectedHeader.getString(KID));
+        assertEquals(NEW_ACCT_URL, externalAccountBindingProtectedHeader.getString(URL));
+        assertEquals(Acme.getJwk(account.getPublicKey(), account.getAlgHeader()),
+                decodeJson(externalAccountBinding.getString(PAYLOAD)));
+        assertEquals(getEncodedMacSignature(account.getExternalAccountBindingKey(),
+                        externalAccountBinding.getString(PROTECTED), externalAccountBinding.getString(PAYLOAD)),
+                externalAccountBinding.getString(SIGNATURE));
     }
 
     @Test
@@ -868,6 +919,50 @@ public class AcmeClientSpiTest {
                 .addDirectoryResponseBody(DIRECTORY_RESPONSE_BODY_3)
                 .addNewNonceResponse(NEW_NONCE_RESPONSE_3)
                 .addNewAccountRequestAndResponse(NEW_ACCT_REQUEST_BODY_3, NEW_ACCT_RESPONSE_BODY_3, NEW_ACCT_REPLAY_NONCE_3, NEW_ACCT_LOCATION_3, 400, true)
+                .build();
+    }
+
+    private ClientAndServer setupTestCreateAccountWithExternalAccountBinding() {
+        final String DIRECTORY_RESPONSE_BODY = "{" + System.lineSeparator()  +
+                "  \"DYeab-sWdw0\": \"https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417\"," + System.lineSeparator()  +
+                "  \"keyChange\": \"http://localhost:4001/acme/key-change\"," + System.lineSeparator()  +
+                "  \"meta\": {" + System.lineSeparator()  +
+                "    \"caaIdentities\": [" + System.lineSeparator()  +
+                "      \"happy-hacker-ca.invalid\"" + System.lineSeparator()  +
+                "    ]," + System.lineSeparator()  +
+                "    \"termsOfService\": \"https://boulder:4431/terms/v7\"," + System.lineSeparator()  +
+                "    \"website\": \"https://github.com/letsencrypt/boulder\"," + System.lineSeparator()  +
+                "    \"externalAccountRequired\": true" + System.lineSeparator()  +
+                "  }," + System.lineSeparator()  +
+                "  \"newAccount\": \"http://localhost:4001/acme/new-acct\"," + System.lineSeparator()  +
+                "  \"newNonce\": \"http://localhost:4001/acme/new-nonce\"," + System.lineSeparator()  +
+                "  \"newOrder\": \"http://localhost:4001/acme/new-order\"," + System.lineSeparator()  +
+                "  \"revokeCert\": \"http://localhost:4001/acme/revoke-cert\"" + System.lineSeparator()  +
+                "}";
+
+        final String NEW_NONCE_RESPONSE = "zincnmsv_eabBindingNonceSIbH0iPBrs1nJQ3Jkx";
+
+        final String NEW_ACCT_RESPONSE_BODY = "{" + System.lineSeparator()  +
+                "  \"key\": {" + System.lineSeparator()  +
+                "    \"kty\": \"RSA\"," + System.lineSeparator()  +
+                "    \"n\": \"h8Oee5beDRgxNPe_eME9H6Vo74Fug8HgrikfbfCaU3lKF648QG1X1kGDZThAy8daqJ8bv6c3PJdnx2Hr8jOzl509bnM6cCWfywTpcIZoUzQQZLY_K8GMDAyglsQrItgCiQalIqbuJEkoc3WQAIxJ23xv9bK5xnVQkTW4rVBAcYNQwoBjGYOWSizTGfjgmQqTXloaamFZJn97Hnb1qjy5VYm06buyqwAaGHs1CLu3cLZgQpVHQ4kFszk8YO5UAEjiodugWpZURu9TtRKzN0bkEdeQPYVpaupUq1cq47Rp2jqVUXdiQLekyxrQbt8A2uG4LzDQu-b4cZppmzc3hlhSGw\"," + System.lineSeparator()  +
+                "    \"e\": \"AQAB\"" + System.lineSeparator()  +
+                "  }," + System.lineSeparator()  +
+                "  \"contact\": [" + System.lineSeparator()  +
+                "    \"mailto:admin@anexample.com\"" + System.lineSeparator()  +
+                "  ]," + System.lineSeparator()  +
+                "  \"initialIp\": \"10.77.77.1\"," + System.lineSeparator()  +
+                "  \"createdAt\": \"2019-07-12T16:52:19.171896513Z\"," + System.lineSeparator()  +
+                "  \"status\": \"valid\"" + System.lineSeparator()  +
+                "}";
+
+        final String NEW_ACCT_REPLAY_NONCE = "taroeabReplayNoncenG4pbkz9ZIfFAxFcw1xSWWm4m";
+        final String NEW_ACCT_LOCATION = "http://localhost:4001/acme/acct/390";
+
+        return new AcmeMockServerBuilder(server)
+                .addDirectoryResponseBody(DIRECTORY_RESPONSE_BODY)
+                .addNewNonceResponse(NEW_NONCE_RESPONSE)
+                .addNewAccountRequestAndResponse("", NEW_ACCT_RESPONSE_BODY, NEW_ACCT_REPLAY_NONCE, NEW_ACCT_LOCATION, 201)
                 .build();
     }
 
@@ -2416,5 +2511,23 @@ public class AcmeClientSpiTest {
                 .setKey(aliasToCertificateMap.get(alias), aliasToPrivateKeyMap.get(alias))
                 .build();
         return account;
+    }
+
+    private static String getEncodedJson(JsonObject jsonObject) {
+        return CodePointIterator.ofString(jsonObject.toString()).asUtf8().base64Encode(BASE64_URL, false).drainToString();
+    }
+
+    private static JsonObject decodeJson(String encodedJson) {
+        String decodedJson = new String(CodePointIterator.ofString(encodedJson).base64Decode(BASE64_URL, false).drain(),
+                StandardCharsets.UTF_8);
+        return Json.createReader(new StringReader(decodedJson)).readObject();
+    }
+
+    private static String getEncodedMacSignature(byte[] key, String encodedProtectedHeader, String encodedPayload) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(key, "HmacSHA256"));
+        return ByteIterator.ofBytes(mac.doFinal((encodedProtectedHeader + "." + encodedPayload).getBytes(StandardCharsets.UTF_8)))
+                .base64Encode(BASE64_URL, false)
+                .drainToString();
     }
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ELY-2951

This adds support for external account binding (EAB) when creating ACME accounts.

The change lets `AcmeAccount` carry the EAB credentials provided by the CA, updates the `newAccount` request to include the RFC 8555 `externalAccountBinding` object, and adds a test that checks the actual request sent by the client.
