### PR TITLE
[ELY-3021] Add test for DynamicSSLContext which uses hostnames and not ports

### DIFF
--- a/dynamic-ssl/src/test/java/org/wildfly/security/dynamic/ssl/DynamicSSLContextTest.java
+++ b/dynamic-ssl/src/test/java/org/wildfly/security/dynamic/ssl/DynamicSSLContextTest.java
@@ -64,6 +64,9 @@ public class DynamicSSLContextTest {
     private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10001;
     private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10002;
     private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10003;
+    private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10005;
+    private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10006;
+    private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10007;
     private static org.wildfly.security.dynamic.ssl.SSLServerSocketTestInstance sslServerSocketTestInstancePort10000Default;
 
     @BeforeClass
@@ -72,11 +75,17 @@ public class DynamicSSLContextTest {
         sslServerSocketTestInstancePort10001 = new SSLServerSocketTestInstance(RESOURCES + "server1.keystore.jks", RESOURCES + "server1.truststore.jks", 10001);
         sslServerSocketTestInstancePort10002 = new SSLServerSocketTestInstance(RESOURCES + "server2.keystore.jks", RESOURCES + "server2.truststore.jks", 10002);
         sslServerSocketTestInstancePort10003 = new SSLServerSocketTestInstance(RESOURCES + "server3.keystore.jks", RESOURCES + "server3.truststore.jks", 10003);
+        sslServerSocketTestInstancePort10005 = new SSLServerSocketTestInstance(RESOURCES + "server1-host.keystore.jks", RESOURCES + "server1-host.truststore.jks", 10005);
+        sslServerSocketTestInstancePort10006 = new SSLServerSocketTestInstance(RESOURCES + "server2-host.keystore.jks", RESOURCES + "server2-host.truststore.jks", 10006);
+        sslServerSocketTestInstancePort10007 = new SSLServerSocketTestInstance(RESOURCES + "server3-host.keystore.jks", RESOURCES + "server3-host.truststore.jks", 10007);
         sslServerSocketTestInstancePort10000Default = new SSLServerSocketTestInstance(RESOURCES + "default-server.keystore.jks", RESOURCES + "default-server.truststore.jks", 10000);
 
         sslServerSocketTestInstancePort10001.run();
         sslServerSocketTestInstancePort10002.run();
         sslServerSocketTestInstancePort10003.run();
+        sslServerSocketTestInstancePort10005.run();
+        sslServerSocketTestInstancePort10006.run();
+        sslServerSocketTestInstancePort10007.run();
         sslServerSocketTestInstancePort10000Default.run();
     }
 
@@ -85,6 +94,9 @@ public class DynamicSSLContextTest {
         sslServerSocketTestInstancePort10001.stop();
         sslServerSocketTestInstancePort10002.stop();
         sslServerSocketTestInstancePort10003.stop();
+        sslServerSocketTestInstancePort10005.stop();
+        sslServerSocketTestInstancePort10006.stop();
+        sslServerSocketTestInstancePort10007.stop();
         sslServerSocketTestInstancePort10000Default.stop();
         org.wildfly.security.dynamic.ssl.DynamicSSLTestUtils.deleteKeystores();
     }
@@ -459,4 +471,61 @@ public class DynamicSSLContextTest {
             }
         });
     }
+
+    @Test
+    public void testChangingAuthenticationContextsWithHostnameMatching() throws NoSuchAlgorithmException {
+
+        DynamicSSLContext dynamicSSLContext = new DynamicSSLContext();
+        SSLSocketFactory socketFactory = dynamicSSLContext.getSocketFactory();
+
+        AuthenticationContext.empty().withSsl(MatchRule.ALL.matchHost("server1.example.com"),
+                () -> DynamicSSLTestUtils.createSSLContext(RESOURCES + "client1-host.keystore.jks", RESOURCES + "client1-host.truststore.jks", "Elytron")).run(() -> {
+            try {
+                Socket plainSocket = new Socket();
+                plainSocket.connect(new InetSocketAddress("localhost", 10005));
+                SSLSocket sslSocket = (SSLSocket) socketFactory.createSocket(plainSocket, "server1.example.com", 10005, true);
+                sslSocket.setReuseAddress(true);
+                checkOutputIsOK(sslSocket);
+                sslSocket.close();
+            } catch (Exception e) {
+                Assert.assertEquals("fine", e.getMessage());
+            }
+        });
+
+
+        AuthenticationContext.empty().withSsl(MatchRule.ALL.matchHost("server2.example.com"),
+                () -> DynamicSSLTestUtils.createSSLContext(RESOURCES + "client2-host.keystore.jks", RESOURCES + "client2-host.truststore.jks", "Elytron")).run(() -> {
+            try {
+                Socket plainSocket = new Socket();
+                plainSocket.connect(new InetSocketAddress("localhost", 10006));
+                SSLSocket sslSocket = (SSLSocket) socketFactory.createSocket(plainSocket, "server2.example.com", 10006, true);
+                sslSocket.setReuseAddress(true);
+                checkOutputIsOK(sslSocket);
+                sslSocket.close();
+            } catch (Exception e) {
+                Assert.assertEquals("fine", e.getMessage());
+            }
+        });
+
+
+        AuthenticationContext.empty().withSsl(MatchRule.ALL.matchHost("server3.example.com"),
+                () -> DynamicSSLTestUtils.createSSLContext(RESOURCES + "client3-host.keystore.jks", RESOURCES + "client3-host.truststore.jks", "Elytron")).run(() -> {
+            try {
+                Socket plainSocket = new Socket();
+                plainSocket.connect(new InetSocketAddress("localhost", 10007));
+                SSLSocket sslSocket = (SSLSocket) socketFactory.createSocket(plainSocket, "server3.example.com", 10007, true);
+                sslSocket.setReuseAddress(true);
+                checkOutputIsOK(sslSocket);
+                sslSocket.close();
+            } catch (Exception e) {
+                Assert.assertEquals("fine", e.getMessage());
+            }
+        });
+
+
+    }
+
+
+
+
 }

--- a/dynamic-ssl/src/test/java/org/wildfly/security/dynamic/ssl/DynamicSSLTestUtils.java
+++ b/dynamic-ssl/src/test/java/org/wildfly/security/dynamic/ssl/DynamicSSLTestUtils.java
@@ -70,6 +70,21 @@ public class DynamicSSLTestUtils {
     private static String SERVER3_KEYSTORE_FILENAME = "server3.keystore.jks";
     private static String SERVER3_TRUSTSTORE_FILENAME = "server3.truststore.jks";
 
+    private static String CLIENT1_HOST_KEYSTORE_FILENAME =  "client1-host.keystore.jks";
+    private static String CLIENT1_HOST_TRUSTSTORE_FILENAME ="client1-host.truststore.jks";
+    private static String SERVER1_HOST_KEYSTORE_FILENAME = "server1-host.keystore.jks";
+    private static String SERVER1_HOST_TRUSTSTORE_FILENAME = "server1-host.truststore.jks";
+
+    private static String CLIENT2_HOST_KEYSTORE_FILENAME =  "client2-host.keystore.jks";
+    private static String CLIENT2_HOST_TRUSTSTORE_FILENAME ="client2-host.truststore.jks";
+    private static String SERVER2_HOST_KEYSTORE_FILENAME = "server2-host.keystore.jks";
+    private static String SERVER2_HOST_TRUSTSTORE_FILENAME = "server2-host.truststore.jks";
+
+    private static String CLIENT3_HOST_KEYSTORE_FILENAME =  "client3-host.keystore.jks";
+    private static String CLIENT3_HOST_TRUSTSTORE_FILENAME ="client3-host.truststore.jks";
+    private static String SERVER3_HOST_KEYSTORE_FILENAME = "server3-host.keystore.jks";
+    private static String SERVER3_HOST_TRUSTSTORE_FILENAME = "server3-host.truststore.jks";
+
     private static String DEFAULT_CLIENT_KEYSTORE_FILENAME =  "default-client.keystore.jks";
     private static String DEFAULT_CLIENT_TRUSTSTORE_FILENAME ="default-client.truststore.jks";
     private static String DEFAULT_SERVER_KEYSTORE_FILENAME = "default-server.keystore.jks";
@@ -109,14 +124,6 @@ public class DynamicSSLTestUtils {
             KEYSTORES_DIR.mkdirs();
         }
 
-        generateTwoWaySSLKeystoresAndTruststores(CLIENT1_KEYSTORE_FILENAME, SERVER1_KEYSTORE_FILENAME, CLIENT1_TRUSTSTORE_FILENAME, SERVER1_TRUSTSTORE_FILENAME);
-        generateTwoWaySSLKeystoresAndTruststores(CLIENT2_KEYSTORE_FILENAME, SERVER2_KEYSTORE_FILENAME, CLIENT2_TRUSTSTORE_FILENAME, SERVER2_TRUSTSTORE_FILENAME);
-        generateTwoWaySSLKeystoresAndTruststores(CLIENT3_KEYSTORE_FILENAME, SERVER3_KEYSTORE_FILENAME, CLIENT3_TRUSTSTORE_FILENAME, SERVER3_TRUSTSTORE_FILENAME);
-        generateTwoWaySSLKeystoresAndTruststores(DEFAULT_CLIENT_KEYSTORE_FILENAME, DEFAULT_SERVER_KEYSTORE_FILENAME, DEFAULT_CLIENT_TRUSTSTORE_FILENAME, DEFAULT_SERVER_TRUSTSTORE_FILENAME);
-    }
-
-    private static void generateTwoWaySSLKeystoresAndTruststores(String clientKeystoreFilename, String serverKeystoreFilename,
-                                                                 String clientTruststoreFilename, String serverTruststoreFilename) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
         CAGenerationTool caGenerationTool = null;
         try {
             caGenerationTool = CAGenerationTool.builder()
@@ -128,6 +135,19 @@ public class DynamicSSLTestUtils {
             Assert.fail();
         }
 
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT1_KEYSTORE_FILENAME, SERVER1_KEYSTORE_FILENAME, CLIENT1_TRUSTSTORE_FILENAME, SERVER1_TRUSTSTORE_FILENAME,LOCALHOST_ALIAS,caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT2_KEYSTORE_FILENAME, SERVER2_KEYSTORE_FILENAME, CLIENT2_TRUSTSTORE_FILENAME, SERVER2_TRUSTSTORE_FILENAME,LOCALHOST_ALIAS,caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT3_KEYSTORE_FILENAME, SERVER3_KEYSTORE_FILENAME, CLIENT3_TRUSTSTORE_FILENAME, SERVER3_TRUSTSTORE_FILENAME,LOCALHOST_ALIAS,caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT1_HOST_KEYSTORE_FILENAME, SERVER1_HOST_KEYSTORE_FILENAME, CLIENT1_HOST_TRUSTSTORE_FILENAME, SERVER1_HOST_TRUSTSTORE_FILENAME,"server1.example.com",caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT2_HOST_KEYSTORE_FILENAME, SERVER2_HOST_KEYSTORE_FILENAME, CLIENT2_HOST_TRUSTSTORE_FILENAME, SERVER2_HOST_TRUSTSTORE_FILENAME,"server2.example.com",caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(CLIENT3_HOST_KEYSTORE_FILENAME, SERVER3_HOST_KEYSTORE_FILENAME, CLIENT3_HOST_TRUSTSTORE_FILENAME, SERVER3_HOST_TRUSTSTORE_FILENAME,"server3.example.com",caGenerationTool);
+        generateTwoWaySSLKeystoresAndTruststores(DEFAULT_CLIENT_KEYSTORE_FILENAME, DEFAULT_SERVER_KEYSTORE_FILENAME, DEFAULT_CLIENT_TRUSTSTORE_FILENAME, DEFAULT_SERVER_TRUSTSTORE_FILENAME,LOCALHOST_ALIAS,caGenerationTool);
+    }
+
+    private static void generateTwoWaySSLKeystoresAndTruststores(String clientKeystoreFilename, String serverKeystoreFilename,
+                                                                 String clientTruststoreFilename, String serverTruststoreFilename , String serverHostName , CAGenerationTool caGenerationTool) throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+
+
         // Generates client certificate
         X509Certificate clientCertificate = caGenerationTool.createIdentity(CLIENT_ALIAS,
                 new X500Principal("OU=Elytron"),
@@ -136,7 +156,7 @@ public class DynamicSSLTestUtils {
                 new X509CertificateExtension[]{});
 
         // Generates server certificate
-        X509Certificate serverCertificate = caGenerationTool.createIdentity(LOCALHOST_ALIAS,
+        X509Certificate serverCertificate = caGenerationTool.createIdentity(serverHostName,
                 new X500Principal("OU=Elytron"),
                 serverKeystoreFilename,
                 CAGenerationTool.Identity.CA,
@@ -149,7 +169,7 @@ public class DynamicSSLTestUtils {
         KeyStore serverTrustStore = KeyStore.getInstance(KEYSTORE_TYPE);
         serverTrustStore.load(null, null);
 
-        clientTrustStore.setCertificateEntry(LOCALHOST_ALIAS, serverCertificate);
+        clientTrustStore.setCertificateEntry(serverHostName, serverCertificate);
         serverTrustStore.setCertificateEntry(CLIENT_ALIAS, clientCertificate);
 
         File clientTrustFile = new File(KEYSTORES_DIR, clientTruststoreFilename);
@@ -170,6 +190,12 @@ public class DynamicSSLTestUtils {
         new File(KEYSTORES_DIR, CLIENT2_TRUSTSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, CLIENT3_KEYSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, CLIENT3_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT1_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT1_HOST_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT2_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT2_HOST_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT3_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, CLIENT3_HOST_TRUSTSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, DEFAULT_CLIENT_KEYSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, DEFAULT_CLIENT_TRUSTSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, SERVER1_KEYSTORE_FILENAME).delete();
@@ -178,6 +204,12 @@ public class DynamicSSLTestUtils {
         new File(KEYSTORES_DIR, SERVER2_TRUSTSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, SERVER3_KEYSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, SERVER3_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER1_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER1_HOST_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER2_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER2_HOST_TRUSTSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER3_HOST_KEYSTORE_FILENAME).delete();
+        new File(KEYSTORES_DIR, SERVER3_HOST_TRUSTSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, DEFAULT_SERVER_KEYSTORE_FILENAME).delete();
         new File(KEYSTORES_DIR, DEFAULT_SERVER_TRUSTSTORE_FILENAME).delete();
         KEYSTORES_DIR.delete();


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-3021

Added hostname-based SSL context selection test to DynamicSSLContextTest and extended DynamicSSLTestUtils to generate certificates with configurable hostnames.