### PR TITLE
ELY-2807 Allow complete provider url in the oidc config

### DIFF
--- a/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
+++ b/http/oidc/src/main/java/org/wildfly/security/http/oidc/OidcClientConfiguration.java
@@ -302,6 +302,10 @@ public class OidcClientConfiguration {
 
     private String getDiscoveryUrl() {
         if (providerUrl != null) {
+            // specific OpenID provider configuration found
+            if(providerUrl.contains(DISCOVERY_PATH)) {
+                return providerUrl;
+            }
             // generic OpenID provider configuration found
             return getUrl(providerUrl, DISCOVERY_PATH);
         } else if (authServerBaseUrl != null) {

--- a/http/oidc/src/test/java/org/wildfly/security/http/oidc/MockOidcClientConfiguration.java
+++ b/http/oidc/src/test/java/org/wildfly/security/http/oidc/MockOidcClientConfiguration.java
@@ -46,6 +46,7 @@ import static org.wildfly.security.http.oidc.KeycloakConfiguration.ALICE;
 import static org.wildfly.security.http.oidc.KeycloakConfiguration.ALICE_PASSWORD;
 import static org.wildfly.security.http.oidc.Oidc.AuthenticationRequestFormat.REQUEST;
 import static org.wildfly.security.http.oidc.Oidc.AuthenticationRequestFormat.REQUEST_URI;
+import static org.wildfly.security.http.oidc.Oidc.DISCOVERY_PATH;
 import static org.wildfly.security.http.oidc.Oidc.OIDC_NAME;
 import static org.wildfly.security.http.oidc.Oidc.OIDC_SCOPE;
 
@@ -92,6 +93,18 @@ public class MockOidcClientConfiguration extends OidcBaseTest {
     public void testOidcWithRequestUriParameterUnsupported() throws Exception {
         mockOidcClientConfig();
         performAuthentication(getOidcConfigurationInputStreamWithRequestParameter(REQUEST_URI.getValue()), REQUEST_URI.getValue());
+    }
+
+    @Test
+    public void testOidcWithRequestParameterUnsupportedAndCompleteProviderUrl() throws Exception {
+        mockOidcClientConfig();
+        performAuthentication(getOidcConfigurationInputStreamWithRequestParameterAndCompleteProviderUrl(REQUEST.getValue()), REQUEST.getValue());
+    }
+
+    @Test
+    public void testOidcWithRequestUriParameterUnsupportedAndCompleteProviderUrl() throws Exception {
+        mockOidcClientConfig();
+        performAuthentication(getOidcConfigurationInputStreamWithRequestParameterAndCompleteProviderUrl(REQUEST_URI.getValue()), REQUEST_URI.getValue());
     }
 
     public void performAuthentication(InputStream oidcConfig, String requestFormat) throws Exception {
@@ -141,6 +154,22 @@ public class MockOidcClientConfiguration extends OidcBaseTest {
         String oidcConfig = "{\n" +
                 "    \"client-id\" : \"" + CLIENT_ID + "\",\n" +
                 "    \"provider-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "/" + "\",\n" +
+                "    \"public-client\" : \"false\",\n" +
+                "    \"ssl-required\" : \"EXTERNAL\",\n" +
+                "    \"authentication-request-format\" : \"" + requestParameter + "\",\n" +
+                "    \"request-object-signing-algorithm\" : \"" + HMAC_SHA256 + "\",\n" +
+                "    \"scope\" : \"profile email phone\",\n" +
+                "    \"credentials\" : {\n" +
+                "        \"secret\" : \"" + CLIENT_SECRET + "\"\n" +
+                "    }\n" +
+                "}";
+        return new ByteArrayInputStream(oidcConfig.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream getOidcConfigurationInputStreamWithRequestParameterAndCompleteProviderUrl(String requestParameter){
+        String oidcConfig = "{\n" +
+                "    \"client-id\" : \"" + CLIENT_ID + "\",\n" +
+                "    \"provider-url\" : \"" + KEYCLOAK_CONTAINER.getAuthServerUrl() + "/realms/" + TEST_REALM + "/" + DISCOVERY_PATH + "\",\n" +
                 "    \"public-client\" : \"false\",\n" +
                 "    \"ssl-required\" : \"EXTERNAL\",\n" +
                 "    \"authentication-request-format\" : \"" + requestParameter + "\",\n" +


### PR DESCRIPTION
[ELY-2807 Allow complete provider url in the oidc config](https://redhat.atlassian.net/browse/ELY-2807)

Based on [PR 2193](https://github.com/wildfly-security/wildfly-elytron/pull/2193)