### PR TITLE
Correct tracef() calls to pass exception as first parameter

### DIFF
--- a/auth/client/src/main/java/org/wildfly/security/auth/util/ElytronAuthenticator.java
+++ b/auth/client/src/main/java/org/wildfly/security/auth/util/ElytronAuthenticator.java
@@ -79,7 +79,7 @@ public final class ElytronAuthenticator extends Authenticator {
         try {
             authenticationConfiguration = client.getAuthenticationConfiguration(getRequestingURL().toURI(), context);
         } catch (URISyntaxException e) {
-            log.tracef("URISyntaxException getting URI from the requesting URL [%s]:", getRequestingURL(), e);
+            log.tracef(e, "URISyntaxException getting URI from the requesting URL [%s]:", getRequestingURL());
             return null;
         }
         if (authenticationConfiguration == null) return null;

--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/TokenValidator.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/TokenValidator.java
@@ -118,7 +118,7 @@ public class TokenValidator {
             }
         } catch (InvalidJwtException e) {
             String msg = e.getErrorDetails().get(0).getErrorMessage();
-            log.tracef(msg, e);
+            log.trace(msg, e);
             throw new OidcException(msg, e);
         }
 
@@ -152,7 +152,7 @@ public class TokenValidator {
             JwtClaims jwtClaims = new JwtConsumerBuilder().setSkipSignatureVerification().setSkipAllValidators().build().processToClaims(accessToken);
             return new VerifiedTokens(new IDToken(idJwtClaims), new AccessToken(jwtClaims));
         } catch (InvalidJwtException e) {
-            log.tracef("Problem parsing ID token: " + idToken, e);
+            log.tracef(e, "Problem parsing ID token: %s", idToken);
             throw log.invalidIDToken(e);
         }
     }
@@ -191,7 +191,7 @@ public class TokenValidator {
                 throw log.invalidTokenClaims();
             }
         } catch (InvalidJwtException e) {
-            log.tracef("Problem parsing bearer token: " + token, e);
+            log.tracef(e, "Problem parsing bearer token: %s", token);
             throw log.invalidBearerToken(e);
         }
         return jwtClaims;

--- a/mechanism/gssapi/src/main/java/org/wildfly/security/mechanism/gssapi/GSSCredentialSecurityFactory.java
+++ b/mechanism/gssapi/src/main/java/org/wildfly/security/mechanism/gssapi/GSSCredentialSecurityFactory.java
@@ -174,7 +174,7 @@ public final class GSSCredentialSecurityFactory implements SecurityFactory<GSSKe
                 log.tracef("KerberosTicket refreshed until %s", ticket.getEndTime());
                 stillValid = true;
             } catch (RefreshFailedException e) {
-                log.tracef("Unable to refresh KerberosTicket.", e);
+                log.trace("Unable to refresh KerberosTicket.", e);
             }
         }
 


### PR DESCRIPTION
In some places tracef() is called with the exception as the last parameter. The method expects the exception as first parameter, though. Because of this stack traces are missing in the log. In TokenValidator this hides all details about why token validation fails.

I do not have sufficient access rights in jira to create a corresponding ticket for this fix.