### PR TITLE
[ELY-3034] Update Elytron Web CI job to use JDK 25 on 2.x

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -84,17 +84,17 @@ jobs:
           sudo bash -c "echo '::1         localhost localhost.localdomain localhost6 localhost6.localdomain6' >> /etc/hosts"
           sudo sysctl -w fs.file-max=2097152
       - uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-elytron-web-4.x-jdk21-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-elytron-web-4.x-jdk21-m2
+          key: ${{ runner.os }}-elytron-web-4.x-jdk25-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-elytron-web-4.x-jdk25-m2
       - name: Version Info
         run: mvn -version
       - name: Resolve Elytron version


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ELY-3034