### PR TITLE
[ELY-3066] Add publicKeyUrl support to JwtValidator for remote public key retrieval

### DIFF
--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/_private/ElytronMessages.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/_private/ElytronMessages.java
@@ -102,5 +102,13 @@ public interface ElytronMessages extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 1182, value = "Allowed jku values haven't been configured for the JWT validator. Token validation will fail if the token contains a 'jku' header parameter.")
     void allowedJkuValuesNotConfigured();
+
+    @LogMessage(level = WARN)
+    @Message(id = 1183, value = "Unable to retrieve public key from remote URL \"%1$s\".")
+    void unableToFetchRemotePublicKey(String url);
+
+    @LogMessage(level = WARN)
+    @Message(id = 1184, value = "Not sending new request to remote public key URL \"%s\". Last request time was %d.")
+    void avoidingFetchRemotePublicKey(URL url, long timestamp);
 }
 

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwkManager.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwkManager.java
@@ -18,6 +18,9 @@
 package org.wildfly.security.auth.realm.token.validator;
 
 import org.wildfly.common.Assert;
+import org.wildfly.common.iteration.CodePointIterator;
+import org.wildfly.security.pem.Pem;
+import org.wildfly.security.pem.PemEntry;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -26,6 +29,7 @@ import jakarta.json.JsonReader;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -39,6 +43,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -63,7 +68,16 @@ class JwkManager {
     private final int connectionTimeout;
     private final int readTimeout;
 
+    // State for the configured remote public key URL (non-JKU path)
+    private final URL publicKeyUrl;
+    private volatile PublicKey cachedPublicKey;
+    private volatile long cachedPublicKeyTimestamp = 0;
+
     JwkManager(SSLContext sslContext, HostnameVerifier hostnameVerifier, long updateTimeout, int connectionTimeout, int readTimeout, int minTimeBetweenRequests, Set<String> allowedJkuValues) {
+        this(sslContext, hostnameVerifier, updateTimeout, connectionTimeout, readTimeout, minTimeBetweenRequests, allowedJkuValues, null);
+    }
+
+    JwkManager(SSLContext sslContext, HostnameVerifier hostnameVerifier, long updateTimeout, int connectionTimeout, int readTimeout, int minTimeBetweenRequests, Set<String> allowedJkuValues, URL publicKeyUrl) {
         this.sslContext = sslContext;
         this.hostnameVerifier = hostnameVerifier;
         this.updateTimeout = updateTimeout;
@@ -71,6 +85,81 @@ class JwkManager {
         this.readTimeout = readTimeout;
         this.minTimeBetweenRequests = minTimeBetweenRequests;
         this.allowedJkuValues = allowedJkuValues;
+        this.publicKeyUrl = publicKeyUrl;
+    }
+
+    boolean hasPublicKeyUrl() {
+        return publicKeyUrl != null;
+    }
+
+    /**
+     * Returns the public key from the configured remote URL, fetching it if the cache has expired.
+     * If {@code forceRefresh} is true, bypasses the TTL check and re-fetches — but the
+     * min-time-between-requests guard still applies to prevent DoS of the key server.
+     */
+    synchronized PublicKey getRemotePublicKey(boolean forceRefresh) {
+        long currentTime = System.currentTimeMillis();
+        boolean cacheValid = cachedPublicKey != null && (cachedPublicKeyTimestamp + updateTimeout > currentTime);
+
+        if (!forceRefresh && cacheValid) {
+            return cachedPublicKey;
+        }
+
+        // Respect the minimum time between requests even on a forced refresh
+        if (cachedPublicKeyTimestamp + minTimeBetweenRequests > currentTime) {
+            log.avoidingFetchRemotePublicKey(publicKeyUrl, cachedPublicKeyTimestamp);
+            return cachedPublicKey;
+        }
+
+        PublicKey fetched = fetchPublicKeyFromUrl(publicKeyUrl, sslContext, hostnameVerifier, connectionTimeout, readTimeout);
+        if (fetched != null) {
+            cachedPublicKey = fetched;
+            cachedPublicKeyTimestamp = currentTime;
+        } else {
+            log.unableToFetchRemotePublicKey(publicKeyUrl.toString());
+        }
+        return cachedPublicKey;
+    }
+
+    private static PublicKey fetchPublicKeyFromUrl(URL url, SSLContext sslContext, HostnameVerifier hostnameVerifier, int connectionTimeout, int readTimeout) {
+        InputStream inputStream = null;
+        try {
+            URLConnection connection = url.openConnection();
+            connection.setConnectTimeout(connectionTimeout);
+            connection.setReadTimeout(readTimeout);
+            if (connection instanceof HttpsURLConnection && sslContext != null) {
+                HttpsURLConnection httpsConn = (HttpsURLConnection) connection;
+                httpsConn.setSSLSocketFactory(sslContext.getSocketFactory());
+                if (hostnameVerifier != null) {
+                    httpsConn.setHostnameVerifier(hostnameVerifier);
+                }
+            }
+            connection.connect();
+            inputStream = connection.getInputStream();
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            byte[] chunk = new byte[4096];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(chunk)) != -1) {
+                buffer.write(chunk, 0, bytesRead);
+            }
+            Iterator<PemEntry<?>> pemEntries = Pem.parsePemContent(CodePointIterator.ofUtf8Bytes(buffer.toByteArray()));
+            if (!pemEntries.hasNext()) {
+                log.warn("Remote public key URL returned no PEM content: " + url);
+                return null;
+            }
+            PublicKey publicKey = pemEntries.next().tryCast(PublicKey.class);
+            if (publicKey == null) {
+                log.warn("Remote public key URL did not return a valid public key: " + url);
+            }
+            return publicKey;
+        } catch (IOException e) {
+            log.warn("Unable to connect to remote public key URL: " + url);
+            return null;
+        } finally {
+            if (inputStream != null) {
+                try { inputStream.close(); } catch (IOException ignored) {}
+            }
+        }
     }
 
     /**

--- a/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
+++ b/auth/realm/token/src/main/java/org/wildfly/security/auth/realm/token/validator/JwtValidator.java
@@ -89,13 +89,14 @@ public class JwtValidator implements TokenValidator {
         this.allowedJkuValues = checkNotNullParam("allowedJkuValues", configuration.allowedJkuValues);
         this.defaultPublicKey = configuration.publicKey;
         this.namedKeys = configuration.namedKeys;
-        if (configuration.sslContext != null) {
-            this.jwkManager = new JwkManager(configuration.sslContext,
-                                            configuration.hostnameVerifier != null ? configuration.hostnameVerifier : HttpsURLConnection.getDefaultHostnameVerifier(),
-                                            configuration.updateTimeout, configuration.connectionTimeout, configuration.readTimeout, configuration.minTimeBetweenRequests,
-                                            configuration.allowedJkuValues);
-        }
-        else {
+        if (configuration.sslContext != null || configuration.publicKeyUrl != null) {
+            HostnameVerifier hv = configuration.hostnameVerifier != null
+                    ? configuration.hostnameVerifier
+                    : HttpsURLConnection.getDefaultHostnameVerifier();
+            this.jwkManager = new JwkManager(configuration.sslContext, hv,
+                    configuration.updateTimeout, configuration.connectionTimeout, configuration.readTimeout,
+                    configuration.minTimeBetweenRequests, configuration.allowedJkuValues, configuration.publicKeyUrl);
+        } else {
             log.tokenRealmJwtNoSSLIgnoringJku();
             this.jwkManager = null;
         }
@@ -109,7 +110,7 @@ public class JwtValidator implements TokenValidator {
         if (audiences.isEmpty()) {
             log.tokenRealmJwtWarnNoAudienceIgnoringAudienceCheck();
         }
-        if (allowedJkuValues.isEmpty()) {
+        if (allowedJkuValues.isEmpty() && (jwkManager == null || !jwkManager.hasPublicKeyUrl())) {
             log.allowedJkuValuesNotConfigured();
         }
 
@@ -131,11 +132,22 @@ public class JwtValidator implements TokenValidator {
 
         JsonObject claims = extractClaims(encodedClaims);
 
-        if (verifySignature(encodedHeader, encodedClaims, encodedSignature)
+        if (verifySignature(encodedHeader, encodedClaims, encodedSignature, false)
                 && hasValidIssuer(claims)
                 && hasValidAudience(claims)
                 && verifyTimeConstraints(claims)) {
             return toAttributes(claims);
+        }
+
+        // After a failed verification, attempt to re-fetch the configured remote public key
+        // (subject to the min-time-between-requests guard to avoid being used to DoS the key server)
+        if (jwkManager != null && jwkManager.hasPublicKeyUrl()) {
+            if (verifySignature(encodedHeader, encodedClaims, encodedSignature, true)
+                    && hasValidIssuer(claims)
+                    && hasValidAudience(claims)
+                    && verifyTimeConstraints(claims)) {
+                return toAttributes(claims);
+            }
         }
 
         return null;
@@ -181,7 +193,7 @@ public class JwtValidator implements TokenValidator {
         return retValue;
     }
 
-    private boolean verifySignature(String encodedHeader, String encodedClaims, String encodedSignature) throws RealmUnavailableException {
+    private boolean verifySignature(String encodedHeader, String encodedClaims, String encodedSignature, boolean forceKeyRefresh) throws RealmUnavailableException {
         if (defaultPublicKey == null && jwkManager == null && namedKeys.isEmpty()) {
             return true;
         }
@@ -190,7 +202,7 @@ public class JwtValidator implements TokenValidator {
             Base64.Decoder urlDecoder = Base64.getUrlDecoder();
             byte[] decodedSignature = urlDecoder.decode(encodedSignature);
 
-            Signature signature = createSignature(encodedHeader, encodedClaims);
+            Signature signature = createSignature(encodedHeader, encodedClaims, forceKeyRefresh);
             boolean verify = signature != null ? ByteIterator.ofBytes(decodedSignature).verify(signature) : false;
 
             if (!verify) {
@@ -251,7 +263,7 @@ public class JwtValidator implements TokenValidator {
         return valid;
     }
 
-    private Signature createSignature(String encodedHeader, String encodedClaims) throws NoSuchAlgorithmException, SignatureException, RealmUnavailableException {
+    private Signature createSignature(String encodedHeader, String encodedClaims, boolean forceKeyRefresh) throws NoSuchAlgorithmException, SignatureException, RealmUnavailableException {
 
         byte[] headerDecoded = Base64.getUrlDecoder().decode(encodedHeader);
         JsonObject headers = null;
@@ -262,7 +274,7 @@ public class JwtValidator implements TokenValidator {
         String headerAlg = resolveAlgorithm(headers);
         Signature signature = Signature.getInstance(headerAlg);
         try {
-            PublicKey publicKey = resolvePublicKey(headers);
+            PublicKey publicKey = resolvePublicKey(headers, forceKeyRefresh);
             if (publicKey == null) {
                 log.debug("Public key could not be resolved.");
                 return null;
@@ -301,11 +313,18 @@ public class JwtValidator implements TokenValidator {
         }
     }
 
-    private PublicKey resolvePublicKey(JsonObject headers) {
+    private PublicKey resolvePublicKey(JsonObject headers, boolean forceKeyRefresh) {
         JsonString kid = headers.getJsonString("kid");
         JsonString jku = headers.getJsonString("jku");
 
         if (kid == null) {
+            // No kid: try the configured remote URL first, then fall back to the inline default key
+            if (jwkManager != null && jwkManager.hasPublicKeyUrl()) {
+                PublicKey remoteKey = jwkManager.getRemotePublicKey(forceKeyRefresh);
+                if (remoteKey != null) {
+                    return remoteKey;
+                }
+            }
             if (defaultPublicKey == null) {
                 log.debug("Default public key not configured. Cannot validate token without kid claim.");
                 return null;
@@ -352,6 +371,7 @@ public class JwtValidator implements TokenValidator {
         private Set<String> audience = new LinkedHashSet<>();
         private Set<String> allowedJkuValues = new LinkedHashSet<>();
         private PublicKey publicKey;
+        private URL publicKeyUrl;
         private Map<String, PublicKey> namedKeys = new LinkedHashMap<>();
         private HostnameVerifier hostnameVerifier;
         private SSLContext sslContext;
@@ -516,6 +536,26 @@ public class JwtValidator implements TokenValidator {
          */
         public Builder setAllowedJkuValues(String... allowedJkuValues) {
             this.allowedJkuValues.addAll(asList(allowedJkuValues));
+            return this;
+        }
+
+        /**
+         * <p>A remote URL from which to retrieve a PEM-encoded public key. This is an alternative to
+         * inlining a public key via {@link #publicKey(byte[])} for cases where JKU is not used.
+         *
+         * <p>The key is fetched on first use and cached. It is refreshed when the cache expires
+         * (controlled by {@link #setJkuTimeout(long)}) or after a failed signature verification,
+         * subject to the minimum-time-between-requests guard ({@link #setJkuMinTimeBetweenRequests(int)})
+         * to prevent being used to DoS the server hosting the key.
+         *
+         * <p>Both HTTP and HTTPS URLs are supported. For HTTPS, configure an {@link SSLContext}
+         * via {@link #useSslContext(SSLContext)}.
+         *
+         * @param publicKeyUrl the URL of the remote public key endpoint serving a PEM-encoded public key
+         * @return this instance
+         */
+        public Builder publicKeyUrl(URL publicKeyUrl) {
+            this.publicKeyUrl = publicKeyUrl;
             return this;
         }
 


### PR DESCRIPTION
issue: [ticket](https://redhat.atlassian.net/jira/software/c/projects/ELY/issues?jql=project%20%3D%20ELY%0AAND%20textfields%20~%20%22Add%20support%20for%20retrieving%20a%20public%20key%20from%20a%20remote%20URL%20in%20JwtValidator%2A%22%0AORDER%20BY%20cf%5B10019%5D%20ASC&selectedIssue=ELY-3066)