### PR TITLE
[ELY-2878] Add support to run Elytron Web tests in CI

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -29,7 +29,7 @@ jobs:
           echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4' >	%SystemRoot%\System32\drivers\etc\hosts
           echo '::1         localhost localhost.localdomain localhost6 localhost6.localdomain6' >> %SystemRoot%\System32\drivers\etc\hosts
         shell: cmd
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
@@ -45,7 +45,7 @@ jobs:
       #    docker-machine create --driver virtualbox default
       #    docker --version
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-${{ matrix.java }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -73,3 +73,46 @@ jobs:
         if: ${{ failure() && ! contains(matrix.os, 'windows') }}
         shell: bash
         run: cat /etc/hosts;  ifconfig -a;
+
+  elytron-web-build:
+    name: Elytron Web Tests - JDK ${{ matrix.java }}
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['21']
+    steps:
+      - name: Update hosts
+        run: |
+          cat /etc/hosts
+          sudo bash -c "echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4' > /etc/hosts"
+          sudo bash -c "echo '::1         localhost localhost.localdomain localhost6 localhost6.localdomain6' >> /etc/hosts"
+          sudo sysctl -w fs.file-max=2097152
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-${{ matrix.java }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.java }}-m2
+      - name: Version Info
+        run: mvn -version
+      - name: Install wildfly-elytron SNAPSHOT
+        run: mvn -B install -DskipTests --file pom.xml
+      - name: Get wildfly-elytron version
+        id: elytron-version
+        run: |
+          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+      - name: Clone Elytron Web
+        run: git clone --depth 1 -b 4.x https://github.com/wildfly-security/elytron-web.git elytron-web
+      - name: Build and test Elytron Web
+        run: mvn -B verify -Dversion.org.wildfly.security.elytron=${{ steps.elytron-version.outputs.version }}
+        working-directory: elytron-web


### PR DESCRIPTION
[ELY-2878] Add support to run Elytron Web tests in CI

https://issues.redhat.com/browse/ELY-2878

## 1. Description

This PR extends the GitHub Actions PR CI workflow to also build and run the Elytron Web tests after the Elytron build completes.

Some Elytron HTTP testing requires a real HTTP server integration which is provided by Elytron Web (Undertow integration). Running Elytron Web tests as part of Elytron CI helps detect regressions early and enables further HTTP testing expansion.

This follows the common downstream validation pattern where dependent projects are built against the current Elytron SNAPSHOT.

## 2. Changes Made

- Added a new CI job `elytron-web-build` in `.github/workflows/pr-ci.yaml`
- Job runs after the main build job using `needs: build`
- Installs Elytron SNAPSHOT artifacts into the local Maven repository
- Clones the Elytron Web repository (4.x branch)
- Builds Elytron Web against the locally built Elytron version
- Runs Elytron Web tests to verify compatibility

## 3. CI Design Decisions

- Only ubuntu-latest + JDK 21 used to reduce CI cost
- Elytron Web already tests full OS/JDK matrix in its own CI
- This job only verifies Elytron → Elytron Web integration
- Failure is treated as a gate to prevent regressions

## 4. Technical Details

The Elytron version is dynamically extracted:

mvn help:evaluate -Dexpression=project.version -q -DforceStdout

Elytron Web is built using:

mvn -B verify -Dversion.org.wildfly.security.elytron=<SNAPSHOT>

## 5. Testing

### Automated
- YAML validated locally
- Workflow validated by GitHub Actions

### Manual
Verified that:

- Both `build` and `elytron-web-build` jobs run
- `elytron-web-build` waits for `build`
- Elytron Web builds successfully against SNAPSHOT
- Test results are reported in CI

## 6. Future Improvements (optional)

Possible future extensions:

- Add additional Elytron Web branches if needed
- Expand JDK matrix if integration coverage is required

## 7. Result

This ensures Elytron changes do not break Elytron Web integration and allows safer expansion of HTTP testing.