### PR TITLE
[ELY-3044] Fix MaskedPasswordTest salt rejected by Java 25 PBES1Core

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -13,11 +13,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: 'temurin'
       # ELY-2204 - Temporarily preventing OidcTest from running on macOS since there
       # are intermittent issues with starting up the Docker container.
       #- if: matrix.os == 'macos-latest'
@@ -28,7 +29,7 @@ jobs:
       #    docker-machine create --driver virtualbox default
       #    docker --version
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/MaskedPasswordTest.java
@@ -107,7 +107,7 @@ public class MaskedPasswordTest {
     public void testEncryptableSpec() throws Exception {
         char[] initialKeyMaterial = "my deep dark secret".toCharArray();
 
-        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[8]);
+        MaskedPasswordAlgorithmSpec algorithmSpec = new MaskedPasswordAlgorithmSpec(initialKeyMaterial, 1, new byte[]{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08});
 
         EncryptablePasswordSpec spec = new EncryptablePasswordSpec("myMaskedPassword".toCharArray(), algorithmSpec);
         PasswordFactory factory = PasswordFactory.getInstance(algorithm);


### PR DESCRIPTION
The test failure is also affecting the 1.15.x maintenance branch.

I will merge after CI as this is a like for like backport.