### PR TITLE
ELY-2911 JwtValidator: add defaultJkuUrl for OIDC providers that omit jku header

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -82,6 +82,7 @@ public class JwtValidator implements TokenValidator {
     private final Map<String, PublicKey> namedKeys;
 
     private final PublicKey defaultPublicKey;
+    private final URL defaultJkuUrl;
 
     JwtValidator(Builder configuration) {
         this.issuers = checkNotNullParam("issuers", configuration.issuers);
@@ -89,6 +90,7 @@ public class JwtValidator implements TokenValidator {
         this.allowedJkuValues = checkNotNullParam("allowedJkuValues", configuration.allowedJkuValues);
         this.defaultPublicKey = configuration.publicKey;
         this.namedKeys = configuration.namedKeys;
+        this.defaultJkuUrl = configuration.defaultJkuUrl;
         if (configuration.sslContext != null) {
             this.jwkManager = new JwkManager(configuration.sslContext,
                                             configuration.hostnameVerifier != null ? configuration.hostnameVerifier : HttpsURLConnection.getDefaultHostnameVerifier(),
@@ -99,7 +101,7 @@ public class JwtValidator implements TokenValidator {
             log.tokenRealmJwtNoSSLIgnoringJku();
             this.jwkManager = null;
         }
-        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty()) {
+        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty() && defaultJkuUrl == null) {
             log.tokenRealmJwtWarnNoPublicKeyIgnoringSignatureCheck();
         }
 
@@ -182,7 +184,7 @@ public class JwtValidator implements TokenValidator {
     }
 
     private boolean verifySignature(String encodedHeader, String encodedClaims, String encodedSignature) throws RealmUnavailableException {
-        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty()) {
+        if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty() && defaultJkuUrl == null) {
             return true;
         }
 
@@ -328,6 +330,9 @@ public class JwtValidator implements TokenValidator {
                 return null;
             }
         } else {
+            if (defaultJkuUrl != null && jwkManager != null) {
+                return jwkManager.getPublicKey(kid.getString(), defaultJkuUrl);
+            }
             if (namedKeys.isEmpty()) {
                 log.debug("Cannot validate token with kid claim.");
                 return null;
@@ -359,6 +364,7 @@ public class JwtValidator implements TokenValidator {
         private int connectionTimeout = CONNECTION_TIMEOUT;
         private int readTimeout = CONNECTION_TIMEOUT;
         private int minTimeBetweenRequests = MIN_TIME_BETWEEN_REQUESTS;
+        private URL defaultJkuUrl;
 
         private Builder() {
         }
@@ -516,6 +522,22 @@ public class JwtValidator implements TokenValidator {
          */
         public Builder setAllowedJkuValues(String... allowedJkuValues) {
             this.allowedJkuValues.addAll(asList(allowedJkuValues));
+            return this;
+        }
+
+        /**
+         * Sets a default JWKS URL to use for fetching signing keys when the JWT contains a {@code kid}
+         * header but no {@code jku} header. This enables key resolution via the {@link JwkManager} with
+         * caching and automatic refresh, which is the standard behavior for OIDC providers like Keycloak
+         * that include {@code kid} but not {@code jku} in their JWT headers.
+         *
+         * <p>Requires an {@link SSLContext} to be configured if the URL uses HTTPS.
+         *
+         * @param defaultJkuUrl the default JWKS URL
+         * @return this instance
+         */
+        public Builder setDefaultJkuUrl(URL defaultJkuUrl) {
+            this.defaultJkuUrl = defaultJkuUrl;
             return this;
         }
 

--- a/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/auth/realm/token/JwtSecurityRealmTest.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -781,6 +782,71 @@ public class JwtSecurityRealmTest {
         // token validation should succeed
         assertIdentityExist(securityRealm, evidence1);
         assertIdentityExist(securityRealm, evidence2);
+    }
+
+    @Test
+    public void testDefaultJkuUrl() throws Exception {
+        // JWTs with kid but no jku — simulates KeyCloak-issued tokens
+        BearerTokenEvidence evidence1 = new BearerTokenEvidence(createJwt(keyPair1, 60, -1, "1", null));
+        BearerTokenEvidence evidence2 = new BearerTokenEvidence(createJwt(keyPair2, 60, -1, "2", null));
+        BearerTokenEvidence evidence3 = new BearerTokenEvidence(createJwt(keyPair3, 60, -1, "3", null));
+
+        X509TrustManager tm = getTrustManager();
+        SSLContext sslContext = new SSLContextBuilder().setTrustManager(tm).setClientMode(true).setSessionTimeout(10).build().create();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setDefaultJkuUrl(new URL("https://localhost:50831"))
+                        .setJkuTimeout(0)
+                        .setJkuMinTimeBetweenRequests(0)
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a,b) -> true).build())
+                .build();
+
+        // keys 1 and 2 are served by the mock server
+        assertIdentityExist(securityRealm, evidence1);
+        assertIdentityExist(securityRealm, evidence2);
+        // key 3 is not in the JWKS response
+        assertIdentityNotExist(securityRealm, evidence3);
+    }
+
+    @Test
+    public void testDefaultJkuUrlKeyRotation() throws Exception {
+        // Start with only key 1
+        server.setDispatcher(createTokenDispatcher(jwksToJson(jwk1).toString()));
+
+        BearerTokenEvidence evidence1 = new BearerTokenEvidence(createJwt(keyPair1, 60, -1, "1", null));
+        BearerTokenEvidence evidence2 = new BearerTokenEvidence(createJwt(keyPair2, 60, -1, "2", null));
+
+        X509TrustManager tm = getTrustManager();
+        SSLContext sslContext = new SSLContextBuilder().setTrustManager(tm).setClientMode(true).setSessionTimeout(10).build().create();
+
+        TokenSecurityRealm securityRealm = TokenSecurityRealm.builder()
+                .principalClaimName("sub")
+                .validator(JwtValidator.builder()
+                        .issuer("elytron-oauth2-realm")
+                        .audience("my-app-valid")
+                        .setDefaultJkuUrl(new URL("https://localhost:50831"))
+                        .setJkuTimeout(0)
+                        .setJkuMinTimeBetweenRequests(0)
+                        .useSslContext(sslContext)
+                        .useSslHostnameVerifier((a,b) -> true).build())
+                .build();
+
+        assertIdentityExist(securityRealm, evidence1);
+        assertIdentityNotExist(securityRealm, evidence2);
+
+        // Rotate: now serve both keys
+        server.setDispatcher(createTokenDispatcher(jwksResponse));
+
+        assertIdentityExist(securityRealm, evidence1);
+        assertIdentityExist(securityRealm, evidence2);
+
+        // Restore default dispatcher
+        server.setDispatcher(createTokenDispatcher(jwksResponse));
     }
 
     private void assertIdentityNotExist(SecurityRealm realm, Evidence evidence) throws RealmUnavailableException {


### PR DESCRIPTION
Closes https://redhat.atlassian.net/browse/ELY-2911