### PR TITLE
CVE-2026-19611 wildfly-elytron: Password keyspace reduction via NFKC fullwidth character folding

### DIFF
--- a/password/impl/src/main/java/org/wildfly/security/password/impl/AbstractPasswordImpl.java
+++ b/password/impl/src/main/java/org/wildfly/security/password/impl/AbstractPasswordImpl.java
@@ -57,7 +57,9 @@ abstract class AbstractPasswordImpl implements Password {
     }
 
     static byte[] getNormalizedPasswordBytes(final char[] characters, Charset charset) {
-        return Normalizer.normalize(new String(characters), Normalizer.Form.NFKC).getBytes(charset);
+        // Use Unicode Normalization Form C (NFC), which performs canonical composition without the compatibility folding
+        // applied by Normalization Form KC (NFKC), preserving distinctions such as fullwidth password characters.
+        return Normalizer.normalize(new String(characters), Normalizer.Form.NFC).getBytes(charset);
     }
 
     @Override

--- a/password/impl/src/test/java/org/wildfly/security/password/impl/ScramDigestPasswordTest.java
+++ b/password/impl/src/test/java/org/wildfly/security/password/impl/ScramDigestPasswordTest.java
@@ -130,6 +130,10 @@ public class ScramDigestPasswordTest {
 
         normalized = ScramDigestPasswordImpl.getNormalizedPasswordBytes("a\u0041\u030Ab".toCharArray());
         Assert.assertArrayEquals("a\u00C5b".getBytes(StandardCharsets.UTF_8), normalized);
+
+        // NFC normalization preserves fullwidth characters instead of folding them to their ASCII equivalents as NFKC does.
+        normalized = ScramDigestPasswordImpl.getNormalizedPasswordBytes("\uFF21\uFF22\uFF11".toCharArray());
+        Assert.assertArrayEquals("\uFF21\uFF22\uFF11".getBytes(StandardCharsets.UTF_8), normalized);
     }
 
     @Test

--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramClientCompatibilityTest.java
@@ -229,9 +229,9 @@ public class ScramClientCompatibilityTest {
 
         message = "r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096".getBytes(StandardCharsets.UTF_8);
         message = saslClient.evaluateChallenge(message);
-        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=5Drqrw2srEQfQ84h8Okz6eV091w=", new String(message, StandardCharsets.UTF_8));
+        assertEquals("c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=4EzH3xE6rmqrbIbkgj7L8nrETSQ=", new String(message, StandardCharsets.UTF_8));
 
-        message = "v=7xo0Rb9jQts952duIEz4oaIfD/c=".getBytes(StandardCharsets.UTF_8);
+        message = "v=HlhX1cnJ8BCY7EUPXizvgue/hcQ=".getBytes(StandardCharsets.UTF_8);
         message = saslClient.evaluateChallenge(message);
 
         assertTrue(saslClient.isComplete());

--- a/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
+++ b/tests/base/src/test/java/org/wildfly/security/sasl/scram/ScramServerCompatibilityTest.java
@@ -357,13 +357,13 @@ public class ScramServerCompatibilityTest {
                         .setPermissionsMap(Collections.singletonMap("strange=user, \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301", permissions))
                         .build();
 
-        byte[] message = "n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u00BD\u00B4,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
+        byte[] message = "n,a=strange=3Dadmin=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,n=strange=3Duser=2C \\\u0438\u4F60\uD83C\uDCA1\u0031\u2044\u0032\u0020\u0301,r=fyko+d2lbbFgONRv9qkxdawL".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
         assertEquals("r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096", new String(message, StandardCharsets.UTF_8));
 
-        message = "c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=ZWpaDThPD7OErOz+6Q+n9msNhMQ=".getBytes(StandardCharsets.UTF_8);
+        message = "c=bixhPXN0cmFuZ2U9M0RhZG1pbj0yQyBc0LjkvaDwn4KhMeKBhDIgzIEs,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=4EzH3xE6rmqrbIbkgj7L8nrETSQ=".getBytes(StandardCharsets.UTF_8);
         message = saslServer.evaluateResponse(message);
-        assertEquals("v=k1gWxds6QP4FdDqmsLtaxIl38NM=", new String(message, StandardCharsets.UTF_8));
+        assertEquals("v=HlhX1cnJ8BCY7EUPXizvgue/hcQ=", new String(message, StandardCharsets.UTF_8));
         assertTrue(saslServer.isComplete());
     }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ELY-3069

# Overview

Passwords are now processed using **Unicode Normalization Form C (NFC)** rather than **Unicode Normalization Form KC (NFKC)**.

This change addresses a password keyspace reduction vulnerability caused by compatibility folding. Under NFKC, visually distinct compatibility characters, including fullwidth Latin letters and digits, could be converted to their ASCII equivalents before hashing. As a result, more than one distinct password could authenticate against the same stored hash.

## Normalization forms

The distinction between the two forms is important:

- **Unicode Normalization Form C (NFC)** performs canonical composition. It combines canonically equivalent character sequences, but preserves compatibility distinctions such as fullwidth characters.
- **Unicode Normalization Form KC (NFKC)** performs canonical composition and compatibility folding. For example, fullwidth characters such as `Ａ` (U+FF21), `Ｂ` (U+FF22), and `１` (U+FF11) are folded to `A` (U+0041), `B` (U+0042), and `1` (U+0031). Other compatibility characters, such as `½` (U+00BD), can also be converted to a sequence of ordinary characters.

NFC is now used for password hashing and verification so that compatibility characters are not silently converted into other password characters.

This change concerns password processing only. SCRAM usernames and protocol fields continue to use their existing SASLprep/StringPrep processing, including compatibility normalization required for SCRAM interoperability. This processing can make some distinct Unicode username representations equivalent, but it is separate from password hashing and does not create the password keyspace-reduction issue addressed by this fix. This release does not change username normalization.

## Administrator action required

Administrators must treat password credentials generated with the previous implementation as legacy credentials and require password resets after applying this fix.

The stored hash does not contain the original password or the normalization form used to create it. Consequently, the hash alone cannot identify whether the original password contained characters affected by NFKC compatibility folding. It is therefore not possible to reliably identify only the affected accounts from the stored password data.

For this reason, administrators should reset all credentials using the affected password algorithms that were created before this fix was deployed. A reset causes the password to be generated and stored using NFC.

The reset requirement applies to credentials using these password algorithms:

- BCrypt
- SCRAM digest passwords
- Unix SHA crypt
- Unix MD5 crypt
- Sun Unix MD5 crypt
- Unix DES crypt
- BSD Unix DES crypt
- One-time password

For a filesystem realm, this means reviewing identities containing password credentials using any of the algorithms above and requiring those users to change their passwords. Existing credential files are not automatically rewritten when the realm is loaded or when authentication is attempted.

If an administrator cannot reset all relevant credentials immediately, the deployment should be treated as a migration state. Users with affected legacy credentials may experience authentication failures and should be directed to reset their passwords.

## Behaviour of existing legacy credentials

A credential created before this fix may have been generated as follows:

```text
stored hash = hash(NFKC(password))
```

After this fix, a supplied password is verified as follows:

```text
candidate hash = hash(NFC(candidate password))
```

For passwords containing compatibility characters, these representations can differ. Therefore, an existing user may no longer be able to authenticate with the original Unicode password after the fix, even though that password worked before the fix.

At the same time, an ASCII or otherwise compatibility-folded equivalent may still match the legacy stored hash in some cases. This means that deploying the code fix alone does not guarantee that every legacy credential is free from the original ambiguity. A password reset is required to replace the legacy hash with one generated using NFC.

Users whose passwords contain no characters affected by NFKC compatibility folding should continue to authenticate normally. However, because the affected cases cannot be identified from the hash, the recommended administrative action is to reset all pre-fix credentials using the affected algorithms rather than attempting to identify individual passwords.

## Security impact

Before this change, distinct passwords that differed only by compatibility characters could be reduced to the same password input before hashing. This reduced the effective password keyspace and could allow an attacker using an ASCII-focused dictionary to test passwords that were originally configured with non-ASCII compatibility characters.

After the change, newly generated and reset credentials preserve compatibility distinctions during password hashing and verification. Existing credentials remain legacy credentials until their passwords are reset.