### PR TITLE
[1.10.x] [JBEAP-32428] Add a BruteForceRealmWrapper Implementation

### DIFF
--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/BruteForceRealmWrapper.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/BruteForceRealmWrapper.java
@@ -1,0 +1,578 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+*/
+package org.wildfly.security.auth.realm;
+
+import static org.wildfly.common.Assert.checkNotNullParam;
+import static org.wildfly.security.auth.realm.ElytronMessages.log;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.Principal;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.wildfly.common.Assert;
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.server.ModifiableRealmIdentity;
+import org.wildfly.security.auth.server.ModifiableSecurityRealm;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.auth.server.event.RealmEvent;
+import org.wildfly.security.auth.server.event.RealmFailedAuthenticationEvent;
+import org.wildfly.security.auth.server.event.RealmSuccessfulAuthenticationEvent;
+import org.wildfly.security.authz.Attributes;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.evidence.Evidence;
+
+/**
+ * A wrapper around {@code SecurityRealm} instances to add brute force detection
+ * for brute force password guessing attacks.
+ *
+ * After a failed authentication attempt a {@code FailureSession} is created to track
+ * the failure count and to coordinate temporarily disabling the identity.
+ *
+ * This implementation is entirely in memory so will be cleared if the server is
+ * reloaded or restarted.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class BruteForceRealmWrapper {
+
+    private static final String HANDLE_REALM_EVENT_NAME = "handleRealmEvent";
+
+    private static final Set<Method> GET_IDENTITY_METHODS;
+    private static final Method EVENT_HANDLER_METHOD;
+
+    private static final int MINUTES_TO_MS = 60 * 1000;
+    private static final long MINUTES_TO_NANOS = 60L * 1000L * 1000L * 1000L;
+    private static final long LOG_INTERVAL_NANOS = 15 * MINUTES_TO_NANOS;
+
+    static {
+        Set<Method> getIdentityMethods = new HashSet<>();
+        // We don't need to scan SecurityRealm as ModificableSecurityRealm extends this.
+        for (Method method : ModifiableSecurityRealm.class.getMethods()) {
+            if (RealmIdentity.class.isAssignableFrom(method.getReturnType())) {
+                getIdentityMethods.add(method);
+            }
+        }
+        GET_IDENTITY_METHODS = Collections.unmodifiableSet(getIdentityMethods);
+
+        try {
+            EVENT_HANDLER_METHOD = SecurityRealm.class.getMethod(HANDLE_REALM_EVENT_NAME, RealmEvent.class);
+        } catch (NoSuchMethodException | SecurityException e) {
+            // This really should not happen so just fail the static initialisation if it does.
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private volatile boolean built = false;
+
+    private ScheduledExecutorService executor;
+    private SecurityRealm wrapped;
+    private String realmName;
+    private int maxFailedAttempts = 10;
+    private int lockoutInterval = 15;
+    private int failureSessionTimeout = 30;
+    private int maxCachedSessions = 25000;
+    private List<Class<?>> additionalInterfaces = new ArrayList<>();
+
+    /**
+     * Create a new instance of {@code BruteForceRealmWrapper} that can be used
+     * to wrap a {@code SecurityRealm} instance and provide brute force protection.
+     *
+     * @return a new instance of {@code BruteForceRealmWrapper}.
+     */
+    public static BruteForceRealmWrapper create() {
+        return new BruteForceRealmWrapper();
+    }
+
+     /**
+     * Set the {@code ScheduledExecutorService} that will be used for expiring the
+     * sessions tracking authentication failures.
+     *
+     * @param executor the {@code ScheduledExecutorService}
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper withExecutor(ScheduledExecutorService executor) {
+        assertNotBuilt();
+        this.executor = executor;
+
+        return this;
+    }
+
+    /**
+     * Set the realm name that should be used in any log messages.
+     *
+     * If no realm name is specified the simple class name of the wrapped realm
+     * will be used instead.
+     *
+     * @param realmName the realm name that should be used in any log messages.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper setRealmName(final String realmName) {
+        assertNotBuilt();
+        this.realmName = realmName;
+
+        return this;
+    }
+
+    /**
+     * Set the maximum number of consecutive failed login attempts for a specific user
+     * before the lockout kicks in for the configured interval.
+     *
+     * @param maxFailedAttempts - the maximum number of failed attempts before the lockout
+     *                          interval kicks in.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper setMaxFailedAttempts(final int maxFailedAttempts) {
+        assertNotBuilt();
+        if (maxFailedAttempts > 0) {
+            this.maxFailedAttempts = maxFailedAttempts;
+        }
+
+        return this;
+    }
+
+    /**
+     * After the maximum number of failed authentication attempts the interval in minutes
+     * the account will be locked for.
+     *
+     * Subsequent failed attempts during the lockout period will renew the lockout indefinitely,
+     * even if those attempts use the correct credential.
+     *
+     * @param lockoutInterval the lockout interval in minutes.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper setLockoutInterval(final int lockoutInterval) {
+        assertNotBuilt();
+        if (lockoutInterval > 0) {
+            this.lockoutInterval = lockoutInterval;
+        }
+
+        return this;
+    }
+
+    /**
+     * After a failed authentication attempt how long in minutes to keep the tracking session
+     * alive.
+     *
+     * Subsequent failed attempts will renew the timeout.
+     *
+     * @param failureSessionTimeout the lockout interval in minutes.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper setFailureSessionTimeout(final int failureSessionTimeout) {
+        assertNotBuilt();
+        if (failureSessionTimeout > 0) {
+            this.failureSessionTimeout = failureSessionTimeout;
+        }
+
+        return this;
+    }
+
+    /**
+     * Set the maximum number of sessions that will be cached before the least recently used
+     * session is evicted from the cache.
+     *
+     * @param maxCachedSessions the maximum number of sessions that will be cached before the
+     * least recently used session is evicted.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper setMaxCachedSessions(final int maxCachedSessions) {
+        assertNotBuilt();
+        if (maxCachedSessions > 0) {
+            this.maxCachedSessions = maxCachedSessions;
+        }
+
+        return this;
+    }
+
+    /**
+     * Add an additional interface to be proxied by the dynamic proxy.
+     *
+     * @param interfaze an additional interface to be proxied by the dynamic proxy.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper addAdditionalInterface(final Class<?> interfaze) {
+        assertNotBuilt();
+        checkNotNullParam("interfaze", interfaze);
+        if (!interfaze.isInterface()) {
+            throw log.notAnInterface(interfaze.getName());
+        }
+        additionalInterfaces.add(interfaze);
+
+        return this;
+    }
+
+    /**
+     * Set the security realm that is to be wrapped by the wrapper.
+     *
+     * @param toWrap the security realm that is to be wrapped by the wrapper.
+     * @return {@code this} to allow chaining.
+     */
+    public BruteForceRealmWrapper wrapping(final SecurityRealm toWrap) {
+        assertNotBuilt();
+        this.wrapped = checkNotNullParam("toWrap", toWrap);
+
+        return this;
+    }
+
+    public <S extends SecurityRealm> S wrap(final Class<S> securityRealmType) {
+        assertNotBuilt();
+        checkNotNullParam("executor", executor);
+        checkNotNullParam("wrapped", wrapped);
+
+        ArrayList<Class<?>> proxiedInterfaces = new ArrayList<>();
+
+        // Get the Elytron SecurityRealm interfaces identified.
+        if (wrapped instanceof ModifiableSecurityRealm) {
+            proxiedInterfaces.add(ModifiableSecurityRealm.class);
+        }
+        if (wrapped instanceof CacheableSecurityRealm) {
+            proxiedInterfaces.add(CacheableSecurityRealm.class);
+        }
+        if (proxiedInterfaces.isEmpty()) {
+            // The prior two extend from this.
+            proxiedInterfaces.add(SecurityRealm.class);
+        }
+
+        String realmName = this.realmName != null ? this.realmName : wrapped.getClass().getSimpleName();
+
+        // Iterate the additional interfaces and verify that the wrapped realm does
+        // actually support them as we will be just passing calls through.
+        for (Class<?> additionalInterface : additionalInterfaces) {
+            if (!additionalInterface.isInstance(wrapped)) {
+                throw log.doesNotImplementRequiredInterface(realmName, wrapped.getClass().getName(), additionalInterface.getName());
+            }
+            proxiedInterfaces.add(additionalInterface);
+        }
+
+        Object proxy = Proxy.newProxyInstance(BruteForceRealmWrapper.class.getClassLoader(),
+            proxiedInterfaces.toArray(new Class[proxiedInterfaces.size()]), new RealmWrapper(realmName, maxCachedSessions));
+
+        if (!securityRealmType.isInstance(proxy)) {
+            throw log.doesNotImplementRequiredInterface(realmName, wrapped.getClass().getName(), securityRealmType.getName());
+        }
+
+        S response = securityRealmType.cast(proxy);
+
+        built = true;
+        return response;
+    }
+
+    private void assertNotBuilt() {
+        if (built) {
+            throw log.bruteForceWrapperAlreadyBuilt();
+        }
+    }
+
+    /*
+     * Sometimes {@code SecurityRealm} implementations delegate to other instances, each of these
+     * could be wrapped individualy with the {@code BruteForceRealmWrapper}, to avoid unpredictable
+     * interactions interception of events should only happen in the first realm wrapper in the chain.
+     *
+     * This {@code ThreadLocal<Boolean>} is to track if brute force event handling has already occurred
+     * on the current call stack.
+     */
+    private static final ThreadLocal<Boolean> BRUTE_FORCE_EVENT_HANDLED = new ThreadLocal<Boolean>() {
+
+            @Override
+            protected Boolean initialValue() {
+                return Boolean.FALSE;
+            }
+    };
+
+    private class RealmWrapper implements InvocationHandler {
+
+        private final String realmName;
+        private final Map<Principal, FailureSession> failedAttempts;
+        private long lastWarnLoggedNanos = Long.MIN_VALUE; // Does not need to be volatile as always accessed in the same lock.
+
+        RealmWrapper(final String realmName, final int maxSessions) {
+            this.realmName = realmName;
+            failedAttempts = new LinkedHashMap<Principal, FailureSession>(16, 0.75f, true) {
+
+                @Override
+                protected boolean removeEldestEntry(java.util.Map.Entry<Principal, FailureSession> eldest) {
+                    if (size() > maxSessions) {
+                        // If this is called the handleRealmEvent method is adding an entry to the Map so holds the
+                        // lock, if the FailureSession invalidate task is running it will not receive the lock until
+                        // after this clean up is complete so interrupt it.
+                        eldest.getValue().cancelExpiry(true);
+
+                        long nowNanos = System.nanoTime();
+                        if (lastWarnLoggedNanos == Long.MIN_VALUE || (nowNanos - lastWarnLoggedNanos) > LOG_INTERVAL_NANOS) {
+                            // We don't want to flood the log, but we do want to ensure we are periodically reporting
+                            // this situation so an administrator can take action.
+                            log.bruteForceSessionEvicted(realmName);
+                            lastWarnLoggedNanos = nowNanos;
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                }
+
+            };
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            boolean eventHandled = BRUTE_FORCE_EVENT_HANDLED.get();
+            try {
+                BRUTE_FORCE_EVENT_HANDLED.set(true);
+
+                return invoke(proxy, method, args, eventHandled);
+            } finally {
+                // We set this to the value we obtained from the ThreadLocal as there could
+                // be multiple wrappers in the call chain.
+                BRUTE_FORCE_EVENT_HANDLED.set(eventHandled);
+            }
+        }
+
+        private Object invoke(Object proxy, Method method, Object[] args, boolean eventHandled) throws Throwable {
+            if (EVENT_HANDLER_METHOD.equals(method) && args[0] instanceof RealmEvent) {
+                if (log.isTraceEnabled()) {
+                    log.tracef("Event Received %s, for Realm %s, alreadyHandled %b", args[0].getClass().getSimpleName(), realmName, eventHandled);
+                }
+                if (!eventHandled) {
+                    handleRealmEvent((RealmEvent) args[0]);
+                }
+            } else if (GET_IDENTITY_METHODS.contains(method) && (args[0] instanceof Principal || args[0] instanceof Evidence) ) {
+                Principal principal = args[0] instanceof Principal ? (Principal) args[0] : ((Evidence)args[0]).getDecodedPrincipal();
+                if (isDisabled(principal)) {
+                    log.tracef("Protecting realm %s and Returning DisabledRealmIdentity for %s", realmName, principal.getName());
+                    Class<?> returnType = method.getReturnType();
+                    if (ModifiableRealmIdentity.class.equals(returnType)) {
+                        return new DisabledModifiableRealmIdentity(principal);
+                    } else if (RealmIdentity.class.equals(returnType)) {
+                        return new DisabledRealmIdentity(principal);
+                    }
+                } else {
+                    if (principal != null) {
+                        log.tracef("Identity not disabled for realm %s, proceeding for %s", realmName, principal.getName());
+                    }
+                }
+            }
+
+            // If we have reached this point we have not replaced the call to the target realm so can allow it to
+            // proceed.
+            try {
+                return method.invoke(wrapped, args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        }
+
+
+        private boolean isDisabled(final Principal principal) {
+            if (principal == null) {
+                return false;
+            }
+
+            // If Principal should be blocked.
+            //    Return disabled RealmIdentity
+            synchronized(failedAttempts) {
+                FailureSession session = failedAttempts.get(principal);
+                return session != null && session.isDisabled();
+                // We don't reset any timers here, that will happen when we receive the decision about
+                // the authentication.
+            }
+        }
+
+        private void invalidate(final Principal principal) {
+            synchronized(failedAttempts) {
+                log.tracef("Removing brute force session for %s in realm %s", principal.getName(), realmName);
+                failedAttempts.remove(principal);
+            }
+        }
+
+        private  void handleRealmEvent(RealmEvent event) {
+            if (event instanceof RealmFailedAuthenticationEvent) {
+                RealmFailedAuthenticationEvent rfae = (RealmFailedAuthenticationEvent) event;
+                RealmIdentity identity = rfae.getRealmIdentity();
+                final Principal principal = identity != null ? identity.getRealmIdentityPrincipal() : null;
+
+                if (principal != null && exists(identity)) {
+                    synchronized (failedAttempts) {
+                        FailureSession session = failedAttempts.get(principal);
+                        if (session != null) {
+                            if (!session.cancelExpiry(true)) {
+                                // We hold the lock so if executing we should have been able to interrupt and
+                                // prevent it from removing the session.
+                                log.tracef("Unable to cancel cleanup for '%s' in realm %s", principal, realmName);
+                                return;
+                            }
+                        } else {
+                            session = new FailureSession(() -> invalidate(principal));
+                            log.tracef("Beginning tracking of failed authentication attempts for '%s' in realm %s", principal, realmName);
+                            failedAttempts.put(principal, session);
+                        }
+                        int count = session.failAuthentication();
+                        if (count >= maxFailedAttempts) {
+                            log.tracef("Disabling authentication for '%s' in realm %s", principal, realmName);
+                            session.disableForMs(lockoutInterval * MINUTES_TO_MS);
+                        }
+                        session.scheduleTimeout(failureSessionTimeout * MINUTES_TO_MS);
+                    }
+
+                }
+            } else if (event instanceof RealmSuccessfulAuthenticationEvent) {
+                RealmSuccessfulAuthenticationEvent rsae = (RealmSuccessfulAuthenticationEvent) event;
+                RealmIdentity identity = rsae.getRealmIdentity();
+                final Principal principal = identity != null ? identity.getRealmIdentityPrincipal() : null;
+
+                if (principal != null) {
+                    synchronized (failedAttempts) {
+                        FailureSession session = failedAttempts.get(principal);
+                        if (session != null) {
+                            log.tracef("Successful authentication for previously cached failed authentication '%s' in realm %s",
+                                    principal.getName(), realmName);
+                            // No point interrupting cleanup is likely in progress.
+                            if (session.cancelExpiry(false)) {
+                                invalidate(principal);
+                            }
+                        }
+                        // If the expiration could not be cancelled it is likely running in parallel
+                        // and will remove the session once it obtains the lock.
+                    }
+                }
+            }
+        }
+
+        private boolean exists(RealmIdentity identity) {
+            try {
+                return identity.exists();
+            } catch (RealmUnavailableException e) {
+                log.tracef(e,"Unable to determine if identity exists in realm %s", realmName);
+                return false;
+            }
+        }
+
+    }
+
+
+
+    private class FailureSession {
+        private final Runnable invalidate;
+
+        private volatile int failedCount = 0;
+        private volatile long disableUntil = 0;
+        private volatile ScheduledFuture<?> futureCleanup;
+
+        FailureSession(final Runnable invalidate) {
+            this.invalidate = invalidate;
+        }
+
+        int failAuthentication() {
+            return ++failedCount;
+        }
+
+        void disableForMs(final long duration) {
+            this.disableUntil = System.currentTimeMillis() + duration;
+        }
+
+        boolean isDisabled() {
+            return System.currentTimeMillis() < disableUntil;
+        }
+
+        boolean cancelExpiry(boolean interrupt) {
+            return futureCleanup.cancel(interrupt);
+        }
+
+        void scheduleTimeout(final long duration) {
+            long now = System.currentTimeMillis();
+            long disabledDuration = disableUntil - now;
+            // Pick the bigger duration incase we disable for longer than the session.
+            long scheduleTime = disabledDuration > duration ? disabledDuration : duration;
+            futureCleanup = executor.schedule(invalidate::run, scheduleTime, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    static class DisabledRealmIdentity implements RealmIdentity {
+
+        private final Principal principal;
+
+        DisabledRealmIdentity(final Principal principal) {
+            this.principal = principal;
+        }
+
+        @Override
+        public Principal getRealmIdentityPrincipal() {
+            return principal;
+        }
+
+        public SupportLevel getCredentialAcquireSupport(final Class<? extends Credential> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialType", credentialType);
+            return SupportLevel.UNSUPPORTED;
+        }
+
+        public SupportLevel getEvidenceVerifySupport(final Class<? extends Evidence> evidenceType, final String algorithmName) throws RealmUnavailableException {
+            Assert.checkNotNullParam("evidenceType", evidenceType);
+            return SupportLevel.UNSUPPORTED;
+        }
+
+        public <C extends Credential> C getCredential(final Class<C> credentialType) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialType", credentialType);
+            return null;
+        }
+
+        public boolean verifyEvidence(final Evidence evidence) throws RealmUnavailableException {
+            Assert.checkNotNullParam("evidence", evidence);
+            return false;
+        }
+
+        public boolean exists() throws RealmUnavailableException {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "DISABLED";
+        }
+    }
+
+    static class DisabledModifiableRealmIdentity extends DisabledRealmIdentity implements ModifiableRealmIdentity {
+
+        DisabledModifiableRealmIdentity(final Principal principal) {
+            super(principal);
+        }
+
+        public boolean exists() throws RealmUnavailableException {
+            return true;
+        }
+
+        public void delete() throws RealmUnavailableException {
+            // no operation
+        }
+
+        public void create() throws RealmUnavailableException {
+            throw log.unableToCreateIdentity();
+        }
+
+        public void setCredentials(final Collection<? extends Credential> credentials) throws RealmUnavailableException {
+            throw log.noSuchIdentity();
+        }
+
+        public void setAttributes(final Attributes attributes) throws RealmUnavailableException {
+            throw log.noSuchIdentity();
+        }
+    }
+
+}

--- a/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/ElytronMessages.java
+++ b/auth/realm/base/src/main/java/org/wildfly/security/auth/realm/ElytronMessages.java
@@ -128,4 +128,26 @@ interface ElytronMessages extends BasicLogger {
 
     @Message(id = 11005, value = "Invalid unicode endoding, offending sequence: %s.")
     IOException invalidUnicodeSequence(String s, @Cause NoSuchElementException nsee);
+
+    @Message(id = 13013, value = "Unable to create identity")
+    RealmUnavailableException unableToCreateIdentity();
+
+    @Message(id = 13014, value = "No such identity")
+    RealmUnavailableException noSuchIdentity();
+
+    @Message(id = 13015, value = "The delegate SecurityRealm does not implement ModifiableSecurityRealm")
+    RealmUnavailableException notModifiableRealm();
+
+    @Message(id = 13016, value = "This BruteForceRealmWrapper has already been built")
+    IllegalStateException bruteForceWrapperAlreadyBuilt();
+
+    @Message(id = 13017, value = "Class '%s' is not an interface, only interfaces can be proxied")
+    IllegalStateException notAnInterface(String className);
+
+    @Message(id = 13018, value = "Wrapped SecurityRealm '%s' implementation class '%s' does not implement interface '%s'")
+    IllegalStateException doesNotImplementRequiredInterface(String realmName, String implementationClass, String interfaceName);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 13019, value = "The brute force tracking session cache for security realm '%s' is at capacity, tracking sessions are being evicted.")
+    void bruteForceSessionEvicted(String realmName);
 }

--- a/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/BruteForceRealmWrapperTest.java
+++ b/auth/realm/base/src/test/java/org/wildfly/security/auth/realm/BruteForceRealmWrapperTest.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.wildfly.security.auth.realm;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.Provider;
+import java.security.Security;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.SecurityRealm;
+import org.wildfly.security.auth.server.event.RealmAuthenticationEvent;
+import org.wildfly.security.auth.server.event.RealmFailedAuthenticationEvent;
+import org.wildfly.security.auth.server.event.RealmSuccessfulAuthenticationEvent;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.WildFlyElytronPasswordProvider;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * A high level test case for the {@code BruteForceRealmWrapper}.
+*
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class BruteForceRealmWrapperTest {
+
+    private static final Provider provider = WildFlyElytronPasswordProvider.getInstance();
+
+    private static final String USER_TEMPLATE = "user-%d";
+    private static final String PASSWORD_TEMPLATE = "password-%d";
+    private static final String BAD_PASSWORD = "let-me-in";
+
+    @BeforeClass
+    public static void registerProvider() {
+        Security.addProvider(provider);
+    }
+
+    @AfterClass
+    public static void removeProvider() {
+        Security.removeProvider(provider.getName());
+    }
+
+    private static String user(final int no) {
+        return format(USER_TEMPLATE, no);
+    }
+
+    private static char[] password(final int no) {
+        return format(PASSWORD_TEMPLATE, no).toCharArray();
+    }
+
+    // We are using in memory realms etc so just initialise for each test.
+
+    /**
+     * Original SecurityRealm with no wrapping applied.
+     */
+    private SecurityRealm rawRealm;
+
+    /**
+     * SecurityRealm wrapped with brute force protection.
+     *
+     * This test case configures max failed attempts = 5
+     *
+     */
+    private SecurityRealm protectedRealm;
+
+    private Map<Object, Runnable> scheduledRunnables;
+
+    @Before
+    public void setupTestRealm() throws Exception {
+        // Base Realm
+        SimpleMapBackedSecurityRealm mapBackedSecurityRealm = new SimpleMapBackedSecurityRealm();
+        Map<String, SimpleRealmEntry> identityMap = new HashMap<>();
+        mapBackedSecurityRealm.setIdentityMap(identityMap);
+        PasswordFactory factory = PasswordFactory.getInstance(ALGORITHM_CLEAR);
+        for (int i = 1 ; i <= 9 ; i++) {
+            ClearPasswordSpec passwordSpec = new ClearPasswordSpec(password(i));
+
+            identityMap.put(user(i), new SimpleRealmEntry(Collections.singletonList(new PasswordCredential(factory.generatePassword(passwordSpec)))));
+        }
+        rawRealm = mapBackedSecurityRealm;
+
+        scheduledRunnables = new HashMap<>();
+        protectedRealm = BruteForceRealmWrapper.create()
+            .wrapping(rawRealm)
+            .withExecutor(createScheduledExecutorService())
+            .setMaxFailedAttempts(5)
+            .setLockoutInterval(5)
+            .setFailureSessionTimeout(2)
+            .setMaxCachedSessions(3)
+            .wrap(SecurityRealm.class);
+    }
+
+    @After
+    public void clearTest() {
+        protectedRealm = null;
+        scheduledRunnables = null;
+        rawRealm = null;
+    }
+
+    private void clearScheduleRunnables() {
+        scheduledRunnables.forEach((k, v) -> v.run());
+    }
+
+    private void performAuthentication(final SecurityRealm securityRealm, final int identityNo, final boolean expectExists, final boolean simulateSuccess) throws Exception {
+        performAuthentication(securityRealm, identityNo, expectExists, simulateSuccess, simulateSuccess);
+    }
+
+    private void performAuthentication(final SecurityRealm securityRealm, final int identityNo, final boolean expectExists, final boolean simulateSuccess, final boolean useGoodPassword) throws Exception {
+        NamePrincipal principal = new NamePrincipal(user(identityNo));
+        RealmIdentity realmIdentity = securityRealm.getRealmIdentity(principal);
+
+        assertEquals("RealmIdentity.exists()", expectExists, realmIdentity.exists());
+
+        PasswordGuessEvidence passwordGuessEvidence = new PasswordGuessEvidence(useGoodPassword ? password(identityNo) : BAD_PASSWORD.toCharArray());
+        assertEquals("RealmIdentity.verifyEvidence()", simulateSuccess, realmIdentity.verifyEvidence(passwordGuessEvidence));
+
+        RealmAuthenticationEvent realmAuthenticationEvent;
+        if (simulateSuccess) {
+            realmAuthenticationEvent = new RealmSuccessfulAuthenticationEvent(realmIdentity, realmIdentity.getAuthorizationIdentity(), null, passwordGuessEvidence);
+        } else {
+            realmAuthenticationEvent = new RealmFailedAuthenticationEvent(realmIdentity, null, passwordGuessEvidence);
+        }
+        securityRealm.handleRealmEvent(realmAuthenticationEvent);
+    }
+
+    /**
+     * Test that the wrapped realm can be repeatedly called for authentication attempts.
+     */
+    @Test
+    public void testSuccessfulAccess() throws Exception {
+        // Test against rawRealm - just to verify our call is correct.
+        performAuthentication(rawRealm, 1, true, true);
+
+        // Now make 10 calls against the wrapper to verify success.
+        for (int i = 0 ; i < 10 ; i++) {
+            performAuthentication(protectedRealm, 1, true, true);
+        }
+
+        // No failure sessions should have been created.
+        assertEquals("No failure sessions", 0, scheduledRunnables.size());
+    }
+
+    /**
+     * Test that the required number of failed authentications does disable the identity.
+     *
+     * Also test the base realm still works - i.e. prove it is brute force wrapping preventing access.
+     * Simulate the session expiring and verify authentication works again.
+     */
+    @Test
+    public void testDisabledIdentity() throws Exception {
+        // Test against rawRealm - just to verify our call is correct.
+        performAuthentication(rawRealm, 2, true, true);
+
+        // Now make 5 bad calls
+        for (int i = 0 ; i < 5 ; i++) {
+            performAuthentication(protectedRealm, 2, true, false, false);
+        }
+
+        // Only one identity is being tested so we should have one session.
+        assertEquals("Expected failure session", 1, scheduledRunnables.size());
+
+        // Even though we now use the good password we should be locked out.
+        performAuthentication(protectedRealm, 2, true, false, true);
+
+        // Test against rawRealm again - double check it is brute force protection causing the lock out.
+        performAuthentication(rawRealm, 2, true, true);
+
+        // Remove all tracking sessions - this simulates a session timeout.
+        clearScheduleRunnables();
+
+        // Now it should work again
+        performAuthentication(protectedRealm, 2, true, true);
+    }
+
+    /**
+     * Test case to verify that sessions are evicted from the cache once the maximum size is reached.
+     * @throws Exception
+     */
+    @Test
+    public void testMaxCachedSessions() throws Exception {
+        // Lock an identity. 4
+        // Test against rawRealm - just to verify our call is correct.
+        performAuthentication(rawRealm, 4, true, true);
+
+        // Now make 5 bad calls
+        for (int i = 0 ; i < 5 ; i++) {
+            performAuthentication(protectedRealm, 4, true, false, false);
+        }
+
+        // Only one identity is being tested so we should have one session.
+        assertEquals("Expected failure session", 1, scheduledRunnables.size());
+
+        // Add 2 more sessions to cache 5,6
+        performAuthentication(protectedRealm, 5, true, false, false);
+        performAuthentication(protectedRealm, 6, true, false, false);
+
+        // There should now be three sessions.
+        assertEquals("Expected failure session", 3, scheduledRunnables.size());
+
+        // Verify identity is locked. 4
+        performAuthentication(protectedRealm, 4, true, false, true);
+
+        // Add 3 sessions to cache 5,6,7
+        performAuthentication(protectedRealm, 5, true, false, false);
+        performAuthentication(protectedRealm, 6, true, false, false);
+        performAuthentication(protectedRealm, 7, true, false, false);
+
+        // Should still be 3 sessions.
+        assertEquals("Expected failure session", 3, scheduledRunnables.size());
+
+        // Verify identity was evicted and can now be accessed. 4
+        performAuthentication(protectedRealm, 4, true, true, true);
+    }
+
+    /**
+     * If a user has entered the wrong password multiple times but less than max,
+     * verify they can
+     */
+    @Test
+    public void testSuccessAfterAlmostBadAccess() throws Exception {
+        // Test against rawRealm - just to verify our call is correct.
+        performAuthentication(rawRealm, 3, true, true);
+
+        // Now make 4 bad calls
+        for (int i = 0 ; i < 4 ; i++) {
+            performAuthentication(protectedRealm, 3, true, false, false);
+        }
+
+        // Only one identity is being tested so we should have one session.
+        assertEquals("Expected failure session", 1, scheduledRunnables.size());
+
+        // We did not quite reach lockout so this should work.
+        performAuthentication(protectedRealm, 3, true, true);
+
+        // No failure sessions should have been created.
+        assertEquals("No failure sessions", 0, scheduledRunnables.size());
+
+        // Now make 4 bad calls
+        for (int i = 0 ; i < 4 ; i++) {
+            performAuthentication(protectedRealm, 3, true, false, false);
+        }
+
+        // Only one identity is being tested so we should have one session.
+        assertEquals("Expected failure session", 1, scheduledRunnables.size());
+
+        // Although we have now had 8 failed attempts, after 4 we had a successful auth which should have caused a reset.
+        performAuthentication(protectedRealm, 3, true, true);
+
+        // No failure sessions should have been created.
+        assertEquals("No failure sessions", 0, scheduledRunnables.size());
+    }
+
+    /**
+     * Where the wrapped realm is able to identify if an identity exists this wrapper should not be
+     * creating a tracking session for identities that do not exist.
+     */
+    @Test
+    public void testNonExistantIdentity() throws Exception {
+        // Test against rawRealm - just to verify our call is correct.
+        performAuthentication(rawRealm, 10, false, false);
+
+        // Now make 5 bad calls
+        for (int i = 0 ; i < 5 ; i++) {
+            performAuthentication(protectedRealm, 10, false, false);
+        }
+
+        // No failure sessions should have been created.
+        assertEquals("No failure sessions", 0, scheduledRunnables.size());
+    }
+
+    /*
+     * As part of a unit test we don't want to be waiting for timeouts in the executor, instead we
+     * provide a Proxy to intercept the calls so we can verify the registration and simulate the
+     * timeouts.
+     */
+
+    private ScheduledExecutorService createScheduledExecutorService() {
+        return (ScheduledExecutorService) Proxy.newProxyInstance(BruteForceRealmWrapperTest.class.getClassLoader(),
+            new Class[] { ScheduledExecutorService.class }, new ScheduledExecutorInvocationHandler());
+    }
+
+    static Method getTargetMethod() {
+        try {
+            return ScheduledExecutorService.class.getMethod("schedule", Runnable.class, long.class, TimeUnit.class);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private class ScheduledExecutorInvocationHandler implements InvocationHandler {
+
+        final Method TARGET_METHOD = getTargetMethod();
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            if (TARGET_METHOD.equals(method)) {
+                if (args[0] instanceof Runnable) {
+                    TestScheduledFuture future = new TestScheduledFuture((p) -> scheduledRunnables.remove(p) != null);
+                    scheduledRunnables.put(future, (Runnable)args[0]);
+
+                    return future;
+                }
+
+                throw new IllegalArgumentException("Expected Runnable");
+            } else {
+                return null;
+            }
+        }
+    }
+
+    private static class TestScheduledFuture implements ScheduledFuture<Void> {
+
+        private final Function<Object, Boolean> cancel;
+
+        private boolean isCancelled = false;
+
+        public TestScheduledFuture(Function<Object, Boolean> cancel) {
+            this.cancel = cancel;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            // Not relevant to test.
+            return 0;
+        }
+
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return cancel.apply(this);
+        }
+
+        @Override
+        public Void get() throws InterruptedException, ExecutionException {
+            // Not relevant to test.
+            return null;
+        }
+
+        @Override
+        public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            // Not relevant to test.
+            return null;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return isCancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            // Not relevant to test.
+            return false;
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            // Not relevant to test.
+            throw new UnsupportedOperationException("Unimplemented method 'compareTo'");
+        }
+
+    }
+
+}

--- a/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
+++ b/http/digest/src/main/java/org/wildfly/security/http/digest/DigestAuthenticationMechanism.java
@@ -216,11 +216,13 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             return;
         }
 
-        byte[] hA1 = getH_A1(messageDigest, username, messageRealm);
+        byte[] hA1;
 
-        if (hA1 == null) {
-            httpDigest.trace("Failed: unable to get expected proof");
-            fail();
+        try {
+            hA1 = getH_A1(messageDigest, username, messageRealm); // Does not return null.
+        } catch (AuthenticationMechanismException ame) {
+            httpDigest.trace("Failed: unable to get expected proof", ame);
+            failSafely();
             request.authenticationFailed(httpDigest.authenticationFailed(), httpResponse -> prepareResponse(selectedRealm, httpResponse, false));
             return;
         }
@@ -426,6 +428,22 @@ final class DigestAuthenticationMechanism implements HttpServerAuthenticationMec
             callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
         } catch (Throwable t) {
             throw httpDigest.mechCallbackHandlerFailedForUnknownReason(t);
+        }
+    }
+
+    /**
+     * Safely handles the authentication failure callback without throwing exceptions.
+     *
+     * This method attempts to invoke the callback handler with an authentication failure notification.
+     * Unlike {@link #fail()}, any exceptions encountered during callback handling are caught and logged
+     * rather than propagated, making this method safe for use in error handling paths where exceptions
+     * cannot be thrown or where they can be ignored.
+     */
+    private void failSafely() {
+        try {
+            callbackHandler.handle(new Callback[] { AuthenticationCompleteCallback.FAILED });
+        } catch (Throwable t) {
+            httpDigest.trace("Error handling AuthenticationCompleteCallback.FAILED", t);
         }
     }
 

--- a/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
+++ b/mechanism/digest/src/main/java/org/wildfly/security/mechanism/digest/PasswordDigestObtainer.java
@@ -91,6 +91,12 @@ public class PasswordDigestObtainer {
         return realm;
     }
 
+     /**
+     * Handles callbacks for user and password information.
+     *
+     * @return the salted password, never {@code null}.
+     * @throws AuthenticationMechanismException if the callback handler does not support credential acquisition.
+     */
     public byte[] handleUserRealmPasswordCallbacks() throws AuthenticationMechanismException {
 
         realmChoiceCallBack = skipRealmCallbacks || realms == null || realms.length <= 1 ? null :


### PR DESCRIPTION
https://issues.redhat.com/browse/ELY-2891
https://issues.redhat.com/browse/ELY-3003
https://issues.redhat.com/browse/ELY-3005
https://issues.redhat.com/browse/ELY-3007

Upstream PR: https://github.com/wildfly-security/wildfly-elytron/pull/2363
Related Issue: https://redhat.atlassian.net/browse/JBEAP-32428

The reason we need it is because in the 1.10.x version of wildfly-elytron (which is used by wildfly-core 10.1.x at Jboss EAP 7.3.x ) the `BruteForceRealmWrapper` is not available