### PR TITLE
[ELY-3044] Fix MaskedPasswordTest salt rejected by Java 25 PBES1Core

### DIFF
--- a/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
@@ -107,7 +107,7 @@ public class MaskedPasswordTest {
     public void testEncryptableSpec() throws Exception {
         char[] initialKeyMaterial = "my deep dark secret".toCharArray();
 
-        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[8]);
+        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
 
         EncryptablePasswordSpec spec = new EncryptablePasswordSpec("myMaskedPassword".toCharArray(), algorithmSpec);
         PasswordFactory factory = PasswordFactory.getInstance(algorithm);


### PR DESCRIPTION
Java 25 rejects all-zero salts for DESede-based PBE encryption. Replace new byte[8] with a non-weak 8-byte salt so the three masked-MD5-3DES test cases pass on Java 25 Temurin/macOS.

This was fixed upstream but the latter JDK updates on all maintenance branches need this too.