### PR TITLE
[ELY-3044] Fix MaskedPasswordTest salt rejected by Java 25 PBES1Core

### DIFF
--- a/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
@@ -107,7 +107,7 @@ public class MaskedPasswordTest {
     public void testEncryptableSpec() throws Exception {
         char[] initialKeyMaterial = "my deep dark secret".toCharArray();
 
-        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[8]);
+        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
 
         EncryptablePasswordSpec spec = new EncryptablePasswordSpec("myMaskedPassword".toCharArray(), algorithmSpec);
         PasswordFactory factory = PasswordFactory.getInstance(algorithm);


### PR DESCRIPTION

https://redhat.atlassian.net/browse/ELY-3044
