### PR TITLE
[ELY-2911] Add fallback JKU logic for IDP key rotation missing jku headers

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -37,6 +37,8 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -82,6 +84,7 @@ public class JwtValidator implements TokenValidator {
     private final Map<String, PublicKey> namedKeys;
 
     private final PublicKey defaultPublicKey;
+    private final URL jkuFallbackUrl;
 
     JwtValidator(Builder configuration) {
         this.issuers = checkNotNullParam("issuers", configuration.issuers);
@@ -89,6 +92,7 @@ public class JwtValidator implements TokenValidator {
         this.allowedJkuValues = checkNotNullParam("allowedJkuValues", configuration.allowedJkuValues);
         this.defaultPublicKey = configuration.publicKey;
         this.namedKeys = configuration.namedKeys;
+        this.jkuFallbackUrl = configuration.jkuFallbackUrl;
         if (configuration.sslContext != null) {
             this.jwkManager = new JwkManager(configuration.sslContext,
                                             configuration.hostnameVerifier != null ? configuration.hostnameVerifier : HttpsURLConnection.getDefaultHostnameVerifier(),
@@ -99,7 +103,7 @@ public class JwtValidator implements TokenValidator {
             log.tokenRealmJwtNoSSLIgnoringJku();
             this.jwkManager = null;
         }
-        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty()) {
+        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty() && jkuFallbackUrl == null) {
             log.tokenRealmJwtWarnNoPublicKeyIgnoringSignatureCheck();
         }
 
@@ -182,7 +186,7 @@ public class JwtValidator implements TokenValidator {
     }
 
     private boolean verifySignature(String encodedHeader, String encodedClaims, String encodedSignature) throws RealmUnavailableException {
-        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty()) {
+        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty() && jkuFallbackUrl == null) {
             return true;
         }
 
@@ -312,6 +316,10 @@ public class JwtValidator implements TokenValidator {
             }
             return defaultPublicKey;
         }
+        if (kid.getString().isEmpty()) {
+            log.debug("Empty kid claim. Cannot resolve key.");
+            return null;
+        }
         if (jku != null) {
             if (jwkManager == null) {
                 log.debugf("Cannot validate token with jku [%s]. SSL is not configured and jku claim is not supported.", jku);
@@ -328,15 +336,27 @@ public class JwtValidator implements TokenValidator {
                 return null;
             }
         } else {
+            PublicKey res = namedKeys.get(kid.getString());
+            if (res != null) {
+                return res;
+            }
+            if (jkuFallbackUrl != null) {
+                if (jwkManager == null) {
+                    log.debugf("Cannot use jku fallback URL [%s]. SSL is not configured.", jkuFallbackUrl);
+                    return null;
+                }
+                if (!allowedJkuValues.contains(jkuFallbackUrl.toString())) {
+                    log.debug("Cannot validate token, jku fallback URL is not allowed");
+                    return null;
+                }
+                return jwkManager.getPublicKey(kid.getString(), jkuFallbackUrl);
+            }
             if (namedKeys.isEmpty()) {
                 log.debug("Cannot validate token with kid claim.");
-                return null;
-            }
-            PublicKey res = namedKeys.get(kid.getString());
-            if (res == null) {
+            } else {
                 log.debug("Unknown kid.");
             }
-            return res;
+            return null;
         }
     }
 
@@ -359,6 +379,7 @@ public class JwtValidator implements TokenValidator {
         private int connectionTimeout = CONNECTION_TIMEOUT;
         private int readTimeout = CONNECTION_TIMEOUT;
         private int minTimeBetweenRequests = MIN_TIME_BETWEEN_REQUESTS;
+        private URL jkuFallbackUrl;
 
         private Builder() {
         }
@@ -516,6 +537,41 @@ public class JwtValidator implements TokenValidator {
          */
         public Builder setAllowedJkuValues(String... allowedJkuValues) {
             this.allowedJkuValues.addAll(asList(allowedJkuValues));
+            return this;
+        }
+
+        /**
+         * <p>Configures a fallback JWK Set URL used to resolve the public key of a JWT
+         * that carries a <code>kid</code> header but no <code>jku</code> header.
+         *
+         * <p>Many OIDC providers (for example Auth0, Microsoft EntraID, Okta) issue
+         * tokens that include <code>kid</code> but never <code>jku</code>. With this
+         * option configured, the validator treats such tokens as if the JWT's
+         * <code>jku</code> header had been the configured URL, reusing the same JWK
+         * caching and rotation logic that applies to in-token <code>jku</code> values.
+         *
+         * <p>The configured URL must also be listed in {@link #setAllowedJkuValues(String...)};
+         * this preserves the guard that applies to the in-token <code>jku</code> path.
+         *
+         * <p>When both {@link #publicKeys(Map)} and this fallback are configured, the
+         * named keys take precedence: the fallback is consulted only when the token's
+         * <code>kid</code> is not present in the configured named keys map.
+         *
+         * @param jkuFallbackUrl the JWK Set URL used as fallback for <code>kid</code>-only tokens
+         * @return this instance
+         * @throws IllegalArgumentException if the given value is not a valid URL
+         */
+        public Builder setJkuFallbackUrl(String jkuFallbackUrl) {
+            checkNotNullParam("jkuFallbackUrl", jkuFallbackUrl);
+            try {
+                URI uri = new URI(jkuFallbackUrl);
+                if (!"https".equalsIgnoreCase(uri.getScheme())) {
+                    throw new IllegalArgumentException("jku fallback URL must use HTTPS, got: " + uri.getScheme());
+                }
+                this.jkuFallbackUrl = uri.toURL();
+            } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid jku fallback URL: " + jkuFallbackUrl, e);
+            }
             return this;
         }
 

--- a/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
@@ -783,6 +783,121 @@ public class JwtSecurityRealmTest {
         assertIdentityExist(securityRealm, evidence2);
     }
 
+    @Test
+    public void testJkuFallbackResolvesKidWithoutJkuHeader() throws Exception {
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                createJwt(keyPair1, 60, -1, "1", null));
+
+        SSLContext sslContext = getSSLContext();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setAllowedJkuValues("https://localhost:50831")
+                        .setJkuFallbackUrl("https://localhost:50831")
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a, b) -> true).build())
+                .build();
+
+        assertIdentityExist(securityRealm, evidence);
+    }
+
+    @Test
+    public void testJkuFallbackRejectedWhenNotInAllowedJkuValues() throws Exception {
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                createJwt(keyPair1, 60, -1, "1", null));
+
+        SSLContext sslContext = getSSLContext();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setAllowedJkuValues("https://localhost:50832")
+                        .setJkuFallbackUrl("https://localhost:50831")
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a, b) -> true).build())
+                .build();
+
+        assertIdentityNotExist(securityRealm, evidence);
+    }
+
+    @Test
+    public void testNamedKeysTakePrecedenceOverJkuFallback() throws Exception {
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                createJwt(keyPair1, 60, -1, "1", null));
+
+        Map<String, PublicKey> namedKeys = new LinkedHashMap<>();
+        namedKeys.put("1", keyPair3.getPublic());
+
+        SSLContext sslContext = getSSLContext();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setAllowedJkuValues("https://localhost:50831")
+                        .publicKeys(namedKeys)
+                        .setJkuFallbackUrl("https://localhost:50831")
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a, b) -> true).build())
+                .build();
+
+        assertIdentityNotExist(securityRealm, evidence);
+    }
+
+    @Test
+    public void testJkuFallbackUsedWhenKidMissingFromNamedKeys() throws Exception {
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                createJwt(keyPair1, 60, -1, "1", null));
+
+        Map<String, PublicKey> namedKeys = new LinkedHashMap<>();
+        namedKeys.put("2", keyPair2.getPublic());
+
+        SSLContext sslContext = getSSLContext();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setAllowedJkuValues("https://localhost:50831")
+                        .publicKeys(namedKeys)
+                        .setJkuFallbackUrl("https://localhost:50831")
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a, b) -> true).build())
+                .build();
+
+        assertIdentityExist(securityRealm, evidence);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetJkuFallbackUrlRejectsInvalidUrl() {
+        JwtValidator.builder().setJkuFallbackUrl("not a url :)");
+    }
+
+    @Test
+    public void testJkuFallbackWithoutSslIsRejected() throws Exception {
+        BearerTokenEvidence evidence = new BearerTokenEvidence(
+                createJwt(keyPair1, 60, -1, "1", null));
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setAllowedJkuValues("https://localhost:50831")
+                        .setJkuFallbackUrl("https://localhost:50831")
+                        .build())
+                .build();
+
+        assertIdentityNotExist(securityRealm, evidence);
+    }
+
     private void assertIdentityNotExist(SecurityRealm realm, Evidence evidence) throws RealmUnavailableException {
         RealmIdentity identity = realm.getRealmIdentity(evidence);
         assertNotNull(identity);


### PR DESCRIPTION
### Description
This PR resolves [ELY-2911](https://issues.jboss.org/browse/ELY-2911). 

Currently, the `JwtValidator` does not support automatic public key rotation if a JWT token contains a `kid` header but lacks a `jku` header.

As discussed in the issue, there were two proposed approaches: a custom callback mechanism or a configured JKU fallback URI. **I opted for the JKU fallback URI approach** because it is significantly simpler for end-users and securely leverages the existing `JwkManager` for fetching and caching keys.

I am open to any suggestions for further refinement.