### PR TITLE
[ELY-1745] / [ELY-2838] The AvailableRealmsCallback should not result in a NPE if there is no mechanism configuration.

### DIFF
--- a/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
+++ b/auth/server/base/src/main/java/org/wildfly/security/auth/server/ServerAuthenticationContext.java
@@ -30,6 +30,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -1083,7 +1084,8 @@ public final class ServerAuthenticationContext implements AutoCloseable {
                     ((SecurityIdentityCallback) callback).setSecurityIdentity(identity);
                     handleOne(callbacks, idx + 1);
                 } else if (callback instanceof AvailableRealmsCallback) {
-                    Collection<String> names = stateRef.get().getMechanismConfiguration().getMechanismRealmNames();
+                    MechanismConfiguration mechanismConfiguration = stateRef.get().getMechanismConfiguration();
+                    Collection<String> names = mechanismConfiguration != null ? mechanismConfiguration.getMechanismRealmNames() : Collections.emptyList();
                     if (log.isTraceEnabled()) {
                         log.tracef("Handling AvailableRealmsCallback: realms = [%s]", String.join(", ", names));
                     }
@@ -1403,7 +1405,7 @@ public final class ServerAuthenticationContext implements AutoCloseable {
         public InactiveState(SecurityIdentity capturedIdentity, MechanismConfigurationSelector mechanismConfigurationSelector,
                              MechanismInformation mechanismInformation, IdentityCredentials privateCredentials, IdentityCredentials publicCredentials, Attributes runtimeAttributes) {
             this.capturedIdentity = capturedIdentity;
-            this.mechanismConfigurationSelector = mechanismConfigurationSelector;
+            this.mechanismConfigurationSelector = mechanismConfigurationSelector != null ? mechanismConfigurationSelector : MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY);
             this.mechanismInformation = checkNotNullParam("mechanismInformation", mechanismInformation);
             this.privateCredentials = privateCredentials;
             this.publicCredentials = publicCredentials;

--- a/auth/server/base/src/test/java/org/wildfly/security/server/AvailableRealmsCallbackTest.java
+++ b/auth/server/base/src/test/java/org/wildfly/security/server/AvailableRealmsCallbackTest.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.server;
+
+import org.junit.Test;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.auth.server.ServerAuthenticationContext;
+
+import java.io.IOException;
+
+public class AvailableRealmsCallbackTest {
+
+    @Test
+    public void testNullMechanismConfigurationSelector() throws RealmUnavailableException {
+        SecurityDomain securityDomain = SecurityDomain.builder().build();
+        ServerAuthenticationContext sac = securityDomain.createNewAuthenticationContext(null);
+        sac.setAuthenticationName("user");
+    }
+
+    @Test
+    public void testEmptyMechanismConfiguration() throws IOException {
+        SecurityDomain securityDomain = SecurityDomain.builder().build();
+        MechanismConfigurationSelector mechanismConfigurationSelector = MechanismConfigurationSelector.constantSelector(MechanismConfiguration.EMPTY);
+        ServerAuthenticationContext sac = securityDomain.createNewAuthenticationContext(mechanismConfigurationSelector);
+        sac.setAuthenticationName("user");
+    }
+}
+

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2025 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,6 @@ package org.wildfly.security.sasl.test;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.auth.server.MechanismConfigurationSelector;
 import org.wildfly.security.sasl.digest.DigestServerFactory;
@@ -28,8 +27,6 @@ import org.wildfly.security.sasl.util.SaslMechanismInformation;
 
 import java.security.Provider;
 import java.security.Security;
-
-import static org.junit.Assert.fail;
 
 // has dependency on wildfly-elytron-client
 public class SaslAvailableRealmsCallbackTest {
@@ -48,24 +45,13 @@ public class SaslAvailableRealmsCallbackTest {
         Security.removeProvider(providers.getName());
     }
 
-    @Ignore("ELY-1745")
     @Test
     public void testNullMechanismConfigurationSelector() throws Exception {
-        // fixme: ELY-1745
         new SaslServerBuilder(DigestServerFactory.class, DIGEST).setMechanismConfigurationSelectorSupplier(() -> null).build();
     }
 
-    @Test
-    public void testNullMechanismConfiguration()  {
-        try {
-            new SaslServerBuilder(DigestServerFactory.class, DIGEST).setDontAssertBuiltServer().setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null)).build();
-            fail("Expected exception to be thrown");
-        } catch (Throwable t) {
-            t.printStackTrace();
-        }
+    @Test(expected = IllegalStateException.class)
+    public void testNullMechanismConfiguration() throws Exception {
+        new SaslServerBuilder(DigestServerFactory.class, DIGEST).setDontAssertBuiltServer().setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null)).build();
     }
-
-
-
-
 }

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
@@ -17,6 +17,11 @@
  */
 package org.wildfly.security.sasl.test;
 
+import static org.junit.Assert.assertNull;
+
+import java.security.Provider;
+import java.security.Security;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,9 +29,6 @@ import org.wildfly.security.auth.server.MechanismConfigurationSelector;
 import org.wildfly.security.sasl.digest.DigestServerFactory;
 import org.wildfly.security.sasl.digest.WildFlyElytronSaslDigestProvider;
 import org.wildfly.security.sasl.util.SaslMechanismInformation;
-
-import java.security.Provider;
-import java.security.Security;
 
 // has dependency on wildfly-elytron-client
 public class SaslAvailableRealmsCallbackTest {
@@ -50,8 +52,8 @@ public class SaslAvailableRealmsCallbackTest {
         new SaslServerBuilder(DigestServerFactory.class, DIGEST).setMechanismConfigurationSelectorSupplier(() -> null).build();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testNullMechanismConfiguration() throws Exception {
-        new SaslServerBuilder(DigestServerFactory.class, DIGEST).setDontAssertBuiltServer().setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null)).build();
+        assertNull(new SaslServerBuilder(DigestServerFactory.class, DIGEST).setDontAssertBuiltServer().setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null)).build());
     }
 }

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslAvailableRealmsCallbackTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.security.sasl.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.security.auth.server.MechanismConfigurationSelector;
+import org.wildfly.security.sasl.digest.DigestServerFactory;
+import org.wildfly.security.sasl.digest.WildFlyElytronSaslDigestProvider;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
+
+import java.security.Provider;
+import java.security.Security;
+
+import static org.junit.Assert.fail;
+
+// has dependency on wildfly-elytron-client
+public class SaslAvailableRealmsCallbackTest {
+
+    private static final String DIGEST = SaslMechanismInformation.Names.DIGEST_MD5;
+
+    private static final Provider providers = WildFlyElytronSaslDigestProvider.getInstance();
+
+    @BeforeClass
+    public static void registerPasswordProvider() {
+        Security.addProvider(providers);
+    }
+
+    @AfterClass
+    public static void removePasswordProvider() {
+        Security.removeProvider(providers.getName());
+    }
+
+    @Ignore("ELY-1745")
+    @Test
+    public void testNullMechanismConfigurationSelector() throws Exception {
+        // fixme: ELY-1745
+        new SaslServerBuilder(DigestServerFactory.class, DIGEST).setMechanismConfigurationSelectorSupplier(() -> null).build();
+    }
+
+    @Test
+    public void testNullMechanismConfiguration()  {
+        try {
+            new SaslServerBuilder(DigestServerFactory.class, DIGEST).setDontAssertBuiltServer().setMechanismConfigurationSelectorSupplier(() -> MechanismConfigurationSelector.constantSelector(null)).build();
+            fail("Expected exception to be thrown");
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+
+
+
+
+}

--- a/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/test/SaslServerBuilder.java
@@ -127,6 +127,8 @@ public class SaslServerBuilder {
     private ScheduledExecutorService scheduledExecutorService;
     private Supplier<Provider[]> providerSupplier;
 
+    private Supplier<MechanismConfigurationSelector> mechanismConfigurationSelectorSupplier;
+
     public SaslServerBuilder(Class<? extends SaslServerFactory> serverFactoryClass, String mechanismName) {
         this.serverFactoryClass = serverFactoryClass;
         this.mechanismName = mechanismName;
@@ -162,6 +164,7 @@ public class SaslServerBuilder {
         if (keepDomain) {
             copy.securityDomain = securityDomain;
         }
+        copy.mechanismConfigurationSelectorSupplier = mechanismConfigurationSelectorSupplier;
         return copy;
     }
 
@@ -365,6 +368,12 @@ public class SaslServerBuilder {
         return this;
     }
 
+    public SaslServerBuilder setMechanismConfigurationSelectorSupplier(Supplier<MechanismConfigurationSelector> mechanismConfigurationSelectorSupplier) {
+        Assert.assertNotNull("mechanismConfigurationSupplier", mechanismConfigurationSelectorSupplier);
+        this.mechanismConfigurationSelectorSupplier = mechanismConfigurationSelectorSupplier;
+        return this;
+    }
+
     public SaslServer build() throws IOException {
         if (securityDomain == null) {
             securityDomain = createSecurityDomain(hashEncoding, hashCharset);
@@ -406,11 +415,16 @@ public class SaslServerBuilder {
         if (scheduledExecutorService != null) {
             builder.setScheduledExecutorService(scheduledExecutorService);
         }
-        final MechanismConfiguration.Builder mechBuilder = MechanismConfiguration.builder();
-        for (MechanismRealmConfiguration realmConfiguration : mechanismRealms.values()) {
-            mechBuilder.addMechanismRealm(realmConfiguration);
+        if (mechanismConfigurationSelectorSupplier == null) {
+            final MechanismConfiguration.Builder mechBuilder = MechanismConfiguration.builder();
+            for (MechanismRealmConfiguration realmConfiguration : mechanismRealms.values()) {
+                mechBuilder.addMechanismRealm(realmConfiguration);
+            }
+            builder.setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(mechBuilder.build()));
+        } else {
+            builder.setMechanismConfigurationSelector(mechanismConfigurationSelectorSupplier.get());
         }
-        builder.setMechanismConfigurationSelector(MechanismConfigurationSelector.constantSelector(mechBuilder.build()));
+
         final SaslServer server = builder.build().createMechanism(mechanismName);
         if (!dontAssertBuiltServer) {
             Assert.assertNotNull(server);


### PR DESCRIPTION
This PR combines the changes for:

https://redhat.atlassian.net/browse/ELY-1745 / https://github.com/wildfly-security/wildfly-elytron/pull/1858
https://redhat.atlassian.net/browse/ELY-2838 / https://github.com/wildfly-security/wildfly-elytron/pull/2262